### PR TITLE
tests: add retry in metric check, make it more robust

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -57,5 +57,5 @@ Several convenient commands are provided:
 * `check_port_alive <PORT>` - Wrapper to check a port is alive, at most 20 times.
 * `check_port <HOST> <PORT>` - Checks a host:port is alive.
 * `wait_process_exit <process_name>` - Wait for one or more processes to exit by given process name.
-* `check_metric <PORT> <METRIC_NAME> <VALUE PATTERN LIST>...` - check metric value from prometheus.
+* `check_metric <PORT> <METRIC_NAME> <RETRY_TIME> <VALUE PATTERN LIST>...` - check metric value from prometheus.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -57,5 +57,5 @@ Several convenient commands are provided:
 * `check_port_alive <PORT>` - Wrapper to check a port is alive, at most 20 times.
 * `check_port <HOST> <PORT>` - Checks a host:port is alive.
 * `wait_process_exit <process_name>` - Wait for one or more processes to exit by given process name.
-* `check_metric <PORT> <METRIC_NAME> <RETRY_TIME> <VALUE PATTERN LIST>...` - check metric value from prometheus.
+* `check_metric <PORT> <METRIC_NAME> <RETRY_COUNT> <VALUE PATTERN LIST>...` - check metric value from prometheus.
 

--- a/tests/_utils/check_metric
+++ b/tests/_utils/check_metric
@@ -1,19 +1,19 @@
 #!/bin/bash
 # parameter 1: port
 # parameter 2: metric name
-# parameter 3: retry time
+# parameter 3: retry count, if check failed we will wait 1s before next retry, until retry time exceeds retry count
 # parameter 4...: valid value list
 
 set -eu
 
 port=$1
 metric_name=$2
-retry_time=$3
+retry_count=$3
 
 shift 3
 
 counter=0
-while [ $counter -lt $retry_time ]; do
+while [ $counter -lt $retry_count ]; do
     metric=$(curl -s http://127.0.0.1:$port/metrics | grep $metric_name | awk '{print $2}')
     for pattern in "$@"; do
         if [ "$metric" == "${pattern}" ]; then

--- a/tests/_utils/check_metric
+++ b/tests/_utils/check_metric
@@ -1,19 +1,28 @@
 #!/bin/bash
 # parameter 1: port
 # parameter 2: metric name
-# parameter 3...: valid value list
+# parameter 3: retry time
+# parameter 4...: valid value list
 
 set -eu
 
 port=$1
 metric_name=$2
+retry_time=$3
 
-metric=$(curl -s http://127.0.0.1:$port/metrics | grep $metric_name | awk '{print $2}')
-shift 2
-for pattern in "$@"; do
-    if [ "$metric" == "${pattern}" ]; then
-        exit 0
-    fi
+shift 3
+
+counter=0
+while [ $counter -lt $retry_time ]; do
+    metric=$(curl -s http://127.0.0.1:$port/metrics | grep $metric_name | awk '{print $2}')
+    for pattern in "$@"; do
+        if [ "$metric" == "${pattern}" ]; then
+            exit 0
+        fi
+    done
+    ((counter+=1))
+    echo "wait for valid metric for $counter-th time"
+    sleep 1
 done
 
 echo "metric $metric_name has invalid value $metric"

--- a/tests/all_mode/run.sh
+++ b/tests/all_mode/run.sh
@@ -40,8 +40,8 @@ function run() {
     # use sync_diff_inspector to check data now!
     check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
 
-    check_metric $WORKER1_PORT 'dm_syncer_replication_lag{task="test"}' 0 1
-    check_metric $WORKER2_PORT 'dm_syncer_replication_lag{task="test"}' 0 1
+    check_metric $WORKER1_PORT 'dm_syncer_replication_lag{task="test"}' 3 0 1
+    check_metric $WORKER2_PORT 'dm_syncer_replication_lag{task="test"}' 3 0 1
 }
 
 cleanup1 all_mode


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
in all mode test, DM-worker is just restarted before checking metric, the metric may have not been updated in time.

### What is changed and how it works?
add retry in metric check

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test