### PR TITLE
syncer: take the first 2 fields of show binary logs

### DIFF
--- a/syncer/db.go
+++ b/syncer/db.go
@@ -444,11 +444,20 @@ func getBinaryLogs(db *sql.DB) ([]binlogSize, error) {
 	}
 	defer rows.Close()
 
+	rowColumns, err := rows.Columns()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	files := make([]binlogSize, 0, 10)
 	for rows.Next() {
 		var file string
 		var pos int64
-		err = rows.Scan(&file, &pos)
+		var nullPtr interface{}
+		if len(rowColumns) == 2 {
+			err = rows.Scan(&file, &pos)
+		} else {
+			err = rows.Scan(&file, &pos, &nullPtr)
+		}
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
for to mysql 8 compatibility

mysql 8 , show binary logs,One more field

Log_name,File_size,Encrypted

in order to avoid

```
sql: expected 3 destination arguments in Scan, not 2
```

