### PR TITLE
*: fix go vet test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ lint:
 vet:
 	$(GO) build -o bin/shadow golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
 	@echo "vet"
-	@$(GO) vet -composites=false $(PACKAGES) 2>&1 1>/dev/null | awk '{print} END{if(NR>0) {exit 1}}'
+	@$(GO) vet -composites=false $(PACKAGES) 2>&1 | tee /dev/stderr | awk 'END{if(NR>0) {exit 1}}'
 	@$(GO) vet -vettool=$(CURDIR)/bin/shadow $(PACKAGES) 2>&1 | tee /dev/stderr | awk '/shadows declaration|^#/{next}{count+=1} END{if(count>0) {exit 1}}'
 
 dm_integration_test_build:


### PR DESCRIPTION
go module download information writes to tty directly, so we use tee
to redirect stderr for fail detect

<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix issue in https://github.com/pingcap/dm/pull/76.
because go module download information does not go to stdout/stderr directly, we always get these messages from bash pipeline

### What is changed and how it works?

use /dev/stderr to filter real error messages.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 