### PR TITLE
*: replace golang.org/x/net/context with standard context

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -15,6 +15,7 @@ package checker
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -35,7 +36,6 @@ import (
 	"github.com/pingcap/tidb-tools/pkg/filter"
 	"github.com/pingcap/tidb-tools/pkg/table-router"
 	"github.com/siddontang/go/sync2"
-	"golang.org/x/net/context"
 )
 
 type mysqlInstance struct {

--- a/checker/cmd.go
+++ b/checker/cmd.go
@@ -14,10 +14,11 @@
 package checker
 
 import (
+	"context"
+
 	"github.com/pingcap/dm/dm/config"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/errors"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/dm/ctl/master/break_ddl_lock.go
+++ b/dm/ctl/master/break_ddl_lock.go
@@ -14,13 +14,13 @@
 package master
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // NewBreakDDLLockCmd creates a BreakDDLLock command

--- a/dm/ctl/master/check_task.go
+++ b/dm/ctl/master/check_task.go
@@ -14,11 +14,11 @@
 package master
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 
 	"github.com/pingcap/dm/checker"
 	"github.com/pingcap/dm/dm/ctl/common"

--- a/dm/ctl/master/migrate_relay.go
+++ b/dm/ctl/master/migrate_relay.go
@@ -14,13 +14,13 @@
 package master
 
 import (
+	"context"
 	"fmt"
-	"github.com/prometheus/common/log"
 	"strconv"
 
 	"github.com/pingcap/errors"
+	"github.com/prometheus/common/log"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"

--- a/dm/ctl/master/operate_relay.go
+++ b/dm/ctl/master/operate_relay.go
@@ -14,9 +14,10 @@
 package master
 
 import (
+	"context"
+
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
-	"golang.org/x/net/context"
 )
 
 // operateRelay does operation on relay unit

--- a/dm/ctl/master/operate_task.go
+++ b/dm/ctl/master/operate_task.go
@@ -14,9 +14,10 @@
 package master
 
 import (
+	"context"
+
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
-	"golang.org/x/net/context"
 )
 
 // operateTask does operation on task

--- a/dm/ctl/master/purge_relay.go
+++ b/dm/ctl/master/purge_relay.go
@@ -14,12 +14,12 @@
 package master
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 
 	"github.com/pingcap/dm/dm/command"
 	"github.com/pingcap/dm/dm/ctl/common"

--- a/dm/ctl/master/query_error.go
+++ b/dm/ctl/master/query_error.go
@@ -14,13 +14,13 @@
 package master
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // NewQueryErrorCmd creates a QueryError command

--- a/dm/ctl/master/query_status.go
+++ b/dm/ctl/master/query_status.go
@@ -14,13 +14,13 @@
 package master
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // NewQueryStatusCmd creates a QueryStatus command

--- a/dm/ctl/master/refresh_worker_tasks.go
+++ b/dm/ctl/master/refresh_worker_tasks.go
@@ -14,13 +14,13 @@
 package master
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // NewRefreshWorkerTasks creates a RefreshWorkerTasks command

--- a/dm/ctl/master/show_ddl_locks.go
+++ b/dm/ctl/master/show_ddl_locks.go
@@ -14,13 +14,13 @@
 package master
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // NewShowDDLLocksCmd creates a ShowDDlLocks command

--- a/dm/ctl/master/sql_replace.go
+++ b/dm/ctl/master/sql_replace.go
@@ -14,6 +14,7 @@
 package master
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -21,7 +22,6 @@ import (
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // NewSQLReplaceCmd creates a SQLReplace command

--- a/dm/ctl/master/sql_skip.go
+++ b/dm/ctl/master/sql_skip.go
@@ -14,6 +14,7 @@
 package master
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -21,7 +22,6 @@ import (
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // NewSQLSkipCmd creates a SQLSkip command

--- a/dm/ctl/master/start_task.go
+++ b/dm/ctl/master/start_task.go
@@ -14,11 +14,11 @@
 package master
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 
 	"github.com/pingcap/dm/checker"
 	"github.com/pingcap/dm/dm/ctl/common"

--- a/dm/ctl/master/unlock_ddl_lock.go
+++ b/dm/ctl/master/unlock_ddl_lock.go
@@ -14,13 +14,13 @@
 package master
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // NewUnlockDDLLockCmd creates a UnlockDDLLock command

--- a/dm/ctl/master/update_masterconfig.go
+++ b/dm/ctl/master/update_masterconfig.go
@@ -14,13 +14,13 @@
 package master
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // NewUpdateMasterConfigCmd creates a UpdateMasterConfig command

--- a/dm/ctl/master/update_relay.go
+++ b/dm/ctl/master/update_relay.go
@@ -14,11 +14,11 @@
 package master
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"

--- a/dm/ctl/master/update_task.go
+++ b/dm/ctl/master/update_task.go
@@ -14,11 +14,11 @@
 package master
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 
 	"github.com/pingcap/dm/checker"
 	"github.com/pingcap/dm/dm/ctl/common"

--- a/dm/ctl/worker/break_ddl_lock.go
+++ b/dm/ctl/worker/break_ddl_lock.go
@@ -14,13 +14,13 @@
 package worker
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // NewBreakDDLLockCmd creates a BreakDDLLock command

--- a/dm/ctl/worker/operate_relay.go
+++ b/dm/ctl/worker/operate_relay.go
@@ -14,9 +14,9 @@
 package worker
 
 import (
+	"context"
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
-	"golang.org/x/net/context"
 )
 
 // operateRelay does operation on relay unit

--- a/dm/ctl/worker/operate_sub_task.go
+++ b/dm/ctl/worker/operate_sub_task.go
@@ -14,9 +14,10 @@
 package worker
 
 import (
+	"context"
+
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
-	"golang.org/x/net/context"
 )
 
 // operateSubTask does operation on sub task

--- a/dm/ctl/worker/query_error.go
+++ b/dm/ctl/worker/query_error.go
@@ -14,11 +14,12 @@
 package worker
 
 import (
+	"context"
+
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // NewQueryErrorCmd creates a QueryError command

--- a/dm/ctl/worker/query_status.go
+++ b/dm/ctl/worker/query_status.go
@@ -14,11 +14,12 @@
 package worker
 
 import (
+	"context"
+
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // NewQueryStatusCmd creates a QueryStatus command

--- a/dm/ctl/worker/start_sub_task.go
+++ b/dm/ctl/worker/start_sub_task.go
@@ -14,13 +14,13 @@
 package worker
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // NewStartSubTaskCmd creates a StartSubTask command

--- a/dm/ctl/worker/switch_relay_master.go
+++ b/dm/ctl/worker/switch_relay_master.go
@@ -14,11 +14,11 @@
 package worker
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"

--- a/dm/ctl/worker/update_sub_task.go
+++ b/dm/ctl/worker/update_sub_task.go
@@ -14,13 +14,13 @@
 package worker
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/dm/dm/ctl/common"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // NewUpdateSubTaskCmd creates a UpdateSubTask command

--- a/dm/master/server.go
+++ b/dm/master/server.go
@@ -14,6 +14,7 @@
 package master
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/siddontang/go/sync2"
 	"github.com/soheilhy/cmux"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"github.com/pingcap/dm/checker"

--- a/dm/unit/unit.go
+++ b/dm/unit/unit.go
@@ -14,9 +14,10 @@
 package unit
 
 import (
+	"context"
+
 	"github.com/pingcap/dm/dm/config"
 	"github.com/pingcap/dm/dm/pb"
-	"golang.org/x/net/context"
 )
 
 // Unit defines interface for sub task process units, like syncer, loader, relay, etc.

--- a/dm/worker/server.go
+++ b/dm/worker/server.go
@@ -14,6 +14,7 @@
 package worker
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -24,7 +25,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/siddontang/go/sync2"
 	"github.com/soheilhy/cmux"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"github.com/pingcap/dm/dm/common"

--- a/dm/worker/subtask.go
+++ b/dm/worker/subtask.go
@@ -14,6 +14,7 @@
 package worker
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"time"
@@ -32,7 +33,6 @@ import (
 	_ "github.com/pingcap/tidb-tools/pkg/check"
 	_ "github.com/pingcap/tidb-tools/pkg/dbutil"
 	_ "github.com/pingcap/tidb-tools/pkg/utils"
-	"golang.org/x/net/context"
 )
 
 // createUnits creates process units base on task mode

--- a/dm/worker/worker.go
+++ b/dm/worker/worker.go
@@ -14,6 +14,7 @@
 package worker
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sync"
@@ -22,7 +23,6 @@ import (
 	"github.com/pingcap/dm/pkg/log"
 	"github.com/pingcap/errors"
 	"github.com/siddontang/go/sync2"
-	"golang.org/x/net/context"
 
 	"github.com/pingcap/dm/dm/config"
 	"github.com/pingcap/dm/dm/pb"

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
 	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc // indirect
-	golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e
 	golang.org/x/sys v0.0.0-20190116161447-11f53e031339
 	google.golang.org/grpc v1.17.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -15,6 +15,7 @@ package loader
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -24,17 +25,17 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pingcap/dm/dm/config"
-	"github.com/pingcap/dm/dm/pb"
-	"github.com/pingcap/dm/dm/unit"
-	"github.com/pingcap/dm/pkg/log"
-	"github.com/pingcap/dm/pkg/utils"
 	"github.com/pingcap/errors"
 	cm "github.com/pingcap/tidb-tools/pkg/column-mapping"
 	"github.com/pingcap/tidb-tools/pkg/filter"
 	"github.com/pingcap/tidb-tools/pkg/table-router"
 	"github.com/siddontang/go/sync2"
-	"golang.org/x/net/context"
+
+	"github.com/pingcap/dm/dm/config"
+	"github.com/pingcap/dm/dm/pb"
+	"github.com/pingcap/dm/dm/unit"
+	"github.com/pingcap/dm/pkg/log"
+	"github.com/pingcap/dm/pkg/utils"
 )
 
 var (

--- a/loader/status.go
+++ b/loader/status.go
@@ -14,12 +14,11 @@
 package loader
 
 import (
+	"context"
 	"time"
 
-	"github.com/pingcap/dm/pkg/log"
-	"golang.org/x/net/context"
-
 	"github.com/pingcap/dm/dm/pb"
+	"github.com/pingcap/dm/pkg/log"
 )
 
 const (

--- a/mydumper/mydumper.go
+++ b/mydumper/mydumper.go
@@ -14,6 +14,7 @@
 package mydumper
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/dm/dm/unit"
 	"github.com/pingcap/dm/pkg/log"
 	"github.com/siddontang/go/sync2"
-	"golang.org/x/net/context"
 )
 
 // Mydumper is a simple wrapper for mydumper binary

--- a/pkg/streamer/reader.go
+++ b/pkg/streamer/reader.go
@@ -14,18 +14,18 @@
 package streamer
 
 import (
+	"context"
 	"path"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/pingcap/dm/pkg/log"
 	"github.com/pingcap/errors"
 	"github.com/siddontang/go-mysql/mysql"
 	"github.com/siddontang/go-mysql/replication"
-	"golang.org/x/net/context"
 
+	"github.com/pingcap/dm/pkg/log"
 	"github.com/pingcap/dm/pkg/utils"
 )
 

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -15,6 +15,7 @@ package relay
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/binary"
 	"fmt"
@@ -28,17 +29,16 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pingcap/dm/pkg/log"
 	"github.com/pingcap/errors"
 	"github.com/siddontang/go-mysql/mysql"
 	"github.com/siddontang/go-mysql/replication"
 	"github.com/siddontang/go/sync2"
-	"golang.org/x/net/context"
 
 	"github.com/pingcap/dm/dm/config"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/dm/dm/unit"
 	"github.com/pingcap/dm/pkg/gtid"
+	"github.com/pingcap/dm/pkg/log"
 	pkgstreamer "github.com/pingcap/dm/pkg/streamer"
 	"github.com/pingcap/dm/pkg/utils"
 )

--- a/syncer/ddl_exec_info.go
+++ b/syncer/ddl_exec_info.go
@@ -14,12 +14,12 @@
 package syncer
 
 import (
+	"context"
 	"sync"
 	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/siddontang/go/sync2"
-	"golang.org/x/net/context"
 
 	"github.com/pingcap/dm/dm/pb"
 )

--- a/syncer/heartbeat.go
+++ b/syncer/heartbeat.go
@@ -14,18 +14,18 @@
 package syncer
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"reflect"
 	"sync"
 	"time"
 
-	"github.com/pingcap/dm/pkg/log"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb-tools/pkg/filter"
-	"golang.org/x/net/context"
 
 	"github.com/pingcap/dm/dm/config"
+	"github.com/pingcap/dm/pkg/log"
 )
 
 // privileges: SELECT, UPDATE,  optionaly INSERT, optionaly CREATE.

--- a/syncer/inject_sql.go
+++ b/syncer/inject_sql.go
@@ -14,16 +14,17 @@
 package syncer
 
 import (
+	"context"
 	"time"
 
-	"github.com/pingcap/dm/pkg/log"
-	parserpkg "github.com/pingcap/dm/pkg/parser"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/ast"
 	"github.com/siddontang/go-mysql/mysql"
 	"github.com/siddontang/go-mysql/replication"
-	"golang.org/x/net/context"
+
+	"github.com/pingcap/dm/pkg/log"
+	parserpkg "github.com/pingcap/dm/pkg/parser"
 )
 
 // InjectSQLs injects ddl into syncer as binlog events while meet xid/query event

--- a/syncer/metrics.go
+++ b/syncer/metrics.go
@@ -14,13 +14,13 @@
 package syncer
 
 import (
+	"context"
 	"net/http"
 	"time"
 
 	"github.com/pingcap/dm/pkg/log"
 	cpu "github.com/pingcap/tidb-tools/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/net/context"
 
 	"github.com/pingcap/dm/pkg/utils"
 )

--- a/syncer/mode.go
+++ b/syncer/mode.go
@@ -14,14 +14,14 @@
 package syncer
 
 import (
+	"context"
 	"time"
 
-	"github.com/pingcap/dm/pkg/log"
 	"github.com/pingcap/errors"
-	"golang.org/x/net/context"
 
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/dm/dm/unit"
+	"github.com/pingcap/dm/pkg/log"
 	sm "github.com/pingcap/dm/syncer/safe-mode"
 )
 

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -14,6 +14,7 @@
 package syncer
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"runtime/debug"
@@ -22,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pingcap/dm/pkg/log"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	bf "github.com/pingcap/tidb-tools/pkg/binlog-filter"
@@ -33,12 +33,12 @@ import (
 	"github.com/siddontang/go-mysql/mysql"
 	"github.com/siddontang/go-mysql/replication"
 	"github.com/siddontang/go/sync2"
-	"golang.org/x/net/context"
 
 	"github.com/pingcap/dm/dm/config"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/dm/dm/unit"
 	"github.com/pingcap/dm/pkg/gtid"
+	"github.com/pingcap/dm/pkg/log"
 	"github.com/pingcap/dm/pkg/streamer"
 	"github.com/pingcap/dm/pkg/utils"
 	sm "github.com/pingcap/dm/syncer/safe-mode"

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -14,6 +14,7 @@
 package syncer
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"
@@ -31,7 +32,6 @@ import (
 	"github.com/pingcap/tidb-tools/pkg/filter"
 	gmysql "github.com/siddontang/go-mysql/mysql"
 	"github.com/siddontang/go-mysql/replication"
-	"golang.org/x/net/context"
 
 	"github.com/pingcap/dm/dm/config"
 	"github.com/pingcap/dm/pkg/utils"


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`golang.org/x/net/context` is type alias with standard `context` since go 1.9. It is safe and convenient to replace it with standard library

### What is changed and how it works?

replace `golang.org/x/net/context` with `context` and change some import sequence

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test