### PR TITLE
Add unsafe_cleanup.yml for dm ansible

### DIFF
--- a/dm/dm-ansible/unsafe_cleanup.yml
+++ b/dm/dm-ansible/unsafe_cleanup.yml
@@ -1,0 +1,58 @@
+---
+
+# The Playbook of DM
+
+- import_playbook: stop.yml
+
+
+- hosts: alertmanager_servers
+  tasks:
+    - name: clean systemd config
+      file: path="/etc/systemd/system/{{ item }}" state=absent
+      become: true
+      with_items:
+        - alertmanager-{{ alertmanager_port }}.service
+
+
+- hosts: prometheus_servers
+  tasks:
+    - name: clean systemd config
+      file: path="/etc/systemd/system/{{ item }}" state=absent
+      become: true
+      with_items:
+        - prometheus-{{ prometheus_port }}.service
+
+
+- hosts: grafana_servers
+  tasks:
+    - name: clean systemd config
+      file: path="/etc/systemd/system/{{ item }}" state=absent
+      become: true
+      with_items:
+        - grafana-{{ grafana_port }}.service
+
+- hosts: dm_worker_servers 
+  tasks:
+    - name: clean systemd config
+      file: path="/etc/systemd/system/{{ item }}" state=absent
+      become: true
+      with_items:
+        - dm-worker-{{ dm_worker_port }}.service
+
+
+- hosts: dm_master_servers
+  tasks:
+    - name: clean systemd config
+      file: path="/etc/systemd/system/{{ item }}" state=absent
+      become: true
+      with_items:
+        - dm-master-{{ dm_master_port }}.service 
+
+
+- hosts: all
+  tasks:
+    - name: using rm command to clean up deploy_dir
+      shell: "rm -rf {{ deploy_dir }}/*"
+
+    - name: cleaning up deploy dir
+      file: path={{ deploy_dir }} state=absent


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

    Users can unsafe_cleanup the dm module using the new adding yml file in ansible

### What is changed and how it works?

     Add a file named unsafe_cleanup.yml in ansible

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
       ansible-playbook unsafe_cleanup.yml

