### PR TITLE
tracer: remove remaining imports of golang.org/x/net/context

### DIFF
--- a/dm/tracer/server.go
+++ b/dm/tracer/server.go
@@ -14,6 +14,7 @@
 package tracer
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"sync"
@@ -23,7 +24,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/siddontang/go/sync2"
 	"github.com/soheilhy/cmux"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"github.com/pingcap/dm/dm/common"

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -14,12 +14,12 @@
 package tracing
 
 import (
+	"context"
 	"sync"
 	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/siddontang/go/sync2"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"github.com/pingcap/dm/dm/pb"

--- a/pkg/tracing/tracer_test.go
+++ b/pkg/tracing/tracer_test.go
@@ -14,6 +14,7 @@
 package tracing
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
@@ -26,7 +27,6 @@ import (
 	"github.com/siddontang/go-mysql/mysql"
 	"github.com/siddontang/go/sync2"
 	"github.com/soheilhy/cmux"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"github.com/pingcap/dm/dm/common"


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Some imports of `"golang.org/x/net/context"` remained, causing go.mod to automatically include `golang.org/x/net` again.

They were accidentally reintroduced because #58 was merged after #75.

### What is changed and how it works?

Replaced the remaining imports of `"golang.org/x/net/context"` by `"context"`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes