### PR TITLE
syncer: fix checkpoint update when multi sharding group exists

### DIFF
--- a/syncer/sharding_group.go
+++ b/syncer/sharding_group.go
@@ -506,7 +506,7 @@ func (k *ShardingGroupKeeper) lowestFirstPosInGroups() *mysql.Position {
 		}
 		if lowest == nil {
 			lowest = pos
-		} else if lowest.Compare(*pos) < 0 {
+		} else if lowest.Compare(*pos) > 0 {
 			lowest = pos
 		}
 	}

--- a/syncer/sharding_group_test.go
+++ b/syncer/sharding_group_test.go
@@ -1,0 +1,54 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncer
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/siddontang/go-mysql/mysql"
+)
+
+var _ = Suite(&testShardingGroupSuite{})
+
+type testShardingGroupSuite struct {
+}
+
+func (t *testShardingGroupSuite) TestLowestFirstPosInGroups(c *C) {
+	ddls := []string{"DUMMY DDL"}
+
+	g1 := NewShardingGroup([]string{"db1.tbl1", "db1.tbl2"}, false)
+	pos1 := mysql.Position{Name: "mysql-bin.000002", Pos: 123}
+	endPos1 := mysql.Position{Name: "mysql-bin.000002", Pos: 456}
+	_, _, err := g1.TrySync("db1.tbl1", pos1, endPos1, ddls)
+	c.Assert(err, IsNil)
+
+	// lowest
+	g2 := NewShardingGroup([]string{"db2.tbl1", "db2.tbl2"}, false)
+	pos2 := mysql.Position{Name: "mysql-bin.000001", Pos: 123}
+	endPos2 := mysql.Position{Name: "mysql-bin.000001", Pos: 456}
+	_, _, err = g2.TrySync("db2.tbl1", pos2, endPos2, ddls)
+	c.Assert(err, IsNil)
+
+	g3 := NewShardingGroup([]string{"db3.tbl1", "db3.tbl2"}, false)
+	pos3 := mysql.Position{Name: "mysql-bin.000003", Pos: 123}
+	endPos3 := mysql.Position{Name: "mysql-bin.000003", Pos: 456}
+	_, _, err = g3.TrySync("db3.tbl1", pos3, endPos3, ddls)
+	c.Assert(err, IsNil)
+
+	k := NewShardingGroupKeeper()
+	k.groups["db1.tbl"] = g1
+	k.groups["db2.tbl"] = g2
+	k.groups["db3.tbl"] = g3
+
+	c.Assert(*k.lowestFirstPosInGroups(), DeepEquals, pos2)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

when multiple sharding group exists, the global may be updated incorrectly.

### What is changed and how it works?

fix global checkpoint adjusts in `lowestFirstPosInGroups`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to be included in the release note
