### PR TITLE
syncer: fix the error message about executing multiple DDLs

### DIFF
--- a/syncer/sharding_group.go
+++ b/syncer/sharding_group.go
@@ -138,7 +138,7 @@ func (sg *ShardingGroup) Merge(sources []string) (bool, bool, int, error) {
 				if !synced {
 					sg.remain--
 				} else if !utils.CompareShardingDDLs(sg.sourceDDLs[source], ddls) {
-					return isResolving, sg.remain <= 0, sg.remain, errors.NotSupportedf("execute multiple ddls: previous ddl %s and current ddl %s for source table %s", sg.sourceDDLs[source], ddl, source)
+					return isResolving, sg.remain <= 0, sg.remain, errors.NotSupportedf("execute multiple ddls: previous ddl %s and current ddls %q for source table %s", sg.sourceDDLs[source], ddls, source)
 				}
 			}
 
@@ -211,7 +211,7 @@ func (sg *ShardingGroup) TrySync(source string, pos, endPos mysql.Position, ddls
 		sg.sources[source] = true
 		sg.sourceDDLs[source] = ddls
 	} else if !utils.CompareShardingDDLs(sg.sourceDDLs[source], ddls) {
-		return sg.remain <= 0, sg.remain, errors.NotSupportedf("execute multiple ddls: previous ddl %s and current ddl %s for source table %s", sg.sourceDDLs[source], ddl, source)
+		return sg.remain <= 0, sg.remain, errors.NotSupportedf("execute multiple ddls: previous ddl %s and current ddls %q for source table %s", sg.sourceDDLs[source], ddls, source)
 	}
 
 	if sg.firstPos == nil {


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Previous it logged the `ddl` constant in `job.go` making the error message always showing "... and current ddl ddl for source table ..." which is useless. It is supposed to log the parameter `ddls`.

### What is changed and how it works?

Replaced "ddl" with "ddls".

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
    * And mainly verified that `Printf("%q", []string{"a", "b"})` has the desired output.

Code changes

Side effects

Related changes
