### PR TITLE
*: add a `.name` suffix to avoid data overwrite between tasks

### DIFF
--- a/dm/config/subtask.go
+++ b/dm/config/subtask.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -266,6 +267,12 @@ func (c *SubTaskConfig) adjust() error {
 		if err != nil {
 			return errors.Annotatef(err, "invalid timezone string: %s", c.Timezone)
 		}
+	}
+
+	dirSuffix := "." + c.Name
+	if !strings.HasSuffix(c.LoaderConfig.Dir, dirSuffix) { // check to support multiple times calling
+		// if not ends with the task name, we append the task name to the tail
+		c.LoaderConfig.Dir += dirSuffix
 	}
 
 	c.From.Adjust()

--- a/dm/master/task.yaml
+++ b/dm/master/task.yaml
@@ -69,7 +69,7 @@ mysql-instances:             # one or more source database, config more source d
 
     loader:                  # local loader rule
       pool-size: 16
-      dir: "./dumped_data"   # must be unique between tasks for the same instance
+      dir: "./dumped_data"   # if not ends with `.name`, then `.name` will be appended
 
     syncer:
       worker-count: 16

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -772,7 +772,20 @@ func (l *Loader) prepare() error {
 
 	// check if mydumper dir data exists.
 	if !utils.IsDirExists(l.cfg.Dir) {
-		return errors.Errorf("%s is not exists or it's not a dir", l.cfg.Dir)
+		// compatibility with no `.name` suffix
+		dirSuffix := "." + l.cfg.Name
+		var trimmed bool
+		if strings.HasSuffix(l.cfg.Dir, dirSuffix) {
+			dirPrefix := strings.TrimSuffix(l.cfg.Dir, dirSuffix)
+			if utils.IsDirExists(dirPrefix) {
+				log.Warnf("[loader] %s is not exists, trying to load data from %s", l.cfg.Dir, dirPrefix)
+				l.cfg.Dir = dirPrefix
+				trimmed = true
+			}
+		}
+		if !trimmed {
+			return errors.Errorf("%s is not exists or it's not a dir", l.cfg.Dir)
+		}
 	}
 
 	// collect dir files.


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

when running multiple tasks, the user may specify the same `loader.dir` between tasks, then the dumped data maybe overwrote.

### What is changed and how it works?

- append a `.name` prefix to the `loader.dir` if not exists

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
	 - start a full/all task
	 - observe the dumped data dir name
