### PR TITLE
*: remove some unnecessary type conversion

### DIFF
--- a/dm/ctl/master/migrate_relay.go
+++ b/dm/ctl/master/migrate_relay.go
@@ -55,7 +55,7 @@ func migrateRelayFunc(cmd *cobra.Command, _ []string) {
 
 	cli := common.MasterClient()
 	resp, err := cli.MigrateWorkerRelay(ctx, &pb.MigrateWorkerRelayRequest{
-		BinlogName: string(binlogName),
+		BinlogName: binlogName,
 		BinlogPos:  uint32(binlogPos),
 		Worker:     worker,
 	})

--- a/dm/worker/config.go
+++ b/dm/worker/config.go
@@ -125,7 +125,7 @@ func (c *Config) Toml() (string, error) {
 		log.Errorf("[worker] marshal config to toml error %v", err)
 	}
 
-	return string(b.String()), nil
+	return b.String(), nil
 }
 
 // Parse parses flag definitions from the argument list.

--- a/dm/worker/server.go
+++ b/dm/worker/server.go
@@ -467,7 +467,7 @@ func (s *Server) QueryWorkerConfig(ctx context.Context, req *pb.QueryWorkerConfi
 		log.Errorf("[worker] marshal worker config error %v", errors.ErrorStack(err))
 	}
 
-	resp.Content = string(rawConfig)
+	resp.Content = rawConfig
 	resp.SourceID = workerCfg.SourceID
 	return resp, nil
 }

--- a/pkg/binlog/event/dml.go
+++ b/pkg/binlog/event/dml.go
@@ -74,7 +74,7 @@ func GenDMLEvents(flavor string, serverID uint32, latestPos uint32, latestGTID g
 		// TableMapEvent
 		tableMapEv, err2 := GenTableMapEvent(header, latestPos, data.TableID, []byte(data.Schema), []byte(data.Table), data.ColumnType)
 		if err2 != nil {
-			return nil, errors.Annotatef(err2, "generate TableMapEvent for `%s`.`%s`", string(data.Schema), string(data.Table))
+			return nil, errors.Annotatef(err2, "generate TableMapEvent for `%s`.`%s`", data.Schema, data.Table)
 		}
 		latestPos = tableMapEv.Header.LogPos
 		events = append(events, tableMapEv)
@@ -82,7 +82,7 @@ func GenDMLEvents(flavor string, serverID uint32, latestPos uint32, latestGTID g
 		// RowsEvent
 		rowsEv, err2 := GenRowsEvent(header, latestPos, eventType, data.TableID, defaultRowsFlag, data.Rows, data.ColumnType)
 		if err2 != nil {
-			return nil, errors.Annotatef(err2, "generate RowsEvent for `%s`.`%s`", string(data.Schema), string(data.Table))
+			return nil, errors.Annotatef(err2, "generate RowsEvent for `%s`.`%s`", data.Schema, data.Table)
 		}
 		latestPos = rowsEv.Header.LogPos
 		events = append(events, rowsEv)

--- a/pkg/binlog/event/util.go
+++ b/pkg/binlog/event/util.go
@@ -95,7 +95,7 @@ func decodeTableMapColumnMeta(data []byte, columnType []byte) ([]uint16, error) 
 
 // bitmapByteSize returns the byte length of bitmap for columnCount.
 func bitmapByteSize(columnCount int) int {
-	return int(columnCount+7) / 8
+	return (columnCount + 7) / 8
 }
 
 // nullBytes returns a n-length null bytes slice

--- a/pkg/encrypt/encrypt.go
+++ b/pkg/encrypt/encrypt.go
@@ -42,7 +42,7 @@ func SetSecretKey(key []byte) error {
 
 // Encrypt encrypts plaintext to ciphertext
 func Encrypt(plaintext []byte) ([]byte, error) {
-	block, err := aes.NewCipher([]byte(secretKey))
+	block, err := aes.NewCipher(secretKey)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -65,7 +65,7 @@ func Encrypt(plaintext []byte) ([]byte, error) {
 
 // Decrypt decrypts ciphertext to plaintext
 func Decrypt(ciphertext []byte) ([]byte, error) {
-	block, err := aes.NewCipher([]byte(secretKey))
+	block, err := aes.NewCipher(secretKey)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/streamer/reader.go
+++ b/pkg/streamer/reader.go
@@ -342,7 +342,7 @@ func (r *BinlogReader) parseFile(ctx context.Context, s *LocalStreamer, relayLog
 		return false, false, latestPos, "", "", nil
 	}
 
-	needSwitch, needReParse, nextUUID, nextBinlogName, err = r.needSwitchSubDir(currentUUID, fullPath, int64(latestPos))
+	needSwitch, needReParse, nextUUID, nextBinlogName, err = r.needSwitchSubDir(currentUUID, fullPath, latestPos)
 	if err != nil {
 		return false, false, 0, "", "", errors.Trace(err)
 	} else if needReParse {
@@ -353,7 +353,7 @@ func (r *BinlogReader) parseFile(ctx context.Context, s *LocalStreamer, relayLog
 		return true, false, 0, nextUUID, nextBinlogName, nil
 	}
 
-	updatedPath, err := relaySubDirUpdated(ctx, watcherInterval, relayLogDir, fullPath, relayLogFile, int64(latestPos))
+	updatedPath, err := relaySubDirUpdated(ctx, watcherInterval, relayLogDir, fullPath, relayLogFile, latestPos)
 	if err != nil {
 		return false, false, 0, "", "", errors.Trace(err)
 	}

--- a/pkg/streamer/utils_test.go
+++ b/pkg/streamer/utils_test.go
@@ -145,7 +145,7 @@ func (s *testStreamerSuite) TestFileSizeUpdatedError(c *C) {
 
 	// create relay log
 	relayPath := path.Join(subDir, relayFile)
-	err = ioutil.WriteFile(relayPath, []byte(data), 0644)
+	err = ioutil.WriteFile(relayPath, data, 0644)
 	c.Assert(err, IsNil)
 
 	// watcher, for file size decrease


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
use tool https://github.com/mdempsky/unconvert we can find some unnecessary type conversion

### What is changed and how it works?
remove unnecessary type conversion, it is safe because go is a statically typed programming language
two code snippets are not changed for readability and understandability
```
/home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/syncer/dml.go:359:33: unnecessary conversion
                data = strconv.FormatInt(int64(v), 10)
                                              ^
/home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/syncer/dml.go:367:35: unnecessary conversion
                data = strconv.FormatUint(uint64(v), 10)
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
