### PR TITLE
tests: fix random fail in decrypt unit test

### DIFF
--- a/pkg/encrypt/encrypt_test.go
+++ b/pkg/encrypt/encrypt_test.go
@@ -85,7 +85,8 @@ func (t *testEncryptSuite) TestEncrypt(c *C) {
 	block, err := aes.NewCipher(secretKey)
 	c.Assert(err, IsNil)
 	blockSize := block.BlockSize()
-	plaintext3, err := Decrypt(append(ciphertext[1:blockSize+1], append([]byte{ivSep[0]}, ciphertext[blockSize+1:]...)...))
+	c.Assert(len(ciphertext), Greater, blockSize+2)
+	plaintext3, err := Decrypt(append(ciphertext[1:blockSize+1], append([]byte{ivSep[0]}, ciphertext[blockSize+2:]...)...))
 	c.Assert(err, IsNil)
 	c.Assert(plaintext3, Not(DeepEquals), plaintext)
 }

--- a/pkg/encrypt/encrypt_test.go
+++ b/pkg/encrypt/encrypt_test.go
@@ -14,6 +14,7 @@
 package encrypt
 
 import (
+	"crypto/aes"
 	"crypto/rand"
 	"testing"
 
@@ -77,4 +78,14 @@ func (t *testEncryptSuite) TestEncrypt(c *C) {
 	// invalid content
 	_, err = Decrypt(removeChar(ciphertext, ivSep[0]))
 	c.Assert(err, NotNil)
+
+	// a special case, we construct a ciphertext that can be decrypted but the
+	// plaintext is not what we want. This is because currently encrypt mechanism
+	// doesn't keep enough information to decide whether the new ciphertext is valid
+	block, err := aes.NewCipher(secretKey)
+	c.Assert(err, IsNil)
+	blockSize := block.BlockSize()
+	plaintext3, err := Decrypt(append(ciphertext[1:blockSize+1], append([]byte{ivSep[0]}, ciphertext[blockSize+1:]...)...))
+	c.Assert(err, IsNil)
+	c.Assert(plaintext3, Not(DeepEquals), plaintext)
 }

--- a/pkg/encrypt/encrypt_test.go
+++ b/pkg/encrypt/encrypt_test.go
@@ -47,6 +47,17 @@ func (t *testEncryptSuite) TestSetSecretKey(c *C) {
 	c.Assert(err, NotNil)
 }
 
+func removeChar(input []byte, c byte) []byte {
+	i := 0
+	for _, x := range input {
+		if x != c {
+			input[i] = x
+			i++
+		}
+	}
+	return input[:i]
+}
+
 func (t *testEncryptSuite) TestEncrypt(c *C) {
 	plaintext := []byte("a plain text")
 
@@ -64,6 +75,6 @@ func (t *testEncryptSuite) TestEncrypt(c *C) {
 	c.Assert(err, NotNil)
 
 	// invalid content
-	_, err = Decrypt(ciphertext[1:])
+	_, err = Decrypt(removeChar(ciphertext, ivSep[0]))
 	c.Assert(err, NotNil)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
sometimes unit test in decrypt_test.go failed as following:
https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/test_dm_master/detail/test_dm_master/75/pipeline/44

This is because we check whether the 16th char in decrypt text is '@'
https://github.com/pingcap/dm/blob/a5578266da5a08706b82ff8d65fb166b1a9a7975/pkg/encrypt/encrypt.go#L77
but in our test decrypt text, the 17th char could also be '@'


### What is changed and how it works?

This commit only removes all '@' char from test decrypt text, which ensures the unit test case will always run successfully.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test