### PR TITLE
tracer: fix data race, start tracer before task restore

### DIFF
--- a/dm/worker/worker.go
+++ b/dm/worker/worker.go
@@ -112,17 +112,17 @@ func (w *Worker) Start() {
 	// start purger
 	w.relayPurger.Start()
 
+	// start tracer
+	if w.tracer.Enable() {
+		w.tracer.Start()
+	}
+
 	// restore tasks
 	meta := w.meta.Get()
 	for taskName, subtask := range meta.SubTasks {
 		if err := w.StartSubTask(subtask); err != nil {
 			panic(fmt.Sprintf("restore task %s (%s) in worker starting: %v", taskName, subtask, err))
 		}
-	}
-
-	// start tracer
-	if w.tracer.Enable() {
-		w.tracer.Start()
 	}
 
 	ticker := time.NewTicker(5 * time.Second)

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -224,6 +224,10 @@ func (t *Tracer) jobProcessor(ctx context.Context, jobChan <-chan *Job) {
 
 // AddJob add a job to tracer
 func (t *Tracer) AddJob(job *Job) {
+	if t.jobsClosed.Get() {
+		log.Warnf("[tracer] jobs channel already closed, add job %v failed", job)
+		return
+	}
 	if job.Tp == EventFlush {
 		for _, tp := range dispatchEventType {
 			t.jobs[tp] <- job

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,7 +37,7 @@
 
     > If want to run one integration test case only, just pass the CASE parameter, such as `make integration_test CASE=sharding`.
 
-    > There exists some environment variables that you can configuratio by yourself, including `MYSQL_HOST1`, `MYSQL_PORT1`, `MYSQL_HOST2`, `MYSQL_PORT2`, `RESET_MASTER`. If `RESET_MASTER` is not set or set to true, `RESET MASTER` will be executed at upstream MySQL before each case.
+    > There exists some environment variables that you can set by yourself, including `MYSQL_HOST1`, `MYSQL_PORT1`, `MYSQL_HOST2`, `MYSQL_PORT2`, `RESET_MASTER`. If `RESET_MASTER` is not set or set to true, `RESET MASTER` will be executed at upstream MySQL before each case.
 
     > The online DDL test using pt-osc doesn't work if the upstream MySQL has different connect port and bind port (often caused by port forwarding via NAT). In this case, you must specify the real IP and port of MySQL. Otherwise you can skip online DDL test by `export ONLINE_DDL_ENABLE=false`.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,6 +37,8 @@
 
     > If want to run one integration test case only, just pass the CASE parameter, such as `make integration_test CASE=sharding`.
 
+    > There exists some environment variables that you can configuratio by yourself, including `MYSQL_HOST1`, `MYSQL_PORT1`, `MYSQL_HOST2`, `MYSQL_PORT2`, `RESET_MASTER`. If `RESET_MASTER` is not set or set to true, `RESET MASTER` will be executed at upstream MySQL before each case.
+
     > The online DDL test using pt-osc doesn't work if the upstream MySQL has different connect port and bind port (often caused by port forwarding via NAT). In this case, you must specify the real IP and port of MySQL. Otherwise you can skip online DDL test by `export ONLINE_DDL_ENABLE=false`.
 
 4. After executing the tests, run `make coverage` to get a coverage report at `/tmp/dm_test/all_cov.html`.

--- a/tests/_utils/test_prepare
+++ b/tests/_utils/test_prepare
@@ -7,6 +7,7 @@ MASTER_PORT=8261
 WORKER1_PORT=8262
 WORKER2_PORT=8263
 TRACER_PORT=8264
+RESET_MASTER=${RESET_MASTER:-true}
 
 # we do clean staff at beginning of each run, so we can keep logs of the latset run
 function cleanup1() {
@@ -23,3 +24,8 @@ function cleanup2() {
     pkill -hup dm-master.test 2>/dev/null || true
     pkill -hup dm-tracer.test 2>/dev/null || true
 }
+
+if [ "$RESET_MASTER" = true ]; then
+    run_sql "RESET MASTER" $MYSQL_PORT1
+    run_sql "RESET MASTER" $MYSQL_PORT2
+fi

--- a/tests/all_mode/conf/dm-task.yaml
+++ b/tests/all_mode/conf/dm-task.yaml
@@ -40,12 +40,12 @@ mydumpers:
     threads: 4
     chunk-filesize: 64
     skip-tz-utc: true
+    extra-args: "-B all_mode"
 
 loaders:
   global:
     pool-size: 16
     dir: "./dumped_data"
-    extra-args: "-B all_mode"
 
 syncers:
   global:

--- a/tests/online_ddl/conf/dm-task.yaml
+++ b/tests/online_ddl/conf/dm-task.yaml
@@ -77,12 +77,12 @@ mydumpers:
     threads: 4
     chunk-filesize: 64
     skip-tz-utc: true
+    extra-args: "-B online_ddl"
 
 loaders:
   global:
     pool-size: 16
     dir: "./dumped_data"
-    extra-args: "-B online_ddl"
 
 syncers:
   global:

--- a/tests/safe_mode/run.sh
+++ b/tests/safe_mode/run.sh
@@ -86,4 +86,8 @@ cleanup2 $*
 run $*
 cleanup2 $*
 
+wait_process_exit dm-master.test
+wait_process_exit dm-worker.test
+wait_process_exit dm-tracer.test
+
 echo "[$(date)] <<<<<< test case $TEST_NAME success! >>>>>>"

--- a/tests/sharding/conf/dm-task.yaml
+++ b/tests/sharding/conf/dm-task.yaml
@@ -73,12 +73,12 @@ mydumpers:
     threads: 4
     chunk-filesize: 64
     skip-tz-utc: true
+    extra-args: "-B sharding"
 
 loaders:
   global:
     pool-size: 16
     dir: "./dumped_data"
-    extra-args: "-B sharding"
 
 syncers:
   global:


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix data race
```
WARNING: DATA RACE
Read at 0x00c0000e30c8 by goroutine 130:
  github.com/pingcap/dm/pkg/tracing.(*Tracer).AddJob()
      /home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/pkg/tracing/tracer.go:232 +0x1c4
  github.com/pingcap/dm/pkg/tracing.(*Tracer).CollectSyncerBinlogEvent()
      /home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/pkg/tracing/tracer_syncer.go:54 +0x3c5
  github.com/pingcap/dm/syncer.(*Syncer).Run()
      /home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/syncer/syncer.go:1156 +0x20d3
  github.com/pingcap/dm/syncer.(*Syncer).Process()
      /home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/syncer/syncer.go:473 +0x7b1

Previous write at 0x00c0000e30c8 by goroutine 29:
  github.com/pingcap/dm/pkg/tracing.(*Tracer).newJobChans()
      /home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/pkg/tracing/tracer.go:158 +0x7e
  github.com/pingcap/dm/pkg/tracing.(*Tracer).Start()
      /home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/pkg/tracing/tracer.go:81 +0x280
  github.com/pingcap/dm/dm/worker.(*Worker).Start()
      /home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/dm/worker/worker.go:125 +0x694
  github.com/pingcap/dm/dm/worker.(*Server).Start.func1()
      /home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/dm/worker/server.go:83 +0x96

Goroutine 130 (running) created at:
  github.com/pingcap/dm/dm/worker.(*SubTask).Run()
      /home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/dm/worker/subtask.go:159 +0x44f
  github.com/pingcap/dm/dm/worker.(*Worker).StartSubTask()
      /home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/dm/worker/worker.go:202 +0x36d
  github.com/pingcap/dm/dm/worker.(*Worker).Start()
      /home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/dm/worker/worker.go:118 +0x2c6
  github.com/pingcap/dm/dm/worker.(*Server).Start.func1()
      /home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/dm/worker/server.go:83 +0x96

Goroutine 29 (running) created at:
  github.com/pingcap/dm/dm/worker.(*Server).Start()
      /home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/dm/worker/server.go:80 +0x285
  github.com/pingcap/dm/cmd/dm-worker.main()
      /home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/cmd/dm-worker/main.go:66 +0x3e1
  github.com/pingcap/dm/cmd/dm-worker.TestRunMain()
      /home/apple/work/code/pingcap/gopath/src/github.com/pingcap/dm/cmd/dm-worker/main_test.go:36 +0x160
  testing.tRunner()
      /home/apple/.gvm/gos/go1.12/src/testing/testing.go:865 +0x163
```
tracer initialization is in DM-worker `Start` procedure, if task started before tracer job channels' initialization, data race happens

### What is changed and how it works?

* start tracer first, then restore task.
* refused to add tracing job if job channels are not ready
* some test code refine

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test