### PR TITLE
syncer: add metrics for sharding merge

### DIFF
--- a/dm/dm-ansible/scripts/dm.json
+++ b/dm/dm-ansible/scripts/dm.json
@@ -2529,6 +2529,162 @@
               "show": true
             }
           ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "number of unsynced tables in the subtask",
+          "fill": 1,
+          "id": 45,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "dm_syncer_unsynced_table_number{instance=\"$instance\", task=\"$task\"}",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "unsynced tables",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "waiting sharding DDL lock to be resolved, >0 means waiting",
+          "fill": 1,
+          "id": 46,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "dm_syncer_shard_lock_resolving{instance=\"$instance\", task=\"$task\"}",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "shard lock resolving",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": "1",
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
         }
       ],
       "repeat": null,

--- a/dm/dm-ansible/scripts/dm.json
+++ b/dm/dm-ansible/scripts/dm.json
@@ -2614,7 +2614,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "waiting sharding DDL lock to be resolved, >0 means waiting",
+          "description": "waiting shard DDL lock to be resolved, >0 means waiting",
           "fill": 1,
           "id": 46,
           "legend": {

--- a/syncer/metrics.go
+++ b/syncer/metrics.go
@@ -126,6 +126,22 @@ var (
 			Name:      "remaining_time",
 			Help:      "the remaining time in second to catch up master",
 		}, []string{"task"})
+
+	unsyncedTableGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "dm",
+			Subsystem: "syncer",
+			Name:      "unsynced_table_number",
+			Help:      "number of unsynced tables in the subtask",
+		}, []string{"task", "table"})
+
+	shardLockResolving = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "dm",
+			Subsystem: "syncer",
+			Name:      "shard_lock_resolving",
+			Help:      "waiting sharding DDL lock to be resolved",
+		}, []string{"task"})
 )
 
 // RegisterMetrics registers metrics
@@ -142,6 +158,8 @@ func RegisterMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(syncerExitWithErrorCounter)
 	registry.MustRegister(replicationLagGauge)
 	registry.MustRegister(remainingTimeGauge)
+	registry.MustRegister(unsyncedTableGauge)
+	registry.MustRegister(shardLockResolving)
 }
 
 func (s *Syncer) runBackgroundJob(ctx context.Context) {

--- a/syncer/metrics.go
+++ b/syncer/metrics.go
@@ -140,7 +140,7 @@ var (
 			Namespace: "dm",
 			Subsystem: "syncer",
 			Name:      "shard_lock_resolving",
-			Help:      "waiting sharding DDL lock to be resolved",
+			Help:      "waiting shard DDL lock to be resolved",
 		}, []string{"task"})
 )
 

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -1574,12 +1574,12 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 				if err != nil {
 					return errors.Trace(err)
 				}
-				target, _ := GenTableID(ddlInfo.tableNames[1][0].Schema, ddlInfo.tableNames[1][0].Name)
-				unsyncedTableGauge.WithLabelValues(s.cfg.Name, target).Set(float64(remain))
 				log.Infof("[syncer] try to sync table %s to shard group (%v)", source, needShardingHandle)
 			}
 
 			if needShardingHandle {
+				target, _ := GenTableID(ddlInfo.tableNames[1][0].Schema, ddlInfo.tableNames[1][0].Name)
+				unsyncedTableGauge.WithLabelValues(s.cfg.Name, target).Set(float64(remain))
 				log.Infof("[syncer] query event %v for source %v is in sharding, synced: %v, remain: %d", startPos, source, synced, remain)
 				err = safeMode.IncrForTable(ddlInfo.tableNames[1][0].Schema, ddlInfo.tableNames[1][0].Name) // try enable safe-mode when starting syncing for sharding group
 				if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Support to judge whether waiting for sharding DDL lock to be resolved through metrics.

### What is changed and how it works?

- add metrics for sharding merge

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 	1. observe `dm_syncer_unsynced_table_number`/`dm_syncer_shard_lock_resolving`
 	2. execute DDL for a part of shard tables
 	3. observe `dm_syncer_unsynced_table_number`/`dm_syncer_shard_lock_resolving`
 	4. execute DDL for all other shard tables
 	5. observe `dm_syncer_unsynced_table_number`/`dm_syncer_shard_lock_resolving`


Side effects

 - Increased code complexity

Related changes

 - Need to update the documentation
 - Need to update the `dm/dm-ansible`

![image](https://user-images.githubusercontent.com/3183039/55231638-40424880-525e-11e9-8abd-60e08cdbdb2a.png)
