### PR TITLE
*: fix adjusting sub task config when starting task from the meta

### DIFF
--- a/dm/config/subtask.go
+++ b/dm/config/subtask.go
@@ -219,7 +219,7 @@ func (c *SubTaskConfig) DecodeFile(fpath string) error {
 		return errors.Trace(err)
 	}
 
-	return errors.Trace(c.adjust())
+	return errors.Trace(c.Adjust())
 }
 
 // Decode loads config from file data
@@ -229,11 +229,11 @@ func (c *SubTaskConfig) Decode(data string) error {
 		return errors.Trace(err)
 	}
 
-	return errors.Trace(c.adjust())
+	return errors.Trace(c.Adjust())
 }
 
-// adjust adjusts configs
-func (c *SubTaskConfig) adjust() error {
+// Adjust adjusts configs
+func (c *SubTaskConfig) Adjust() error {
 	if c.Name == "" {
 		return errors.New("task name should not be empty")
 	}
@@ -313,7 +313,7 @@ func (c *SubTaskConfig) Parse(arguments []string) error {
 		return errors.Errorf("'%s' is an invalid flag", c.flagSet.Arg(0))
 	}
 
-	return errors.Trace(c.adjust())
+	return errors.Trace(c.Adjust())
 }
 
 // DecryptPassword tries to decrypt db password in config

--- a/dm/config/task.go
+++ b/dm/config/task.go
@@ -485,7 +485,7 @@ func (c *TaskConfig) SubTaskConfigs(sources map[string]DBConfig) ([]*SubTaskConf
 		cfg.LoaderConfig = *inst.Loader
 		cfg.SyncerConfig = *inst.Syncer
 
-		err := cfg.adjust()
+		err := cfg.Adjust()
 		if err != nil {
 			return nil, errors.Annotatef(err, "source %s", inst.SourceID)
 		}

--- a/dm/worker/meta.go
+++ b/dm/worker/meta.go
@@ -50,7 +50,7 @@ func (m *Meta) DecodeFile(fpath string) error {
 		return errors.Trace(err)
 	}
 
-	return nil
+	return m.adjust()
 }
 
 // Decode loads config from file data
@@ -60,6 +60,17 @@ func (m *Meta) Decode(data string) error {
 		return errors.Trace(err)
 	}
 
+	return m.adjust()
+}
+
+func (m *Meta) adjust() error {
+	// adjust the config
+	for name, subTask := range m.SubTasks {
+		err := subTask.Adjust()
+		if err != nil {
+			return errors.Annotatef(err, "task %s", name)
+		}
+	}
 	return nil
 }
 

--- a/dm/worker/meta_test.go
+++ b/dm/worker/meta_test.go
@@ -39,7 +39,8 @@ func (t *testWorker) TestFileMetaDB(c *C) {
 	c.Assert(meta.SubTasks, HasLen, 0)
 
 	err = metaDB.Set(&config.SubTaskConfig{
-		Name: "task1",
+		Name:     "task1",
+		SourceID: "source-1",
 	})
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

when auto stating task from the meta, the DM-worker may panic because no `max-allowed-packet` is set.

```
github.com/pingcap/dm/loader.createConn(0xc00054a000, 0x0, 0xc0004ac000, 0x3400008)
	/Users/zhangxc/gopath/src/github.com/csuzhangxc/dm/loader/db.go:199 +0xea
github.com/pingcap/dm/loader.newRemoteCheckPoint(0xc00054a000, 0xc00053e0a0, 0xe, 0xc0005427e0, 0x1eb1a20, 0x2162ac0, 0xc00027b380)
	/Users/zhangxc/gopath/src/github.com/csuzhangxc/dm/loader/checkpoint.go:73 +0x35
github.com/pingcap/dm/loader.(*Loader).Init(0xc00009c270, 0x0, 0x0)
	/Users/zhangxc/gopath/src/github.com/csuzhangxc/dm/loader/loader.go:363 +0xf5
github.com/pingcap/dm/dm/worker.(*SubTask).Init(0xc0000e8c60, 0x0, 0x0)
	/Users/zhangxc/gopath/src/github.com/csuzhangxc/dm/dm/worker/subtask.go:111 +0xdf
github.com/pingcap/dm/dm/worker.(*Worker).StartSubTask(0xc0003409a0, 0xc0003f0000, 0x0, 0x0)
	/Users/zhangxc/gopath/src/github.com/csuzhangxc/dm/dm/worker/worker.go:195 +0x298
github.com/pingcap/dm/dm/worker.(*Worker).Start(0xc0003409a0)
	/Users/zhangxc/gopath/src/github.com/csuzhangxc/dm/dm/worker/worker.go:118 +0x1d2
github.com/pingcap/dm/dm/worker.(*Server).Start.func1(0xc00033e280)
	/Users/zhangxc/gopath/src/github.com/csuzhangxc/dm/dm/worker/server.go:83 +0x5b
created by github.com/pingcap/dm/dm/worker.(*Server).Start
	/Users/zhangxc/gopath/src/github.com/csuzhangxc/dm/dm/worker/server.go:80 +0x13c
```

### What is changed and how it works?

- adjust subtask config when loading from the meta.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 	- auto starting task without `max-allowed-packet` set in the meta
