### PR TITLE
syncer: fix generated column in where condition

### DIFF
--- a/syncer/dml.go
+++ b/syncer/dml.go
@@ -598,6 +598,9 @@ func pruneGeneratedColumnDML(columns []*column, data [][]interface{}, schema, ta
 		}
 	}
 	for _, row := range data {
+		if len(row) != len(columns) {
+			return nil, nil, errors.Errorf("prune DML columns and data mismatch in length: %d (columns) %d (data)", len(columns), len(data))
+		}
 		value := make([]interface{}, 0, len(row))
 		for i := range row {
 			if !colIndexfilters[i] {

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -1149,7 +1149,7 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 			if err != nil {
 				return errors.Trace(err)
 			}
-			prunedColumns, prunedRows, prunedIndexColumns, err := pruneGeneratedColumnDML(table.columns, rows, table.indexColumns, schemaName, tableName, s.genColsCache)
+			prunedColumns, prunedRows, err := pruneGeneratedColumnDML(table.columns, rows, schemaName, tableName, s.genColsCache)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -1175,7 +1175,6 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 				originalData:         rows,
 				columns:              prunedColumns,
 				originalColumns:      table.columns,
-				indexColumns:         prunedIndexColumns,
 				originalIndexColumns: table.indexColumns,
 			}
 			switch e.Header.EventType {

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -1195,7 +1195,7 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 				}
 			case replication.UPDATE_ROWS_EVENTv0, replication.UPDATE_ROWS_EVENTv1, replication.UPDATE_ROWS_EVENTv2:
 				if !applied {
-					sqls, keys, args, err = genUpdateSQLs(table.schema, table.name, rowData, tblColumns, tblIndexColumns, safeMode.Enable())
+					sqls, keys, args, err = genUpdateSQLs(table.schema, table.name, rowData, rows, tblColumns, table.columns, tblIndexColumns, table.indexColumns, safeMode.Enable())
 					if err != nil {
 						return errors.Errorf("gen update sqls failed: %v, schema: %s, table: %s", err, table.schema, table.name)
 					}
@@ -1219,7 +1219,8 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 				}
 			case replication.DELETE_ROWS_EVENTv0, replication.DELETE_ROWS_EVENTv1, replication.DELETE_ROWS_EVENTv2:
 				if !applied {
-					sqls, keys, args, err = genDeleteSQLs(table.schema, table.name, rowData, tblColumns, tblIndexColumns)
+					// sqls, keys, args, err = genDeleteSQLs(table.schema, table.name, rowData, tblColumns, tblIndexColumns)
+					sqls, keys, args, err = genDeleteSQLs(table.schema, table.name, rows, table.columns, table.indexColumns)
 					if err != nil {
 						return errors.Errorf("gen delete sqls failed: %v, schema: %s, table: %s", err, table.schema, table.name)
 					}

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -1195,6 +1195,8 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 				}
 			case replication.UPDATE_ROWS_EVENTv0, replication.UPDATE_ROWS_EVENTv1, replication.UPDATE_ROWS_EVENTv2:
 				if !applied {
+					// generated column don't exist in SET assignment_list, but can exist in where condition
+					// so we pass the original columns, row data and table indexes and the pruned columns, data, table indexes here
 					sqls, keys, args, err = genUpdateSQLs(table.schema, table.name, rowData, rows, tblColumns, table.columns, tblIndexColumns, table.indexColumns, safeMode.Enable())
 					if err != nil {
 						return errors.Errorf("gen update sqls failed: %v, schema: %s, table: %s", err, table.schema, table.name)
@@ -1219,7 +1221,7 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 				}
 			case replication.DELETE_ROWS_EVENTv0, replication.DELETE_ROWS_EVENTv1, replication.DELETE_ROWS_EVENTv2:
 				if !applied {
-					// sqls, keys, args, err = genDeleteSQLs(table.schema, table.name, rowData, tblColumns, tblIndexColumns)
+					// delete SQL only uses column and data in where condition, so we pass the unpruned columns and data directly
 					sqls, keys, args, err = genDeleteSQLs(table.schema, table.name, rows, table.columns, table.indexColumns)
 					if err != nil {
 						return errors.Errorf("gen delete sqls failed: %v, schema: %s, table: %s", err, table.schema, table.name)

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -773,8 +773,13 @@ func (s *testSyncerSuite) TestGeneratedColumn(c *C) {
 		"create database if not exists gctest_1 DEFAULT CHARSET=utf8mb4",
 		"create table if not exists gctest_1.t_1(id int, age int, cfg varchar(40), cfg_json json as (cfg) virtual)",
 		"create table if not exists gctest_1.t_2(id int primary key, age int, cfg varchar(40), cfg_json json as (cfg) virtual)",
+		"create table if not exists gctest_1.t_3(id int, cfg varchar(40), gen_id int as (cfg->\"$.id\"), unique key gen_id_unique(`gen_id`))",
 	}
 
+	// if table has json typed  generated column but doesn't have primary key or unique key,
+	// update/delete operation will not replicated successfully because json field can't be
+	// used in where condition with `=` operator. In unit test we only check generated SQL
+	// and don't check the data replication to downstream.
 	testCases := []struct {
 		sqls     []string
 		expected []string
@@ -783,11 +788,14 @@ func (s *testSyncerSuite) TestGeneratedColumn(c *C) {
 		{
 			[]string{
 				"insert into gctest_1.t_1(id, age, cfg) values (1, 18, '{}')",
-				"insert into gctest_1.t_1(id, age, cfg) values (2, 19, '{\"key\": \"value\", \"int\": 123}')",
+				"insert into gctest_1.t_1(id, age, cfg) values (2, 19, '{\"key\": \"value\"}')",
 				"insert into gctest_1.t_1(id, age, cfg) values (3, 17, NULL)",
 				"insert into gctest_1.t_2(id, age, cfg) values (1, 18, '{}')",
 				"insert into gctest_1.t_2(id, age, cfg) values (2, 19, '{\"key\": \"value\", \"int\": 123}')",
 				"insert into gctest_1.t_2(id, age, cfg) values (3, 17, NULL)",
+				"insert into gctest_1.t_3(id, cfg) values (1, '{\"id\": 1}')",
+				"insert into gctest_1.t_3(id, cfg) values (2, '{\"id\": 2}')",
+				"insert into gctest_1.t_3(id, cfg) values (3, '{\"id\": 3}')",
 			},
 			[]string{
 				"REPLACE INTO `gctest_1`.`t_1` (`id`,`age`,`cfg`) VALUES (?,?,?);",
@@ -796,14 +804,20 @@ func (s *testSyncerSuite) TestGeneratedColumn(c *C) {
 				"REPLACE INTO `gctest_1`.`t_2` (`id`,`age`,`cfg`) VALUES (?,?,?);",
 				"REPLACE INTO `gctest_1`.`t_2` (`id`,`age`,`cfg`) VALUES (?,?,?);",
 				"REPLACE INTO `gctest_1`.`t_2` (`id`,`age`,`cfg`) VALUES (?,?,?);",
+				"REPLACE INTO `gctest_1`.`t_3` (`id`,`cfg`) VALUES (?,?);",
+				"REPLACE INTO `gctest_1`.`t_3` (`id`,`cfg`) VALUES (?,?);",
+				"REPLACE INTO `gctest_1`.`t_3` (`id`,`cfg`) VALUES (?,?);",
 			},
 			[][]interface{}{
 				{int32(1), int32(18), "{}"},
-				{int32(2), int32(19), "{\"key\": \"value\", \"int\": 123}"},
+				{int32(2), int32(19), "{\"key\": \"value\"}"},
 				{int32(3), int32(17), nil},
 				{int32(1), int32(18), "{}"},
 				{int32(2), int32(19), "{\"key\": \"value\", \"int\": 123}"},
 				{int32(3), int32(17), nil},
+				{int32(1), "{\"id\": 1}"},
+				{int32(2), "{\"id\": 2}"},
+				{int32(3), "{\"id\": 3}"},
 			},
 		},
 		{
@@ -814,22 +828,28 @@ func (s *testSyncerSuite) TestGeneratedColumn(c *C) {
 				"update gctest_1.t_2 set cfg = '{\"a\": 12}', age = 21 where id = 1",
 				"update gctest_1.t_2 set cfg = '{}' where id = 2 and age = 19",
 				"update gctest_1.t_2 set age = 20 where cfg is NULL",
+				"update gctest_1.t_3 set cfg = '{\"id\": 11}' where id = 1",
+				"update gctest_1.t_3 set cfg = '{\"id\": 12, \"old_id\": 2}' where gen_id = 2",
 			},
 			[]string{
-				"UPDATE `gctest_1`.`t_1` SET `id` = ?, `age` = ?, `cfg` = ? WHERE `id` = ? AND `age` = ? AND `cfg` = ? LIMIT 1;",
-				"UPDATE `gctest_1`.`t_1` SET `id` = ?, `age` = ?, `cfg` = ? WHERE `id` = ? AND `age` = ? AND `cfg` = ? LIMIT 1;",
-				"UPDATE `gctest_1`.`t_1` SET `id` = ?, `age` = ?, `cfg` = ? WHERE `id` = ? AND `age` = ? AND `cfg` IS ? LIMIT 1;",
+				"UPDATE `gctest_1`.`t_1` SET `id` = ?, `age` = ?, `cfg` = ? WHERE `id` = ? AND `age` = ? AND `cfg` = ? AND `cfg_json` = ? LIMIT 1;",
+				"UPDATE `gctest_1`.`t_1` SET `id` = ?, `age` = ?, `cfg` = ? WHERE `id` = ? AND `age` = ? AND `cfg` = ? AND `cfg_json` = ? LIMIT 1;",
+				"UPDATE `gctest_1`.`t_1` SET `id` = ?, `age` = ?, `cfg` = ? WHERE `id` = ? AND `age` = ? AND `cfg` IS ? AND `cfg_json` IS ? LIMIT 1;",
 				"UPDATE `gctest_1`.`t_2` SET `id` = ?, `age` = ?, `cfg` = ? WHERE `id` = ? LIMIT 1;",
 				"UPDATE `gctest_1`.`t_2` SET `id` = ?, `age` = ?, `cfg` = ? WHERE `id` = ? LIMIT 1;",
 				"UPDATE `gctest_1`.`t_2` SET `id` = ?, `age` = ?, `cfg` = ? WHERE `id` = ? LIMIT 1;",
+				"UPDATE `gctest_1`.`t_3` SET `id` = ?, `cfg` = ? WHERE `gen_id` = ? LIMIT 1;",
+				"UPDATE `gctest_1`.`t_3` SET `id` = ?, `cfg` = ? WHERE `gen_id` = ? LIMIT 1;",
 			},
 			[][]interface{}{
-				{int32(1), int32(21), "{\"a\": 12}", int32(1), int32(18), "{}"},
-				{int32(2), int32(19), "{}", int32(2), int32(19), "{\"key\": \"value\", \"int\": 123}"},
-				{int32(3), int32(20), nil, int32(3), int32(17), nil},
+				{int32(1), int32(21), "{\"a\": 12}", int32(1), int32(18), "{}", []uint8("{}")},
+				{int32(2), int32(19), "{}", int32(2), int32(19), "{\"key\": \"value\"}", []uint8("{\"key\":\"value\"}")},
+				{int32(3), int32(20), nil, int32(3), int32(17), nil, nil},
 				{int32(1), int32(21), "{\"a\": 12}", int32(1)},
 				{int32(2), int32(19), "{}", int32(2)},
 				{int32(3), int32(20), nil, int32(3)},
+				{int32(1), "{\"id\": 11}", int32(1)},
+				{int32(2), "{\"id\": 12, \"old_id\": 2}", int32(2)},
 			},
 		},
 		{
@@ -840,22 +860,28 @@ func (s *testSyncerSuite) TestGeneratedColumn(c *C) {
 				"delete from gctest_1.t_2 where id = 1",
 				"delete from gctest_1.t_2 where id = 2 and age = 19",
 				"delete from gctest_1.t_2 where cfg is NULL",
+				"delete from gctest_1.t_3 where id = 1",
+				"delete from gctest_1.t_3 where gen_id = 12",
 			},
 			[]string{
-				"DELETE FROM `gctest_1`.`t_1` WHERE `id` = ? AND `age` = ? AND `cfg` = ? LIMIT 1;",
-				"DELETE FROM `gctest_1`.`t_1` WHERE `id` = ? AND `age` = ? AND `cfg` = ? LIMIT 1;",
-				"DELETE FROM `gctest_1`.`t_1` WHERE `id` = ? AND `age` = ? AND `cfg` IS ? LIMIT 1;",
+				"DELETE FROM `gctest_1`.`t_1` WHERE `id` = ? AND `age` = ? AND `cfg` = ? AND `cfg_json` = ? LIMIT 1;",
+				"DELETE FROM `gctest_1`.`t_1` WHERE `id` = ? AND `age` = ? AND `cfg` = ? AND `cfg_json` = ? LIMIT 1;",
+				"DELETE FROM `gctest_1`.`t_1` WHERE `id` = ? AND `age` = ? AND `cfg` IS ? AND `cfg_json` IS ? LIMIT 1;",
 				"DELETE FROM `gctest_1`.`t_2` WHERE `id` = ? LIMIT 1;",
 				"DELETE FROM `gctest_1`.`t_2` WHERE `id` = ? LIMIT 1;",
 				"DELETE FROM `gctest_1`.`t_2` WHERE `id` = ? LIMIT 1;",
+				"DELETE FROM `gctest_1`.`t_3` WHERE `gen_id` = ? LIMIT 1;",
+				"DELETE FROM `gctest_1`.`t_3` WHERE `gen_id` = ? LIMIT 1;",
 			},
 			[][]interface{}{
-				{int32(1), int32(21), "{\"a\": 12}"},
-				{int32(2), int32(19), "{}"},
-				{int32(3), int32(20), nil},
+				{int32(1), int32(21), "{\"a\": 12}", []uint8("{\"a\":12}")},
+				{int32(2), int32(19), "{}", []uint8("{}")},
+				{int32(3), int32(20), nil, nil},
 				{int32(1)},
 				{int32(2)},
 				{int32(3)},
+				{int32(11)},
+				{int32(12)},
 			},
 		},
 	}
@@ -863,6 +889,7 @@ func (s *testSyncerSuite) TestGeneratedColumn(c *C) {
 	dropSQLs := []string{
 		"drop table gctest_1.t_1",
 		"drop table gctest_1.t_2",
+		"drop table gctest_1.t_3",
 		"drop database gctest_1",
 	}
 
@@ -906,12 +933,12 @@ func (s *testSyncerSuite) TestGeneratedColumn(c *C) {
 					c.Assert(sqls[0], Equals, testCase.expected[idx])
 					c.Assert(args[0], DeepEquals, testCase.args[idx])
 				case replication.UPDATE_ROWS_EVENTv0, replication.UPDATE_ROWS_EVENTv1, replication.UPDATE_ROWS_EVENTv2:
-					sqls, _, args, err = genUpdateSQLs(table.schema, table.name, rowData, rowData, tblColumns, tblColumns, tblIndexColumns, tblIndexColumns, false)
+					sqls, _, args, err = genUpdateSQLs(table.schema, table.name, rowData, ev.Rows, tblColumns, table.columns, tblIndexColumns, table.indexColumns, false)
 					c.Assert(err, IsNil)
 					c.Assert(sqls[0], Equals, testCase.expected[idx])
 					c.Assert(args[0], DeepEquals, testCase.args[idx])
 				case replication.DELETE_ROWS_EVENTv0, replication.DELETE_ROWS_EVENTv1, replication.DELETE_ROWS_EVENTv2:
-					sqls, _, args, err = genDeleteSQLs(table.schema, table.name, rowData, tblColumns, tblIndexColumns)
+					sqls, _, args, err = genDeleteSQLs(table.schema, table.name, ev.Rows, table.columns, table.indexColumns)
 					c.Assert(err, IsNil)
 					c.Assert(sqls[0], Equals, testCase.expected[idx])
 					c.Assert(args[0], DeepEquals, testCase.args[idx])

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -862,7 +862,7 @@ func (s *testSyncerSuite) TestGeneratedColumn(c *C) {
 					c.Assert(sqls[0], Equals, testCase.expected[idx])
 					c.Assert(args[0], DeepEquals, testCase.args[idx])
 				case replication.UPDATE_ROWS_EVENTv0, replication.UPDATE_ROWS_EVENTv1, replication.UPDATE_ROWS_EVENTv2:
-					sqls, _, args, err = genUpdateSQLs(table.schema, table.name, rowData, tblColumns, tblIndexColumns, false)
+					sqls, _, args, err = genUpdateSQLs(table.schema, table.name, rowData, rowData, tblColumns, tblColumns, tblIndexColumns, tblIndexColumns, false)
 					c.Assert(err, IsNil)
 					c.Assert(sqls[0], Equals, testCase.expected[idx])
 					c.Assert(args[0], DeepEquals, testCase.args[idx])

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -776,9 +776,9 @@ func (s *testSyncerSuite) TestGeneratedColumn(c *C) {
 		"create table if not exists gctest_1.t_3(id int, cfg varchar(40), gen_id int as (cfg->\"$.id\"), unique key gen_id_unique(`gen_id`))",
 	}
 
-	// if table has json typed  generated column but doesn't have primary key or unique key,
-	// update/delete operation will not replicated successfully because json field can't be
-	// used in where condition with `=` operator. In unit test we only check generated SQL
+	// if table has json typed generated column but doesn't have primary key or unique key,
+	// update/delete operation will not be replicated successfully because json field can't
+	// compared with raw value in where condition. In unit test we only check generated SQL
 	// and don't check the data replication to downstream.
 	testCases := []struct {
 		sqls     []string

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -924,7 +924,7 @@ func (s *testSyncerSuite) TestGeneratedColumn(c *C) {
 					args [][]interface{}
 				)
 
-				prunedColumns, prunedRows, prunedIndexColumns, err := pruneGeneratedColumnDML(table.columns, ev.Rows, table.indexColumns, table.schema, table.name, syncer.genColsCache)
+				prunedColumns, prunedRows, err := pruneGeneratedColumnDML(table.columns, ev.Rows, table.schema, table.name, syncer.genColsCache)
 				c.Assert(err, IsNil)
 				param := &genDMLParam{
 					schema:               table.schema,
@@ -933,7 +933,6 @@ func (s *testSyncerSuite) TestGeneratedColumn(c *C) {
 					originalData:         ev.Rows,
 					columns:              prunedColumns,
 					originalColumns:      table.columns,
-					indexColumns:         prunedIndexColumns,
 					originalIndexColumns: table.indexColumns,
 				}
 				switch e.Header.EventType {

--- a/tests/_utils/run_dm_worker
+++ b/tests/_utils/run_dm_worker
@@ -19,6 +19,6 @@ echo "[$(date)] <<<<<< START DM-WORKER on port $port, config: $conf >>>>>>"
 cd $workdir
 $binary -test.coverprofile="$TEST_DIR/cov.$TEST_NAME.worker.$port.out" DEVEL \
     --worker-addr=:$port --relay-dir="$workdir/relay_log" \
-    --log-file="$workdir/log/dm-worker.log" --config="$conf" \
+    --log-file="$workdir/log/dm-worker.log" -L=debug --config="$conf" \
     > $workdir/log/stdout.log 2>&1 &
 cd $PWD

--- a/tests/all_mode/data/db1.increment.sql
+++ b/tests/all_mode/data/db1.increment.sql
@@ -9,7 +9,17 @@ alter table t1 add column gen_id int as (info->"$.id");
 alter table t1 add index multi_col(`id`, `gen_id`);
 insert into t1 (id, name, info) values (4, 'gentest', '{"id": 123}');
 insert into t1 (id, name, info) values (5, 'gentest', '{"id": 124}');
+update t1 set info = '{"id": 120}' where id = 1;
+update t1 set info = '{"id": 121}' where id = 2;
+update t1 set info = '{"id": 122}' where id = 3;
 
 -- test genColumnCache is reset after ddl
 alter table t1 add column info2 varchar(40);
 insert into t1 (id, name, info) values (6, 'gentest', '{"id": 125, "test cache": false}');
+alter table t1 add unique key gen_idx(`gen_id`);
+update t1 set name = 'gentestxx' where gen_id = 123;
+
+insert into t1 (id, name, info) values (7, 'gentest', '{"id": 126}');
+update t1 set name = 'gentestxxxxxx' where gen_id = 124;
+-- delete with unique key
+delete from t1 where gen_id > 124;


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently we remove all generated column for DML, but generated column in where condition is valid.

### What is changed and how it works?
- keep generated column in index searching
- keep generated column in where condition when generating `update`/`delete` DML

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test


Side effects

 - Increased code complexity