### PR TITLE
tests: fix print_status check, in some case log may not flushed to disk

### DIFF
--- a/tests/all_mode/run.sh
+++ b/tests/all_mode/run.sh
@@ -13,11 +13,10 @@ function run() {
     check_contains 'Query OK, 3 rows affected'
 
     run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
-    run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
-    run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
-
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
+    run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
+    run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
     check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT
 
     # start DM task only

--- a/tests/incremental_mode/run.sh
+++ b/tests/incremental_mode/run.sh
@@ -14,11 +14,10 @@ function run() {
     check_contains 'Query OK, 3 rows affected'
 
     run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
-    run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
-    run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
-
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
+    run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
+    run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
     check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT
 
     # start a task in `full` mode

--- a/tests/load_interrupt/run.sh
+++ b/tests/load_interrupt/run.sh
@@ -43,11 +43,10 @@ function run() {
     export GO_FAILPOINTS="github.com/pingcap/dm/loader/LoadExceedOffsetExit=return($THRESHOLD)"
 
     run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
-    run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
-    run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
-
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
+    run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
+    run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
     check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT
 
     $cur/../bin/dmctl_start_task "$cur/conf/dm-task.yaml"

--- a/tests/online_ddl/run.sh
+++ b/tests/online_ddl/run.sh
@@ -15,11 +15,10 @@ function real_run() {
     check_contains 'Query OK, 3 rows affected'
 
     run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
-    run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
-    run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
-
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
+    run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
+    run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
     check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT
 
     # start DM task only

--- a/tests/print_status/conf/dm-task.yaml
+++ b/tests/print_status/conf/dm-task.yaml
@@ -4,9 +4,7 @@ task-mode: all
 is-sharding: false
 meta-schema: "dm_meta"
 remove-meta: false
-enable-heartbeat: true
-heartbeat-update-interval: 1
-heartbeat-report-interval: 1
+enable-heartbeat: false
 timezone: "Asia/Shanghai"
 
 target-database:

--- a/tests/print_status/run.sh
+++ b/tests/print_status/run.sh
@@ -10,11 +10,14 @@ function run() {
     run_sql_file $cur/data/db.prepare.sql $MYSQL_HOST1 $MYSQL_PORT1
 
     # in load stage, the dumped file split into 14 insert segments, we slow down 14 * 100 ms
-    # in sync stage, there are approximately 530~550 binlog events, we slow down 530 * 3 ms
+    # in sync stage, there are 92 group of binlog events, including an XIDEvent,
+    # TableMapEvent, QueryEvent, GTIDEvent, and a specific Event in each group.
+    # so we slow down 460 * 4 ms. Besides the log may be not flushed to disk asap,
+    # we need to add some retry mechanism
     inject_points=("github.com/pingcap/dm/loader/PrintStatusCheckSeconds=return(1)"
                    "github.com/pingcap/dm/syncer/PrintStatusCheckSeconds=return(1)"
                    "github.com/pingcap/dm/loader/LoadDataSlowDown=sleep(100)"
-                   "github.com/pingcap/dm/syncer/ProcessBinlogSlowDown=sleep(3)")
+                   "github.com/pingcap/dm/syncer/ProcessBinlogSlowDown=sleep(4)")
     export GO_FAILPOINTS="$(join_string \; ${inject_points[@]})"
 
     run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
@@ -50,6 +53,23 @@ function run() {
     check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
 
     # check sync unit print status
+    i=0
+    while [ $i -lt 3 ]
+    do
+        event_count=$(grep "receive binlog event with header" $WORK_DIR/worker1/log/dm-worker.log|grep -v relay|grep "XIDEvent"|wc -l)
+        if [ "$event_count" == "92" ]; then
+            echo "all binlog events have been flushed to disk"
+            break
+        fi
+        ((i++))
+        echo "wait for syncer log flushed for the $i-th time"
+        sleep 1
+    done
+
+    if [ $i -ge 3 ]; then
+        echo "wait for syncer log flushed timeout"
+        exit 1
+    fi
     status_file2=$WORK_DIR/worker1/log/syncer_status.log
     grep -oP "syncer.*\Ktotal events = [0-9]+, total tps = [0-9]+, recent tps = [0-9]+, master-binlog = .*" $WORK_DIR/worker1/log/dm-worker.log > $status_file2
     status_count2=$(wc -l $status_file2|awk '{print $1}')

--- a/tests/print_status/run.sh
+++ b/tests/print_status/run.sh
@@ -21,9 +21,8 @@ function run() {
     export GO_FAILPOINTS="$(join_string \; ${inject_points[@]})"
 
     run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
-    run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
-
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
+    run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
     check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT
 
     # start DM task only

--- a/tests/print_status/run.sh
+++ b/tests/print_status/run.sh
@@ -61,7 +61,7 @@ function run() {
             echo "all binlog events have been flushed to disk"
             break
         fi
-        ((i++))
+        i=$((i+=1))
         echo "wait for syncer log flushed for the $i-th time"
         sleep 1
     done

--- a/tests/safe_mode/run.sh
+++ b/tests/safe_mode/run.sh
@@ -14,12 +14,12 @@ function run() {
 
     export GO_FAILPOINTS='github.com/pingcap/dm/syncer/ReSyncExit=return(true)'
     run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
-    run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
-    run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
-    run_dm_tracer $WORK_DIR/tracer $TRACER_PORT $cur/conf/dm-tracer.toml
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
+    run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
+    run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
     check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT
+    run_dm_tracer $WORK_DIR/tracer $TRACER_PORT $cur/conf/dm-tracer.toml
     check_port_alive $TRACER_PORT
 
     $cur/../bin/dmctl_start_task "$cur/conf/dm-task.yaml"

--- a/tests/sharding/run.sh
+++ b/tests/sharding/run.sh
@@ -23,11 +23,10 @@ function run() {
     check_contains 'Query OK, 3 rows affected'
 
     run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
-    run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
-    run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
-
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
+    run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
+    run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
     check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT
 
     # start DM task only


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix occasional CI failed, such as https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/dm_ghpr_test/detail/dm_ghpr_test/726/pipeline

after dig into log, I find syncer log is not flushed to disk during test running in time.

### What is changed and how it works?
1. disable heartbeat in `print_status` test, so we will have determined binlog event counts
2. add retry mechanism in syncer print status check
3. **update DM-worker, DM-master startup and check rpc available sequence** to following
```
start DM-worker1
check DM-worker1 rpc service is available
start DM-worker2
check DM-worker2 rpc service is available
start DM-server
check DM-server rpc service is available
```

btw, why there are 92 binlog events in test case but there exists 94 SQL statements, this is because the following two statements change zero rows.
```
UPDATE `t_1` SET `c12` = 'a' WHERE `id` = 50;
UPDATE `t_1` SET `c12` = 'c' WHERE `id` = 87;
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 
