### PR TITLE
loader: fix load progress

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -483,6 +483,10 @@ func (l *Loader) IsFreshTask() (bool, error) {
 
 // Restore begins the restore process.
 func (l *Loader) Restore(ctx context.Context) error {
+	// reset some counter used to calculate progress
+	l.totalDataSize.Set(0)
+	l.finishedDataSize.Set(0) // reset before load from checkpoint
+
 	if err := l.prepare(); err != nil {
 		log.Errorf("[loader] scan dir[%s] failed, err[%v]", l.cfg.Dir, err)
 		return errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

if we pause/resume task when loading, the **progress** may show an incorrect value. It's because we forgot to reset `totalDataSize`/`finishedDataSize` when resuming.

### What is changed and how it works?

reset `totalDataSize`/`finishedDataSize` when resuming.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
	 - `pause-task` when loading
 	 - `resume-task`
	 - observe `finishedBytes`/`totalBytes`/`progress` in `query-status`'s output
