### PR TITLE
test: fix Incorrect datetime value error in unit test

### DIFF
--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -666,15 +666,6 @@ func (s *testSyncerSuite) TestTimezone(c *C) {
 		"drop database tztest_1",
 	}
 
-	var sqlMode sql.NullString
-	row := s.db.QueryRow("select @@global.sql_mode")
-	c.Assert(row.Scan(&sqlMode), IsNil)
-	c.Assert(sqlMode.Valid, IsTrue)
-
-	_, err := s.db.Exec("set @@global.sql_mode=''")
-	c.Assert(err, IsNil)
-	defer s.db.Exec("set @@global.sql_mode = ?", sqlMode)
-
 	for _, sql := range createSQLs {
 		s.db.Exec(sql)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```
mysql> insert into tztest_1.t_1(id, a) values (2, '1990-04-15 02:30:12');
ERROR 1292 (22007): Incorrect datetime value: '1990-04-15 02:30:12' for column 'a' at row 1
mysql> select @@global.sql_mode;
+-------------------------------------------------------------------------------------------------------------------------------------------+
| @@global.sql_mode                                                                                                                         |
+-------------------------------------------------------------------------------------------------------------------------------------------+
| ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION |
+-------------------------------------------------------------------------------------------------------------------------------------------+
```
test data is invalid in MySQL 5.7 default sql_mode

### What is changed and how it works?
temporarily set sql_mode to empty in `TestTimezone`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
