### PR TITLE
tests: re-enable checkpoint unit test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/pingcap/dm
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/DATA-DOG/go-sqlmock v1.3.3
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
+github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f h1:5ZfJxyXo8KyX8DgGXC5B7ILL8y51fci/qYz2B4j8iLY=
 github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -16,6 +16,7 @@ package log
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"path"
 	"runtime"
 	"sort"
@@ -44,6 +45,11 @@ func SetLevelByString(level string) {
 // GetLogLevelAsString gets current log's level as a level string.
 func GetLogLevelAsString() string {
 	return log.GetLevel().String()
+}
+
+// SetOutput sets the standard logger output.
+func SetOutput(out io.Writer) {
+	log.SetOutput(out)
 }
 
 // SetOutputByName sets the filename for the log.

--- a/syncer/checkpoint_test.go
+++ b/syncer/checkpoint_test.go
@@ -49,7 +49,7 @@ func (s *testCheckpointSuite) SetUpSuite(c *C) {
 	s.cfg = &config.SubTaskConfig{
 		ServerID:   101,
 		MetaSchema: "test",
-		Name:       "syncer_ut",
+		Name:       "syncer_checkpoint_ut",
 	}
 }
 

--- a/syncer/checkpoint_test.go
+++ b/syncer/checkpoint_test.go
@@ -33,7 +33,7 @@ import (
 // because go-sql-driver/mysql using connection pool for *sql.DB
 // and different SQLs in different txn may in different sessions
 // ref: https://github.com/go-sql-driver/mysql/issues/208
-// so disable checkpoint test now, TestCheckPoint => testCheckPoint
+// so we use different DB from other tests.
 func (s *testSyncerSuite) TestCheckPoint(c *C) {
 	id := "test_for_db"
 	cp := NewRemoteCheckPoint(s.cfg, id)

--- a/syncer/checkpoint_test.go
+++ b/syncer/checkpoint_test.go
@@ -46,12 +46,7 @@ func (s *testSyncerSuite) prepareCheckPointSQL() {
 	loadCheckPointSQL = fmt.Sprintf("SELECT .* FROM `%s`.`%s_syncer_checkpoint` WHERE `id`='%s'", s.cfg.MetaSchema, s.cfg.Name, cpid)
 }
 
-// NOTE: there are binlog events conflict with other test cases
-// and we can not simply disable `sql_log_bin` for this test case
-// because go-sql-driver/mysql using connection pool for *sql.DB
-// and different SQLs in different txn may in different sessions
-// ref: https://github.com/go-sql-driver/mysql/issues/208
-// so we use different DB from other tests.
+// this test case uses sqlmock to simulate all SQL operations in tests
 func (s *testSyncerSuite) TestCheckPoint(c *C) {
 	cp := NewRemoteCheckPoint(s.cfg, cpid)
 	defer func() {
@@ -76,6 +71,7 @@ func (s *testSyncerSuite) TestCheckPoint(c *C) {
 	mock.ExpectExec(clearCheckPointSQL).WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
+	// pass sqlmock db directly
 	err = cp.Init(&Conn{cfg: s.cfg, db: db})
 	c.Assert(err, IsNil)
 	cp.Clear()

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -293,7 +293,7 @@ func (s *Syncer) Init() (err error) {
 		}
 	}
 
-	err = s.checkpoint.Init()
+	err = s.checkpoint.Init(nil)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -49,7 +49,6 @@ type testSyncerSuite struct {
 	syncer   *replication.BinlogSyncer
 	streamer *replication.BinlogStreamer
 	cfg      *config.SubTaskConfig
-	cpCfg    *config.SubTaskConfig
 }
 
 func (s *testSyncerSuite) SetUpSuite(c *C) {

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	_ "github.com/go-sql-driver/mysql"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/dm/pkg/log"
@@ -50,7 +49,6 @@ type testSyncerSuite struct {
 	syncer   *replication.BinlogSyncer
 	streamer *replication.BinlogStreamer
 	cfg      *config.SubTaskConfig
-	cpMock   sqlmock.Sqlmock
 }
 
 func (s *testSyncerSuite) SetUpSuite(c *C) {

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -49,6 +49,7 @@ type testSyncerSuite struct {
 	syncer   *replication.BinlogSyncer
 	streamer *replication.BinlogStreamer
 	cfg      *config.SubTaskConfig
+	cpCfg    *config.SubTaskConfig
 }
 
 func (s *testSyncerSuite) SetUpSuite(c *C) {
@@ -66,6 +67,20 @@ func (s *testSyncerSuite) SetUpSuite(c *C) {
 	}
 	pswd := os.Getenv("MYSQL_PSWD")
 
+	tidbHost := os.Getenv("TIDB_HOST")
+	if tidbHost == "" {
+		tidbHost = "127.0.0.1"
+	}
+	tidbPort, _ := strconv.Atoi(os.Getenv("TIDB_PORT"))
+	if tidbPort == 0 {
+		tidbPort = 4000
+	}
+	tidbUser := os.Getenv("TIDB_USER")
+	if tidbUser == "" {
+		tidbUser = "root"
+	}
+	tidbPswd := os.Getenv("TIDB_PSWD")
+
 	s.cfg = &config.SubTaskConfig{
 		From: config.DBConfig{
 			Host:     host,
@@ -74,13 +89,14 @@ func (s *testSyncerSuite) SetUpSuite(c *C) {
 			Port:     port,
 		},
 		To: config.DBConfig{
-			Host:     host,
-			User:     user,
-			Password: pswd,
-			Port:     port,
+			Host:     tidbHost,
+			User:     tidbUser,
+			Password: tidbPswd,
+			Port:     tidbPort,
 		},
 		ServerID:   101,
 		MetaSchema: "test",
+		Name:       "syncer_ut",
 	}
 	s.cfg.From.Adjust()
 	s.cfg.To.Adjust()

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	_ "github.com/go-sql-driver/mysql"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/dm/pkg/log"
@@ -49,6 +50,7 @@ type testSyncerSuite struct {
 	syncer   *replication.BinlogSyncer
 	streamer *replication.BinlogStreamer
 	cfg      *config.SubTaskConfig
+	cpMock   sqlmock.Sqlmock
 }
 
 func (s *testSyncerSuite) SetUpSuite(c *C) {
@@ -66,20 +68,6 @@ func (s *testSyncerSuite) SetUpSuite(c *C) {
 	}
 	pswd := os.Getenv("MYSQL_PSWD")
 
-	host2 := os.Getenv("MYSQL_HOST2")
-	if host2 == "" {
-		host2 = "127.0.0.1"
-	}
-	port2, _ := strconv.Atoi(os.Getenv("MYSQL_PORT2"))
-	if port2 == 0 {
-		port2 = 3307
-	}
-	user2 := os.Getenv("MYSQL_USER2")
-	if user2 == "" {
-		user2 = "root"
-	}
-	pswd2 := os.Getenv("MYSQL_PSWD2")
-
 	s.cfg = &config.SubTaskConfig{
 		From: config.DBConfig{
 			Host:     host,
@@ -88,10 +76,10 @@ func (s *testSyncerSuite) SetUpSuite(c *C) {
 			Port:     port,
 		},
 		To: config.DBConfig{
-			Host:     host2,
-			User:     user2,
-			Password: pswd2,
-			Port:     port2,
+			Host:     host,
+			User:     user,
+			Password: pswd,
+			Port:     port,
 		},
 		ServerID:   101,
 		MetaSchema: "test",

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -66,19 +66,19 @@ func (s *testSyncerSuite) SetUpSuite(c *C) {
 	}
 	pswd := os.Getenv("MYSQL_PSWD")
 
-	tidbHost := os.Getenv("TIDB_HOST")
-	if tidbHost == "" {
-		tidbHost = "127.0.0.1"
+	host2 := os.Getenv("MYSQL_HOST2")
+	if host2 == "" {
+		host2 = "127.0.0.1"
 	}
-	tidbPort, _ := strconv.Atoi(os.Getenv("TIDB_PORT"))
-	if tidbPort == 0 {
-		tidbPort = 4000
+	port2, _ := strconv.Atoi(os.Getenv("MYSQL_PORT2"))
+	if port2 == 0 {
+		port2 = 3307
 	}
-	tidbUser := os.Getenv("TIDB_USER")
-	if tidbUser == "" {
-		tidbUser = "root"
+	user2 := os.Getenv("MYSQL_USER2")
+	if user2 == "" {
+		user2 = "root"
 	}
-	tidbPswd := os.Getenv("TIDB_PSWD")
+	pswd2 := os.Getenv("MYSQL_PSWD2")
 
 	s.cfg = &config.SubTaskConfig{
 		From: config.DBConfig{
@@ -88,10 +88,10 @@ func (s *testSyncerSuite) SetUpSuite(c *C) {
 			Port:     port,
 		},
 		To: config.DBConfig{
-			Host:     tidbHost,
-			User:     tidbUser,
-			Password: tidbPswd,
-			Port:     tidbPort,
+			Host:     host2,
+			User:     user2,
+			Password: pswd2,
+			Port:     port2,
 		},
 		ServerID:   101,
 		MetaSchema: "test",

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,9 +24,7 @@
 
 1. Setup a MySQL server with binlog enabled first, export proper environment variable `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_USER`, `MYSQL_PSWD`, default is `127.0.0.1`, `3306`, `root` and empty password.
 
-2. Setup anohter MySQL server used for checkpoint test, export proper environment variable `MYSQL_HOST2`, `MYSQL_PORT2`, `MYSQL_USER2`, `MYSQL_PSWD2`, default is `127.0.0.1`, `3307`, `root` and empty password.
-
-3. Run `make test` to run unit test
+2. Run `make test` to run unit test
 
 ### Integration Test
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,9 +22,11 @@
 
 ### Unit Test
 
-1. Setup a MySQL server with binlog enabled first, export proper environment variable `MYSQL_HOST` and `MYSQL_PORT`, default is `127.0.0.1` and `3306`
+1. Setup a MySQL server with binlog enabled first, export proper environment variable `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_USER`, `MYSQL_PSWD`, default is `127.0.0.1`, `3306`, `root` and empty password.
 
-2. Run `make test` to run unit test
+2. Setup a TiDB server, export proper environment variable `TIDB_HOST`, `TIDB_PORT`, `TIDB_USER`, `TIDB_PSWD`, default is `127.0.0.1`, `4000`, `root` and empty password.
+
+3. Run `make test` to run unit test
 
 ### Integration Test
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,7 +24,7 @@
 
 1. Setup a MySQL server with binlog enabled first, export proper environment variable `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_USER`, `MYSQL_PSWD`, default is `127.0.0.1`, `3306`, `root` and empty password.
 
-2. Setup a TiDB server, export proper environment variable `TIDB_HOST`, `TIDB_PORT`, `TIDB_USER`, `TIDB_PSWD`, default is `127.0.0.1`, `4000`, `root` and empty password.
+2. Setup anohter MySQL server used for checkpoint test, export proper environment variable `MYSQL_HOST2`, `MYSQL_PORT2`, `MYSQL_USER2`, `MYSQL_PSWD2`, default is `127.0.0.1`, `3307`, `root` and empty password.
 
 3. Run `make test` to run unit test
 

--- a/tests/wait_for_mysql.sh
+++ b/tests/wait_for_mysql.sh
@@ -3,3 +3,4 @@
 source ./tests/util.sh
 
 check_db_status "${MYSQL_HOST:-127.0.0.1}" "${MYSQL_PORT:-3306}" mysql
+check_db_status "${MYSQL_HOST:-127.0.0.1}" "${MYSQL_PORT:-3307}" mysql

--- a/tests/wait_for_mysql.sh
+++ b/tests/wait_for_mysql.sh
@@ -3,4 +3,3 @@
 source ./tests/util.sh
 
 check_db_status "${MYSQL_HOST:-127.0.0.1}" "${MYSQL_PORT:-3306}" mysql
-check_db_status "${MYSQL_HOST:-127.0.0.1}" "${MYSQL_PORT:-3307}" mysql


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
re-enable checkpoint unit test. ~But after this change, we must setup two MySQLs for unit test~


### What is changed and how it works?
~1. change `To DB` config in unit test, use TiDB as default~
1. use sqlmock in checkpoint test
2. LoadMeta test fix.
3. test save older point


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - should update jenkins CI config, add another MySQL server in Unit test