### PR TITLE
syncer/dml.go: Refine error msg

### DIFF
--- a/syncer/dml.go
+++ b/syncer/dml.go
@@ -117,7 +117,7 @@ func genInsertSQLs(param *genDMLParam) ([]string, [][]string, [][]interface{}, e
 	columnPlaceholders := genColumnPlaceholders(len(columns))
 	for dataIdx, data := range dataSeq {
 		if len(data) != len(columns) {
-			return nil, nil, nil, errors.Errorf("insert columns and data mismatch in length: %d (columns) vs %d (data)", len(columns), len(data))
+			return nil, nil, nil, errors.Errorf("Column count doesn't match value count: %d (columns) vs %d (values)", len(columns), len(data))
 		}
 
 		value := extractValueFromData(data, columns)
@@ -164,11 +164,11 @@ func genUpdateSQLs(param *genDMLParam) ([]string, [][]string, [][]interface{}, e
 		oriChangedData := originalData[i+1]
 
 		if len(oldData) != len(changedData) {
-			return nil, nil, nil, errors.Errorf("update data mismatch in length: %d (columns) vs %d (data)", len(oldData), len(changedData))
+			return nil, nil, nil, errors.Errorf("Old value count doesn't match new value count: %d (columns) vs %d (values)", len(oldData), len(changedData))
 		}
 
 		if len(oldData) != len(columns) {
-			return nil, nil, nil, errors.Errorf("update columns and data mismatch in length: %d (columns) vs %d (data)", len(columns), len(oldData))
+			return nil, nil, nil, errors.Errorf("Column count doesn't match value count: %d (columns) vs %d (values)", len(columns), len(oldData))
 		}
 
 		oldValues := extractValueFromData(oldData, columns)

--- a/syncer/dml.go
+++ b/syncer/dml.go
@@ -252,7 +252,7 @@ func genDeleteSQLs(param *genDMLParam) ([]string, [][]string, [][]interface{}, e
 
 	for _, data := range dataSeq {
 		if len(data) != len(columns) {
-			return nil, nil, nil, errors.Errorf("delete columns and data mismatch in length: %d (columns) vs %d (data)", len(columns), len(data))
+			return nil, nil, nil, errors.Errorf("Column count doesn't match value count: %d (columns) vs %d (values)", len(columns), len(data))
 		}
 
 		value := extractValueFromData(data, columns)

--- a/syncer/dml.go
+++ b/syncer/dml.go
@@ -164,7 +164,7 @@ func genUpdateSQLs(param *genDMLParam) ([]string, [][]string, [][]interface{}, e
 		oriChangedData := originalData[i+1]
 
 		if len(oldData) != len(changedData) {
-			return nil, nil, nil, errors.Errorf("Old value count doesn't match new value count: %d (columns) vs %d (values)", len(oldData), len(changedData))
+			return nil, nil, nil, errors.Errorf("Old value count doesn't match new value count: %d (old) vs %d (new)", len(oldData), len(changedData))
 		}
 
 		if len(oldData) != len(columns) {


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://internal.pingcap.net/jira/browse/TOOL-1078
```
"msg": "gen insert sqls failed: insert columns and data mismatch in length: 32 (columns) vs 33 (data), schema: ctmg, table: np_bas_person\ngithub.com/pingcap/dm/syncer.(*Syncer).Run\n\t/home/jenkins/workspace/build_dm_master/go/src/github.com/pingcap/dm/syncer/syncer.go:1185\ngithub.com/pingcap/dm/syncer.(*Syncer).Process\n\t/home/jenkins/workspace/build_dm_master/go/src/github.com/pingcap/dm/syncer/syncer.go:451\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1333"}
```
mysql
```
ERROR 1136 (21S01): Column count doesn't match value count at row 1
```

### What is changed and how it works?
change to more clear msg like mysql

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 

Code changes


Side effects

 Related changes

