### PR TITLE
poor: resume task if sync unit exits with `invalid connection` error

### DIFF
--- a/dm/worker/subtask.go
+++ b/dm/worker/subtask.go
@@ -197,7 +197,7 @@ retry:
 			I will optimize the implementation of retry feature.
 			*/
 			if st.retryErrors(result.Errors, cu) {
-				log.Warnf("[subtask] %s (%s) retry on error %v, waiting 10 second!", st.cfg.Name, cu.Type(), result.Errors)
+				log.Warnf("[subtask] %s (%s) retry on error %v, waiting 10 seconds!", st.cfg.Name, cu.Type(), result.Errors)
 				st.ctx, st.cancel = context.WithCancel(context.Background())
 				time.Sleep(10 * time.Second)
 				go cu.Resume(st.ctx, pr)

--- a/dm/worker/subtask.go
+++ b/dm/worker/subtask.go
@@ -190,6 +190,12 @@ retry:
 				stage = pb.Stage_Finished // process finished with no error
 			}
 		} else {
+			/* TODO
+			it's a poor and very rough retry feature, the main reason is that
+			the concurrency control of the sub task module is very confusing and needs to be optimized.
+			After improving its state transition and concurrency control,
+			I will optimize the implementation of retry feature.
+			*/
 			if st.retryErrors(result.Errors, cu) {
 				log.Warnf("[subtask] %s (%s) retry on error %v, waiting 10 second!", st.cfg.Name, cu.Type(), result.Errors)
 				st.ctx, st.cancel = context.WithCancel(context.Background())

--- a/dm/worker/subtask.go
+++ b/dm/worker/subtask.go
@@ -638,7 +638,7 @@ func (st *SubTask) retryErrors(errors []*pb.ProcessError, current unit.Unit) boo
 	switch current.Type() {
 	case pb.UnitType_Sync:
 		for _, err := range errors {
-			if strings.Contains(err.Msg, "connection refused") {
+			if strings.Contains(err.Msg, "invalid connection") {
 				continue
 			}
 			retry = false


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
try to resume task if sync unit exits with `invalid connection` error

### What is changed and how it works?
it's a poor and very rough retry feature, the main reason is that the concurrency control of the sub task module is very confusing and needs to be optimized. After improve its state transition and concurrency control, I will optimize the implementation of retry feature.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)
   - set up a dm cluster
   - start a task
   - interfere network to let connetion timeout
   - check whether dm-worker would try to resume task 
