### PR TITLE
*: change `max_allowed_packet` to 64MB

### DIFF
--- a/dm/config/subtask_test.go
+++ b/dm/config/subtask_test.go
@@ -32,6 +32,8 @@ func (t *testConfig) TestSubTask(c *C) {
 			Password: "",
 		},
 	}
+	cfg.From.Adjust()
+	cfg.To.Adjust()
 
 	clone1, err := cfg.Clone()
 	c.Assert(err, IsNil)

--- a/dm/worker/config.go
+++ b/dm/worker/config.go
@@ -180,6 +180,7 @@ func (c *Config) Parse(arguments []string) error {
 	// assign tracer id to source id
 	c.Tracer.Source = c.SourceID
 
+	c.From.Adjust()
 	return c.verify()
 }
 

--- a/loader/checkpoint_test.go
+++ b/loader/checkpoint_test.go
@@ -51,6 +51,7 @@ func (t *testCheckPointSuite) SetUpSuite(c *C) {
 		},
 		MetaSchema: "test",
 	}
+	t.cfg.To.Adjust()
 }
 
 func (t *testCheckPointSuite) TearDownSuite(c *C) {

--- a/loader/db.go
+++ b/loader/db.go
@@ -195,7 +195,8 @@ func executeSQLImp(db *sql.DB, sqls []string) error {
 }
 
 func createConn(cfg *config.SubTaskConfig) (*Conn, error) {
-	dbDSN := fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8", cfg.To.User, cfg.To.Password, cfg.To.Host, cfg.To.Port)
+	dbDSN := fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8mb4&maxAllowedPacket=%d",
+		cfg.To.User, cfg.To.Password, cfg.To.Host, cfg.To.Port, *cfg.To.MaxAllowedPacket)
 	db, err := sql.Open("mysql", dbDSN)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/syncer/db.go
+++ b/syncer/db.go
@@ -246,7 +246,8 @@ func (conn *Conn) executeSQLJobImp(jobs []*job) *ExecErrorContext {
 }
 
 func createDB(cfg *config.SubTaskConfig, dbCfg config.DBConfig, timeout string) (*Conn, error) {
-	dbDSN := fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8&interpolateParams=true&readTimeout=%s", dbCfg.User, dbCfg.Password, dbCfg.Host, dbCfg.Port, timeout)
+	dbDSN := fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8mb4&interpolateParams=true&readTimeout=%s&maxAllowedPacket=%d",
+		dbCfg.User, dbCfg.Password, dbCfg.Host, dbCfg.Port, timeout, *dbCfg.MaxAllowedPacket)
 	db, err := sql.Open("mysql", dbDSN)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -82,6 +82,8 @@ func (s *testSyncerSuite) SetUpSuite(c *C) {
 		ServerID:   101,
 		MetaSchema: "test",
 	}
+	s.cfg.From.Adjust()
+	s.cfg.To.Adjust()
 
 	var err error
 	dbAddr := fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8", s.cfg.From.User, s.cfg.From.Password, s.cfg.From.Host, s.cfg.From.Port)


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

the default value of `max_allowed_packet` in MySQL server and _go-sql-driver/mysql_ driver is 4MB, but in TiDB server it's 64MB.
ref:

- <https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_allowed_packet>
- <https://github.com/go-sql-driver/mysql#maxallowedpacket>

### What is changed and how it works?

- change the default value of `max_allowed_packet` to 64MB
	- in fact, in the clinet this can be 1GB, ref <https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_allowed_packet>
- add a `max-allowed-packet` config item for DB config
- change `charset` from `utf8` to `utf8mb4`

we can refactor DB operation to a pkg and add test cases for config later.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 	- config with/without `max_allowed_packet` in DM-worker's config and task's config
	- hack the code to see the DSN


Side effects

 - Increased code complexity

