### PR TITLE
*: fix update relay processing order

### DIFF
--- a/dm/worker/worker.go
+++ b/dm/worker/worker.go
@@ -565,7 +565,7 @@ func (w *Worker) UpdateRelayConfig(ctx context.Context, content string) error {
 	for _, st := range w.subTasks {
 		isRunning := st.CheckUnit()
 		if !isRunning {
-			return errors.New("There is a subtask does not run syncer.")
+			return errors.New("there is a subtask does not run syncer")
 		}
 	}
 

--- a/dm/worker/worker.go
+++ b/dm/worker/worker.go
@@ -589,10 +589,12 @@ func (w *Worker) UpdateRelayConfig(ctx context.Context, content string) error {
 	cloneCfg, _ := newCfg.DecryptPassword()
 
 	// Update SubTask configure
+	// NOTE: we only update `DB.Config` in SubTaskConfig now
 	for _, st := range w.subTasks {
 		cfg := config.NewSubTaskConfig()
 
 		cfg.From = cloneCfg.From
+		cfg.From.Adjust()
 
 		stage := st.Stage()
 		if stage == pb.Stage_Paused {
@@ -619,7 +621,7 @@ func (w *Worker) UpdateRelayConfig(ctx context.Context, content string) error {
 	log.Info("[worker] update relay configure in subtasks success.")
 
 	// Update relay unit configure
-	err = w.relayHolder.Update(ctx, newCfg)
+	err = w.relayHolder.Update(ctx, cloneCfg)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/dm/worker/worker.go
+++ b/dm/worker/worker.go
@@ -558,14 +558,14 @@ func (w *Worker) UpdateRelayConfig(ctx context.Context, content string) error {
 
 	stage := w.relayHolder.Stage()
 	if stage == pb.Stage_Finished || stage == pb.Stage_Stopped {
-		return errors.Errorf("Worker's relay log unit has already stoped.")
+		return errors.Errorf("Worker's relay log unit in invalid stage: %s", stage.String())
 	}
 
 	// Check whether subtask is running syncer unit
 	for _, st := range w.subTasks {
 		isRunning := st.CheckUnit()
 		if !isRunning {
-			return errors.Errorf("There is a subtask does not run syncer.")
+			return errors.New("There is a subtask does not run syncer.")
 		}
 	}
 
@@ -576,13 +576,13 @@ func (w *Worker) UpdateRelayConfig(ctx context.Context, content string) error {
 		return errors.Trace(err)
 	}
 
-	if newCfg.SourceID != w.cfg.SourceID {
-		return errors.Errorf("update source ID is not allowed")
-	}
-
 	err = newCfg.Reload()
 	if err != nil {
 		return errors.Trace(err)
+	}
+
+	if newCfg.SourceID != w.cfg.SourceID {
+		return errors.New("update source ID is not allowed")
 	}
 
 	log.Infof("[worker] update relay configure with config: %v", newCfg)

--- a/pkg/binlog/reader/tcp.go
+++ b/pkg/binlog/reader/tcp.go
@@ -114,15 +114,6 @@ func (r *TCPReader) Close() error {
 		return errors.New("already closed")
 	}
 
-	setStageClosed := func() error {
-		r.stage = stageClosed
-		return nil
-	}
-
-	if r.syncer == nil {
-		return setStageClosed()
-	}
-
 	defer r.syncer.Close()
 	connID := r.syncer.LastConnectionID()
 	if connID > 0 {
@@ -138,8 +129,8 @@ func (r *TCPReader) Close() error {
 			return errors.Annotatef(err, "kill connection %d for master %s:%d", connID, r.syncerCfg.Host, r.syncerCfg.Port)
 		}
 	}
-
-	return setStageClosed()
+	r.stage = stageClosed
+	return nil
 }
 
 // GetEvent implements Reader.GetEvent.

--- a/pkg/binlog/reader/tcp.go
+++ b/pkg/binlog/reader/tcp.go
@@ -114,6 +114,16 @@ func (r *TCPReader) Close() error {
 		return errors.New("already closed")
 	}
 
+	setStageClosed := func() error {
+		r.stage = stageClosed
+		return nil
+	}
+
+	if r.syncer == nil {
+		return setStageClosed()
+	}
+
+	defer r.syncer.Close()
 	connID := r.syncer.LastConnectionID()
 	if connID > 0 {
 		dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8mb4",
@@ -129,8 +139,7 @@ func (r *TCPReader) Close() error {
 		}
 	}
 
-	r.stage = stageClosed
-	return nil
+	return setStageClosed()
 }
 
 // GetEvent implements Reader.GetEvent.

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -915,24 +915,6 @@ func (r *Relay) Close() {
 	log.Info("[relay] relay unit closed")
 }
 
-func (r *Relay) closeBinlogSyncer(syncer *replication.BinlogSyncer) error {
-	if syncer == nil {
-		return nil
-	}
-
-	defer syncer.Close()
-	lastSlaveConnectionID := syncer.LastConnectionID()
-	if lastSlaveConnectionID > 0 {
-		err := utils.KillConn(r.db, lastSlaveConnectionID)
-		if err != nil {
-			if !utils.IsNoSuchThreadError(err) {
-				return errors.Annotatef(err, "connection ID %d", lastSlaveConnectionID)
-			}
-		}
-	}
-	return nil
-}
-
 // Status implements the dm.Unit interface.
 func (r *Relay) Status() interface{} {
 	masterPos, masterGTID, err := utils.GetMasterStatus(r.db, r.cfg.Flavor)
@@ -1014,7 +996,7 @@ func (r *Relay) Reload(newCfg *Config) error {
 	// Update Charset
 	r.cfg.Charset = newCfg.Charset
 
-	r.db.Close()
+	r.closeDB()
 	cfg := r.cfg.From
 	dbDSN := fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8mb4&interpolateParams=true&readTimeout=%s", cfg.User, cfg.Password, cfg.Host, cfg.Port, showStatusConnectionTimeout)
 	db, err := sql.Open("mysql", dbDSN)


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
in DM-worker `UpdateRelayConfig` function, the check of `update source ID is not allowed` is before new config loaded, which will always fail.
Besides I find we will get the following error after we update a relay config. This is caused by we forget to close binlog replication syncer after relay paused
```
2019/05/10 06:19:52.383 relay.go:176: [error] [relay] process exit with error ERROR 1236 (HY000): A slave with the same server_uuid/server_id as this slave has connected to the master; the first event 'bin.000007' at 27622680, the last event read from './bin.000007' at 27622993, the last byte read from './bin.000007' at 27622993.
github.com/pingcap/errors.AddStack
        /root/.gvm/pkgsets/go1.12/global/pkg/mod/github.com/pingcap/errors@v0.11.0/errors.go:174
github.com/pingcap/errors.Trace
        /root/.gvm/pkgsets/go1.12/global/pkg/mod/github.com/pingcap/errors@v0.11.0/juju_adaptor.go:12
github.com/pingcap/dm/relay.(*Relay).process
        /root/code/gopath/src/github.com/pingcap/dm/relay/relay.go:357
github.com/pingcap/dm/relay.(*Relay).Process
        /root/code/gopath/src/github.com/pingcap/dm/relay/relay.go:173
github.com/pingcap/dm/dm/worker.(*RelayHolder).run
        /root/code/gopath/src/github.com/pingcap/dm/dm/worker/relay.go:107
github.com/pingcap/dm/dm/worker.(*RelayHolder).resumeRelay.func1
        /root/code/gopath/src/github.com/pingcap/dm/dm/worker/relay.go:200
runtime.goexit
        /root/.gvm/gos/go1.12/src/runtime/asm_amd64.s:1337
2019/05/10 06:19:52.383 relay.go:113: [error] process error with type UnknownError:
```

### What is changed and how it works?

1. Load the new DM-worker config before any validation
2. close binlog syncer in `TCPReader.Close`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
   - more integration test with dmctl API will be added in pr #135 
 - Manual test (add detailed scripts or steps below)
   - deploy a DM cluster
   - run `update-relay -w worker_host:worker_port path_to_new_dm_worker_config` in dmctl
   - check `update-relay` is success
 