### PR TITLE
syncer: do not skip all queries begin with '#'

### DIFF
--- a/syncer/ddl_test.go
+++ b/syncer/ddl_test.go
@@ -326,6 +326,34 @@ func (s *testSyncerSuite) TestIgnoreDMLInQuery(c *C) {
 			isDDL:    false,
 			hasError: true,
 		},
+		{
+			sql:      "#",
+			schema:   "",
+			ignore:   false,
+			isDDL:    false,
+			hasError: false,
+		},
+		{
+			sql:      "# this is a comment",
+			schema:   "",
+			ignore:   false,
+			isDDL:    false,
+			hasError: false,
+		},
+		{
+			sql:      "# a comment with DDL\nCREATE TABLE do_db.do_table (c1 INT)",
+			schema:   "",
+			ignore:   false,
+			isDDL:    true,
+			hasError: false,
+		},
+		{
+			sql:      "# a comment with DML\nUPDATE `ignore_db`.`ignore_table` SET c1=2 WHERE c1=1",
+			schema:   "ignore_db",
+			ignore:   true,
+			isDDL:    false,
+			hasError: false,
+		},
 	}
 
 	cfg := &config.SubTaskConfig{

--- a/syncer/filter.go
+++ b/syncer/filter.go
@@ -48,10 +48,6 @@ var (
 	alterTableRegex = regexp.MustCompile(fmt.Sprintf("^(?i)ALTER%s\\s+TABLE\\s+\\S+", commentRegexStr))
 	// https://dev.mysql.com/doc/refman/5.7/en/create-trigger.html
 	builtInSkipDDLs = []string{
-		// For mariadb, for query event, like `# Dumm`
-		// But i don't know what is the meaning of this event.
-		"^#",
-
 		// transaction
 		"^SAVEPOINT",
 

--- a/syncer/filter_test.go
+++ b/syncer/filter_test.go
@@ -25,7 +25,6 @@ func (s *testSyncerSuite) TestSkipQueryEvent(c *C) {
 		sql           string
 		expectSkipped bool
 	}{
-		{"#", true},
 		{"SAVEPOINT `a1`", true},
 
 		// flush


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Previously, we skipped all queries begin with `#` as a comment.
But, a query starts with `#` may be a valid DDL or DML, like
```
# this is a comment
CREATE TABLE do_db.do_table (c1 INT)
```
So, we can not simply skip it.

### What is changed and how it works?

- remove `#` from the `builtInSkipDDLs`
- let the caller decide whether needing to skip the query

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

---

In our current integration test framework, comments start with `#` line will be ignored by the *mysql* client, then no comments will stay in binlog events. So, add such a test case has no meaning.