### PR TITLE
config: verify subtask config when generating from task

### DIFF
--- a/dm/config/task.go
+++ b/dm/config/task.go
@@ -485,6 +485,11 @@ func (c *TaskConfig) SubTaskConfigs(sources map[string]DBConfig) ([]*SubTaskConf
 		cfg.LoaderConfig = *inst.Loader
 		cfg.SyncerConfig = *inst.Syncer
 
+		err := cfg.adjust()
+		if err != nil {
+			return nil, errors.Annotatef(err, "source %s", inst.SourceID)
+		}
+
 		cfgs[i] = cfg
 	}
 	return cfgs, nil

--- a/dm/master/server.go
+++ b/dm/master/server.go
@@ -191,7 +191,7 @@ func (s *Server) StartTask(ctx context.Context, req *pb.StartTaskRequest) (*pb.S
 	if err != nil {
 		return &pb.StartTaskResponse{
 			Result: false,
-			Msg:    errors.Cause(err).Error(),
+			Msg:    errors.ErrorStack(err),
 		}, nil
 	}
 	log.Infof("[server] starting task with config:\n%v", cfg)
@@ -374,7 +374,7 @@ func (s *Server) UpdateTask(ctx context.Context, req *pb.UpdateTaskRequest) (*pb
 	if err != nil {
 		return &pb.UpdateTaskResponse{
 			Result: false,
-			Msg:    errors.Cause(err).Error(),
+			Msg:    errors.ErrorStack(err),
 		}, nil
 	}
 	log.Infof("[server] update task with config:\n%v", cfg)


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

avoid panic mentioned in #97 

### What is changed and how it works?

- adjust subtask config when generating from task config
- show error stack for start/update task in dmctl

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
	 - start task with un-encrypted downstream password

