### PR TITLE
relay: use Reader interface read binlog events

### DIFF
--- a/pkg/binlog/reader/reader.go
+++ b/pkg/binlog/reader/reader.go
@@ -22,11 +22,27 @@ import (
 	"github.com/pingcap/dm/pkg/gtid"
 )
 
+type readerStage int
+
 const (
-	stageNew = iota
+	stageNew readerStage = iota
 	stagePrepared
 	stageClosed
 )
+
+// String implements Stringer.String.
+func (s readerStage) String() string {
+	switch s {
+	case stageNew:
+		return "new"
+	case stagePrepared:
+		return "prepared"
+	case stageClosed:
+		return "closed"
+	default:
+		return "unknown"
+	}
+}
 
 // Reader is a binlog event reader, it may read binlog events from a TCP stream, binlog files or any other in-memory buffer.
 // One reader should read binlog events either through position mode or GTID mode.
@@ -44,4 +60,7 @@ type Reader interface {
 	// You can pass a context (like Cancel or Timeout) to break the block.
 	// If you do not want to check the stage (for reducing the lock operation), you can set `checkStage` to false.
 	GetEvent(ctx context.Context, checkStage bool) (*replication.BinlogEvent, error)
+
+	// Status returns the status of the reader.
+	Status() interface{}
 }

--- a/pkg/binlog/reader/reader.go
+++ b/pkg/binlog/reader/reader.go
@@ -1,0 +1,47 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reader
+
+import (
+	"context"
+
+	gmysql "github.com/siddontang/go-mysql/mysql"
+	"github.com/siddontang/go-mysql/replication"
+
+	"github.com/pingcap/dm/pkg/gtid"
+)
+
+const (
+	stageNew = iota
+	stagePrepared
+	stageClosed
+)
+
+// Reader is a binlog event reader, it may read binlog events from a TCP stream, binlog files or any other in-memory buffer.
+// One reader should read binlog events either through position mode or GTID mode.
+type Reader interface {
+	// StartSyncByPos prepares the reader for reading binlog from the specified position.
+	StartSyncByPos(pos gmysql.Position) error
+
+	// StartSyncByGTID prepares the reader for reading binlog from the specified GTID set.
+	StartSyncByGTID(gSet gtid.Set) error
+
+	// Close closes the reader and release the resource.
+	Close() error
+
+	// GetEvent gets the binlog event one by one, it will block if no event can be read.
+	// You can pass a context (like Cancel or Timeout) to break the block.
+	// If you do not want to check the stage (for reducing the lock operation), you can set `checkStage` to false.
+	GetEvent(ctx context.Context, checkStage bool) (*replication.BinlogEvent, error)
+}

--- a/pkg/binlog/reader/reader.go
+++ b/pkg/binlog/reader/reader.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pingcap/dm/pkg/gtid"
 )
 
-type readerStage int
+type readerStage int32
 
 const (
 	stageNew readerStage = iota
@@ -58,8 +58,7 @@ type Reader interface {
 
 	// GetEvent gets the binlog event one by one, it will block if no event can be read.
 	// You can pass a context (like Cancel or Timeout) to break the block.
-	// If you do not want to check the stage (for reducing the lock operation), you can set `checkStage` to false.
-	GetEvent(ctx context.Context, checkStage bool) (*replication.BinlogEvent, error)
+	GetEvent(ctx context.Context) (*replication.BinlogEvent, error)
 
 	// Status returns the status of the reader.
 	Status() interface{}

--- a/pkg/binlog/reader/tcp.go
+++ b/pkg/binlog/reader/tcp.go
@@ -144,9 +144,7 @@ func (r *TCPReader) GetEvent(ctx context.Context) (*replication.BinlogEvent, err
 
 // Status implements Reader.Status.
 func (r *TCPReader) Status() interface{} {
-	r.mu.Lock()
 	stage := r.stage.Get()
-	r.mu.Unlock()
 
 	var connID uint32
 	if stage != int32(stageNew) {

--- a/pkg/binlog/reader/tcp.go
+++ b/pkg/binlog/reader/tcp.go
@@ -1,0 +1,130 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reader
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+
+	"github.com/pingcap/errors"
+	gmysql "github.com/siddontang/go-mysql/mysql"
+	"github.com/siddontang/go-mysql/replication"
+
+	"github.com/pingcap/dm/pkg/gtid"
+	"github.com/pingcap/dm/pkg/utils"
+)
+
+// TCPReader is a binlog event reader which read binlog events from a TCP stream.
+type TCPReader struct {
+	stageMu sync.Mutex
+	stage   int
+
+	syncerCfg replication.BinlogSyncerConfig
+	syncer    *replication.BinlogSyncer
+	streamer  *replication.BinlogStreamer
+}
+
+// NewTCPReader creates a TCPReader instance.
+func NewTCPReader(syncerCfg replication.BinlogSyncerConfig) Reader {
+	return &TCPReader{
+		syncerCfg: syncerCfg,
+		syncer:    replication.NewBinlogSyncer(syncerCfg),
+	}
+}
+
+// StartSyncByPos implements Reader.StartSyncByPos.
+func (r *TCPReader) StartSyncByPos(pos gmysql.Position) error {
+	r.stageMu.Lock()
+	defer r.stageMu.Unlock()
+
+	if r.stage != stageNew {
+		return errors.NotValidf("stage %d, expect %d", r.stage, stageNew)
+	}
+
+	streamer, err := r.syncer.StartSync(pos)
+	if err != nil {
+		return errors.Annotatef(err, "start sync from position %s", pos)
+	}
+
+	r.streamer = streamer
+	r.stage = stagePrepared
+	return nil
+}
+
+// StartSyncByGTID implements Reader.StartSyncByGTID.
+func (r *TCPReader) StartSyncByGTID(gSet gtid.Set) error {
+	r.stageMu.Lock()
+	defer r.stageMu.Unlock()
+
+	if r.stage != stageNew {
+		return errors.NotValidf("stage %d, expect %d", r.stage, stageNew)
+	}
+
+	if gSet == nil {
+		return errors.NotValidf("nil GTID set")
+	}
+
+	streamer, err := r.syncer.StartSyncGTID(gSet.Origin())
+	if err != nil {
+		return errors.Annotatef(err, "start sync from GTID set %s", gSet)
+	}
+
+	r.streamer = streamer
+	r.stage = stagePrepared
+	return nil
+}
+
+// Close implements Reader.Close.
+func (r *TCPReader) Close() error {
+	r.stageMu.Lock()
+	defer r.stageMu.Unlock()
+
+	if r.stage == stageClosed {
+		return errors.NotValidf("already closed")
+	}
+
+	connID := r.syncer.LastConnectionID()
+	if connID > 0 {
+		dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8mb4",
+			r.syncerCfg.User, r.syncerCfg.Password, r.syncerCfg.Host, r.syncerCfg.Port)
+		db, err := sql.Open("mysql", dsn)
+		if err != nil {
+			return errors.Annotate(err, "open connection to the master")
+		}
+		defer db.Close()
+		err = utils.KillConn(db, connID)
+		if err != nil {
+			return errors.Annotatef(err, "kill connection %d", connID)
+		}
+	}
+
+	r.stage = stageClosed
+	return nil
+}
+
+// GetEvent implements Reader.GetEvent.
+func (r *TCPReader) GetEvent(ctx context.Context, checkStage bool) (*replication.BinlogEvent, error) {
+	if checkStage {
+		r.stageMu.Lock()
+		if r.stage != stagePrepared {
+			r.stageMu.Unlock()
+			return nil, errors.NotValidf("stage %d, expect %d", r.stage, stagePrepared)
+		}
+		r.stageMu.Unlock()
+	}
+
+	return r.streamer.GetEvent(ctx)
+}

--- a/pkg/binlog/reader/tcp.go
+++ b/pkg/binlog/reader/tcp.go
@@ -145,11 +145,11 @@ func (r *TCPReader) GetEvent(ctx context.Context) (*replication.BinlogEvent, err
 // Status implements Reader.Status.
 func (r *TCPReader) Status() interface{} {
 	r.mu.Lock()
-	stage := r.stage
+	stage := r.stage.Get()
 	r.mu.Unlock()
 
 	var connID uint32
-	if stage.Get() != int32(stageNew) {
+	if stage != int32(stageNew) {
 		connID = r.syncer.LastConnectionID()
 	}
 	return &TCPReaderStatus{

--- a/pkg/binlog/reader/tcp_test.go
+++ b/pkg/binlog/reader/tcp_test.go
@@ -141,7 +141,7 @@ func (t *testTCPReaderSuite) TestSyncPos(c *C) {
 	trStatus, ok := status.(*TCPReaderStatus)
 	c.Assert(ok, IsTrue)
 	c.Assert(trStatus.Stage, Equals, stagePrepared.String())
-	c.Assert(trStatus.Connection, Greater, uint32(0))
+	c.Assert(trStatus.ConnID, Greater, uint32(0))
 	trStatusStr := trStatus.String()
 	c.Assert(strings.Contains(trStatusStr, stagePrepared.String()), IsTrue)
 
@@ -216,7 +216,7 @@ func (t *testTCPReaderSuite) TestSyncGTID(c *C) {
 	trStatus, ok := status.(*TCPReaderStatus)
 	c.Assert(ok, IsTrue)
 	c.Assert(trStatus.Stage, Equals, stageNew.String())
-	c.Assert(trStatus.Connection, Equals, uint32(0))
+	c.Assert(trStatus.ConnID, Equals, uint32(0))
 
 	// not prepared
 	e, err := r.GetEvent(context.Background(), true)
@@ -251,7 +251,7 @@ func (t *testTCPReaderSuite) TestSyncGTID(c *C) {
 	trStatus, ok = status.(*TCPReaderStatus)
 	c.Assert(ok, IsTrue)
 	c.Assert(trStatus.Stage, Equals, stageClosed.String())
-	c.Assert(trStatus.Connection, Greater, uint32(0))
+	c.Assert(trStatus.ConnID, Greater, uint32(0))
 
 	// already closed
 	err = r.Close()

--- a/pkg/binlog/reader/tcp_test.go
+++ b/pkg/binlog/reader/tcp_test.go
@@ -1,0 +1,305 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reader
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/ast"
+	gmysql "github.com/siddontang/go-mysql/mysql"
+	"github.com/siddontang/go-mysql/replication"
+
+	"github.com/pingcap/dm/pkg/gtid"
+	"github.com/pingcap/dm/pkg/utils"
+)
+
+var (
+	_           = Suite(&testTCPReaderSuite{})
+	dbName      = "test_tcp_reader_db"
+	tableName   = "test_tcp_reader_table"
+	columnValue = 123
+	flavor      = gmysql.MySQLFlavor
+	serverIDs   = []uint32{3251, 3252}
+)
+
+func TestSuite(t *testing.T) {
+	TestingT(t)
+}
+
+type testTCPReaderSuite struct {
+	host     string
+	port     int
+	user     string
+	password string
+	db       *sql.DB
+}
+
+func (t *testTCPReaderSuite) SetUpSuite(c *C) {
+	t.setUpConn(c)
+	t.setUpData(c)
+}
+
+func (t *testTCPReaderSuite) setUpConn(c *C) {
+	t.host = os.Getenv("MYSQL_HOST")
+	if t.host == "" {
+		t.host = "127.0.0.1"
+	}
+	t.port, _ = strconv.Atoi(os.Getenv("MYSQL_PORT"))
+	if t.port == 0 {
+		t.port = 3306
+	}
+	t.user = os.Getenv("MYSQL_USER")
+	if t.user == "" {
+		t.user = "root"
+	}
+	t.password = os.Getenv("MYSQL_PSWD")
+
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8mb4", t.user, t.password, t.host, t.port)
+	db, err := sql.Open("mysql", dsn)
+	c.Assert(err, IsNil)
+	t.db = db
+}
+
+func (t *testTCPReaderSuite) setUpData(c *C) {
+	// drop database first.
+	query := fmt.Sprintf("DROP DATABASE `%s`", dbName)
+	_, err := t.db.Exec(query)
+
+	// delete previous binlog files/events.
+	query = "RESET MASTER"
+	_, err = t.db.Exec(query)
+	c.Assert(err, IsNil)
+
+	// execute some SQL statements to generate binlog events.
+	query = fmt.Sprintf("CREATE DATABASE `%s`", dbName)
+	_, err = t.db.Exec(query)
+	c.Assert(err, IsNil)
+
+	query = fmt.Sprintf("CREATE TABLE `%s`.`%s` (c1 INT)", dbName, tableName)
+	_, err = t.db.Exec(query)
+	c.Assert(err, IsNil)
+
+	// we assume `binlog_format` already set to `ROW`.
+	query = fmt.Sprintf("INSERT INTO `%s`.`%s` VALUES (%d)", dbName, tableName, columnValue)
+	_, err = t.db.Exec(query)
+	c.Assert(err, IsNil)
+}
+
+func (t *testTCPReaderSuite) TestSyncPos(c *C) {
+	var (
+		cfg = replication.BinlogSyncerConfig{
+			ServerID:       serverIDs[0],
+			Flavor:         flavor,
+			Host:           t.host,
+			Port:           uint16(t.port),
+			User:           t.user,
+			Password:       t.password,
+			UseDecimal:     true,
+			VerifyChecksum: true,
+		}
+		pos gmysql.Position // empty position
+	)
+
+	// the first reader
+	r := NewTCPReader(cfg)
+	c.Assert(r, NotNil)
+
+	// not prepared
+	e, err := r.GetEvent(context.Background(), true)
+	c.Assert(err, NotNil)
+	c.Assert(e, IsNil)
+
+	// prepare
+	err = r.StartSyncByPos(pos)
+	c.Assert(err, IsNil)
+
+	// verify
+	t.verifyInitialEvents(c, r)
+
+	// re-prepare is invalid
+	err = r.StartSyncByPos(pos)
+	c.Assert(err, NotNil)
+
+	// close the reader
+	err = r.Close()
+	c.Assert(err, IsNil)
+
+	// already closed
+	err = r.Close()
+	c.Assert(err, NotNil)
+
+	// invalid startup position
+	pos = gmysql.Position{
+		Name: "mysql-bin.888888",
+		Pos:  666666,
+	}
+
+	// create a new one.
+	r = NewTCPReader(cfg)
+	err = r.StartSyncByPos(pos)
+	c.Assert(err, IsNil)
+
+	_, err = r.GetEvent(context.Background(), true)
+	// ERROR 1236 (HY000): Could not find first log file name in binary log index file
+	// close connection automatically.
+	c.Assert(err, NotNil)
+
+	// get current position for master
+	pos, _, err = utils.GetMasterStatus(t.db, flavor)
+
+	// execute another DML again
+	query := fmt.Sprintf("INSERT INTO `%s`.`%s` VALUES (%d)", dbName, tableName, columnValue+1)
+	_, err = t.db.Exec(query)
+	c.Assert(err, IsNil)
+
+	// create a new one again
+	r = NewTCPReader(cfg)
+	err = r.StartSyncByPos(pos)
+	c.Assert(err, IsNil)
+
+	t.verifyOneDML(c, r)
+
+	err = r.Close()
+	c.Assert(err, IsNil)
+}
+
+func (t *testTCPReaderSuite) TestSyncGTID(c *C) {
+	var (
+		cfg = replication.BinlogSyncerConfig{
+			ServerID:       serverIDs[1],
+			Flavor:         flavor,
+			Host:           t.host,
+			Port:           uint16(t.port),
+			User:           t.user,
+			Password:       t.password,
+			UseDecimal:     true,
+			VerifyChecksum: true,
+		}
+		gSet gtid.Set // nit GTID set
+	)
+
+	// the first reader
+	r := NewTCPReader(cfg)
+	c.Assert(r, NotNil)
+
+	// not prepared
+	e, err := r.GetEvent(context.Background(), true)
+	c.Assert(err, NotNil)
+	c.Assert(e, IsNil)
+
+	// nil GTID set
+	err = r.StartSyncByGTID(gSet)
+	c.Assert(err, NotNil)
+
+	// empty GTID set
+	gSet, err = gtid.ParserGTID(flavor, "")
+	c.Assert(err, IsNil)
+
+	// prepare
+	err = r.StartSyncByGTID(gSet)
+	c.Assert(err, IsNil)
+
+	// verify
+	t.verifyInitialEvents(c, r)
+
+	// re-prepare is invalid
+	err = r.StartSyncByGTID(gSet)
+	c.Assert(err, NotNil)
+
+	// close the reader
+	err = r.Close()
+	c.Assert(err, IsNil)
+
+	// already closed
+	err = r.Close()
+	c.Assert(err, NotNil)
+
+	// get current GTID set for master
+	_, gSet, err = utils.GetMasterStatus(t.db, flavor)
+
+	// execute another DML again
+	query := fmt.Sprintf("INSERT INTO `%s`.`%s` VALUES (%d)", dbName, tableName, columnValue+2)
+	_, err = t.db.Exec(query)
+	c.Assert(err, IsNil)
+
+	// create a new one
+	r = NewTCPReader(cfg)
+	err = r.StartSyncByGTID(gSet)
+	c.Assert(err, IsNil)
+
+	t.verifyOneDML(c, r)
+
+	err = r.Close()
+	c.Assert(err, IsNil)
+}
+
+func (t *testTCPReaderSuite) verifyInitialEvents(c *C, reader Reader) {
+	// if timeout, we think the test case failed.
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	parser2, err := utils.GetParser(t.db, false)
+	c.Assert(err, IsNil)
+
+forLoop:
+	for {
+		e, err := reader.GetEvent(timeoutCtx, true)
+		c.Assert(err, IsNil)
+		switch ev := e.Event.(type) {
+		case *replication.QueryEvent:
+			stmt, err := parser2.ParseOneStmt(string(ev.Query), "", "")
+			c.Assert(err, IsNil)
+			switch ddl := stmt.(type) {
+			case *ast.CreateDatabaseStmt:
+				c.Assert(ddl.Name, Equals, dbName)
+			case *ast.CreateTableStmt:
+				c.Assert(ddl.Table.Name.O, Equals, tableName)
+			}
+		case *replication.RowsEvent:
+			c.Assert(string(ev.Table.Schema), Equals, dbName)
+			c.Assert(string(ev.Table.Table), Equals, tableName)
+			c.Assert(ev.Rows, HasLen, 1)                // `INSERT INTO`
+			c.Assert(ev.ColumnCount, Equals, uint64(1)) // `c1`
+			break forLoop                               // if we got the DML, then we think our test case passed.
+		}
+	}
+}
+
+func (t *testTCPReaderSuite) verifyOneDML(c *C, reader Reader) {
+	// if timeout, we think the test case failed.
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+forLoop:
+	for {
+		e, err := reader.GetEvent(timeoutCtx, false)
+		c.Assert(err, IsNil)
+		switch ev := e.Event.(type) {
+		case *replication.RowsEvent:
+			c.Assert(string(ev.Table.Schema), Equals, dbName)
+			c.Assert(string(ev.Table.Table), Equals, tableName)
+			c.Assert(ev.Rows, HasLen, 1)                // `INSERT INTO`
+			c.Assert(ev.ColumnCount, Equals, uint64(1)) // `c1`
+			break forLoop
+		}
+	}
+}

--- a/pkg/binlog/reader/tcp_test.go
+++ b/pkg/binlog/reader/tcp_test.go
@@ -125,7 +125,7 @@ func (t *testTCPReaderSuite) TestSyncPos(c *C) {
 	c.Assert(r, NotNil)
 
 	// not prepared
-	e, err := r.GetEvent(context.Background(), true)
+	e, err := r.GetEvent(context.Background())
 	c.Assert(err, NotNil)
 	c.Assert(e, IsNil)
 
@@ -168,7 +168,7 @@ func (t *testTCPReaderSuite) TestSyncPos(c *C) {
 	err = r.StartSyncByPos(pos)
 	c.Assert(err, IsNil)
 
-	_, err = r.GetEvent(context.Background(), true)
+	_, err = r.GetEvent(context.Background())
 	// ERROR 1236 (HY000): Could not find first log file name in binary log index file
 	// close connection automatically.
 	c.Assert(err, NotNil)
@@ -219,7 +219,7 @@ func (t *testTCPReaderSuite) TestSyncGTID(c *C) {
 	c.Assert(trStatus.ConnID, Equals, uint32(0))
 
 	// not prepared
-	e, err := r.GetEvent(context.Background(), true)
+	e, err := r.GetEvent(context.Background())
 	c.Assert(err, NotNil)
 	c.Assert(e, IsNil)
 
@@ -286,7 +286,7 @@ func (t *testTCPReaderSuite) verifyInitialEvents(c *C, reader Reader) {
 
 forLoop:
 	for {
-		e, err := reader.GetEvent(timeoutCtx, true)
+		e, err := reader.GetEvent(timeoutCtx)
 		c.Assert(err, IsNil)
 		switch ev := e.Event.(type) {
 		case *replication.QueryEvent:
@@ -315,7 +315,7 @@ func (t *testTCPReaderSuite) verifyOneDML(c *C, reader Reader) {
 
 forLoop:
 	for {
-		e, err := reader.GetEvent(timeoutCtx, false)
+		e, err := reader.GetEvent(timeoutCtx)
 		c.Assert(err, IsNil)
 		switch ev := e.Event.(type) {
 		case *replication.RowsEvent:

--- a/pkg/binlog/reader/tcp_test.go
+++ b/pkg/binlog/reader/tcp_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -135,6 +136,15 @@ func (t *testTCPReaderSuite) TestSyncPos(c *C) {
 	// verify
 	t.verifyInitialEvents(c, r)
 
+	// check status, stagePrepared
+	status := r.Status()
+	trStatus, ok := status.(*TCPReaderStatus)
+	c.Assert(ok, IsTrue)
+	c.Assert(trStatus.Stage, Equals, stagePrepared.String())
+	c.Assert(trStatus.Connection, Greater, uint32(0))
+	trStatusStr := trStatus.String()
+	c.Assert(strings.Contains(trStatusStr, stagePrepared.String()), IsTrue)
+
 	// re-prepare is invalid
 	err = r.StartSyncByPos(pos)
 	c.Assert(err, NotNil)
@@ -201,6 +211,13 @@ func (t *testTCPReaderSuite) TestSyncGTID(c *C) {
 	r := NewTCPReader(cfg)
 	c.Assert(r, NotNil)
 
+	// check status, stageNew
+	status := r.Status()
+	trStatus, ok := status.(*TCPReaderStatus)
+	c.Assert(ok, IsTrue)
+	c.Assert(trStatus.Stage, Equals, stageNew.String())
+	c.Assert(trStatus.Connection, Equals, uint32(0))
+
 	// not prepared
 	e, err := r.GetEvent(context.Background(), true)
 	c.Assert(err, NotNil)
@@ -228,6 +245,13 @@ func (t *testTCPReaderSuite) TestSyncGTID(c *C) {
 	// close the reader
 	err = r.Close()
 	c.Assert(err, IsNil)
+
+	// check status, stageClosed
+	status = r.Status()
+	trStatus, ok = status.(*TCPReaderStatus)
+	c.Assert(ok, IsTrue)
+	c.Assert(trStatus.Stage, Equals, stageClosed.String())
+	c.Assert(trStatus.Connection, Greater, uint32(0))
 
 	// already closed
 	err = r.Close()

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -298,9 +298,9 @@ func (r *Relay) process(parentCtx context.Context) error {
 		readTimer := time.Now()
 		var e *replication.BinlogEvent
 		if gapReader != nil {
-			e, err = gapReader.GetEvent(ctx, false)
+			e, err = gapReader.GetEvent(ctx)
 		} else {
-			e, err = r.reader.GetEvent(ctx, false)
+			e, err = r.reader.GetEvent(ctx)
 		}
 		cancel()
 		binlogReadDurationHistogram.Observe(time.Since(readTimer).Seconds())

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/dm/dm/config"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/dm/dm/unit"
+	binlogreader "github.com/pingcap/dm/pkg/binlog/reader"
 	fr "github.com/pingcap/dm/pkg/func-rollback"
 	"github.com/pingcap/dm/pkg/gtid"
 	"github.com/pingcap/dm/pkg/log"
@@ -69,10 +70,11 @@ const (
 
 // Relay relays mysql binlog to local file.
 type Relay struct {
-	db                    *sql.DB
-	cfg                   *Config
-	syncer                *replication.BinlogSyncer
-	syncerCfg             replication.BinlogSyncerConfig
+	db        *sql.DB
+	cfg       *Config
+	syncerCfg replication.BinlogSyncerConfig
+	reader    binlogreader.Reader
+
 	gapSyncerCfg          replication.BinlogSyncerConfig
 	meta                  Meta
 	lastSlaveConnectionID uint32
@@ -165,7 +167,7 @@ func (r *Relay) Init() (err error) {
 
 // Process implements the dm.Unit interface.
 func (r *Relay) Process(ctx context.Context, pr chan pb.ProcessResult) {
-	r.syncer = replication.NewBinlogSyncer(r.syncerCfg)
+	r.reader = binlogreader.NewTCPReader(r.syncerCfg)
 
 	errs := make([]*pb.ProcessError, 0, 1)
 	err := r.process(ctx)
@@ -229,7 +231,7 @@ func (r *Relay) process(parentCtx context.Context) error {
 		r.updateMetricsRelaySubDirIndex()
 	}
 
-	streamer, err := r.getBinlogStreamer()
+	err = r.setUpReader()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -300,7 +302,7 @@ func (r *Relay) process(parentCtx context.Context) error {
 		if gapStreamer != nil {
 			e, err = gapStreamer.GetEvent(ctx)
 		} else {
-			e, err = streamer.GetEvent(ctx)
+			e, err = r.reader.GetEvent(ctx, false)
 		}
 		cancel()
 		binlogReadDurationHistogram.Observe(time.Since(readTimer).Seconds())
@@ -344,7 +346,7 @@ func (r *Relay) process(parentCtx context.Context) error {
 						return errors.Annotatef(err, "gap streamer")
 					}
 					if tryReSync && r.cfg.EnableGTID && r.cfg.AutoFixGTID {
-						streamer, err = r.reSyncBinlog(r.syncerCfg)
+						err = r.reSetUpReader(r.syncerCfg)
 						if err != nil {
 							return errors.Annotatef(err, "try auto switch with GTID")
 						}
@@ -751,51 +753,44 @@ func (r *Relay) checkFormatDescriptionEventExists(filename string) (exists bool,
 	return false, nil
 }
 
-// NOTE: now, no online master-slave switching supported
-// when switching, user must Pause relay, update config, then Resume
-// so, will call `getBinlogStreamer` again on new master
-func (r *Relay) getBinlogStreamer() (*replication.BinlogStreamer, error) {
+func (r *Relay) setUpReader() error {
 	defer func() {
-		r.lastSlaveConnectionID = r.syncer.LastConnectionID()
-		log.Infof("[relay] last slave connection id %d", r.lastSlaveConnectionID)
+		status := r.reader.Status()
+		log.Infof("[relay] set up binlog reader with status %s", status)
 	}()
+
 	if r.cfg.EnableGTID {
-		return r.startSyncByGTID()
+		return r.setUpReaderByGTID()
 	}
-	return r.startSyncByPos()
+	return r.setUpReaderByPos()
 }
 
-func (r *Relay) startSyncByGTID() (*replication.BinlogStreamer, error) {
+func (r *Relay) setUpReaderByGTID() error {
 	uuid, gs := r.meta.GTID()
 	log.Infof("[relay] start sync for master(%s, %s) from GTID set %s", r.masterNode(), uuid, gs)
 
-	streamer, err := r.syncer.StartSyncGTID(gs.Origin())
+	err := r.reader.StartSyncByGTID(gs)
 	if err != nil {
 		log.Errorf("[relay] start sync in GTID mode from %s error %v", gs.String(), err)
-		return r.startSyncByPos()
+		return r.setUpReaderByPos()
 	}
 
-	return streamer, errors.Trace(err)
+	return nil
 }
 
-// TODO: exception handling.
-// e.g.
-// 1.relay connects to a difference MySQL
-// 2. upstream MySQL does a pure restart (removes all its' data, and then restart)
-
-func (r *Relay) startSyncByPos() (*replication.BinlogStreamer, error) {
+func (r *Relay) setUpReaderByPos() error {
 	// if the first binlog not exists in local, we should fetch from the first position, whatever the specific position is.
 	uuid, pos := r.meta.Pos()
 	log.Infof("[relay] start sync for master (%s, %s) from %s", r.masterNode(), uuid, pos.String())
 	if pos.Name == "" {
 		// let mysql decides
-		return r.syncer.StartSync(pos)
+		return r.reader.StartSyncByPos(pos)
 	}
 	if stat, err := os.Stat(filepath.Join(r.meta.Dir(), pos.Name)); os.IsNotExist(err) {
 		log.Infof("[relay] should sync from %s:4 instead of %s:%d because the binlog file not exists in local before and should sync from the very beginning", pos.Name, pos.Name, pos.Pos)
 		pos.Pos = 4
 	} else if err != nil {
-		return nil, errors.Trace(err)
+		return errors.Trace(err)
 	} else {
 		if stat.Size() > int64(pos.Pos) {
 			// it means binlog file already exists, and the local binlog file already contains the specific position
@@ -806,25 +801,24 @@ func (r *Relay) startSyncByPos() (*replication.BinlogStreamer, error) {
 			pos.Pos = uint32(stat.Size())
 			err := r.meta.Save(pos, nil)
 			if err != nil {
-				return nil, errors.Trace(err)
+				return errors.Trace(err)
 			}
 		} else if stat.Size() < int64(pos.Pos) {
 			// in such case, we should stop immediately and check
-			return nil, errors.Annotatef(ErrBinlogPosGreaterThanFileSize, "%s size=%d, specific pos=%d", pos.Name, stat.Size(), pos.Pos)
+			return errors.Annotatef(ErrBinlogPosGreaterThanFileSize, "%s size=%d, specific pos=%d", pos.Name, stat.Size(), pos.Pos)
 		}
 	}
 
-	streamer, err := r.syncer.StartSync(pos)
-	return streamer, errors.Trace(err)
+	return r.reader.StartSyncByPos(pos)
 }
 
 // reSyncBinlog re-tries sync binlog when master-slave switched
-func (r *Relay) reSyncBinlog(cfg replication.BinlogSyncerConfig) (*replication.BinlogStreamer, error) {
+func (r *Relay) reSyncBinlog(cfg replication.BinlogSyncerConfig) error {
 	err := r.retrySyncGTIDs()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return errors.Trace(err)
 	}
-	return r.reopenStreamer(cfg)
+	return r.reSetUpReader(cfg)
 }
 
 // retrySyncGTIDs try to auto fix GTID set
@@ -864,18 +858,15 @@ func (r *Relay) retrySyncGTIDs() error {
 	return nil
 }
 
-// reopenStreamer reopen a new streamer
-func (r *Relay) reopenStreamer(cfg replication.BinlogSyncerConfig) (*replication.BinlogStreamer, error) {
-	if r.syncer != nil {
-		err := r.closeBinlogSyncer(r.syncer)
-		r.syncer = nil
+func (r *Relay) reSetUpReader(cfg replication.BinlogSyncerConfig) error {
+	if r.reader != nil {
+		err := r.reader.Close()
+		r.reader = nil
 		if err != nil {
-			return nil, errors.Trace(err)
+			return errors.Trace(err)
 		}
 	}
-
-	r.syncer = replication.NewBinlogSyncer(cfg)
-	return r.getBinlogStreamer()
+	return r.setUpReader()
 }
 
 func (r *Relay) masterNode() string {
@@ -889,9 +880,9 @@ func (r *Relay) IsClosed() bool {
 
 // stopSync stops syncing, now it used by Close and Pause
 func (r *Relay) stopSync() {
-	if r.syncer != nil {
-		r.closeBinlogSyncer(r.syncer)
-		r.syncer = nil
+	if r.reader != nil {
+		r.reader.Close()
+		r.reader = nil
 	}
 	if r.fd != nil {
 		r.fd.Close()


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR is a part work of #91 

Introduced a binlog event `Reader` interface, so we can implement at least 3 kinds of Reader later:

1. TCPReader: read binlog events from a master server through TCP stream
2. FileReader: read binlog events from binlog files (or relay log files)
3. InMemoryReader: read binlog events from memory, used as a mock master to do testing

In this PR, I only implement a `TCPReader` and refactor a litter code for relay writer to make review easier.

Later, the following things will be done:

1. split relay writer to _reader_ --> _translator_ --> _writer_
2. add an InMemoryReader to test 3 parts above
3. refactor sync unit (relay reader) to read through a FileReader and use an InMemoryReader to test it

### What is changed and how it works?

- add a `TCPReader`
- refactor relay writer to use the `TCPReader`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has interface methods change
