### PR TITLE
loader: refine some error messages

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -686,7 +686,7 @@ func (l *Loader) prepareDbFiles(files map[string]struct{}) error {
 		return errors.New("invalid mydumper files for there are no `-schema-create.sql` files found")
 	}
 	if len(l.db2Tables) == 0 {
-		return errors.New("no available `-schema-create.sql` files, check mydumper parameters and bwlist config")
+		return errors.New("no available `-schema-create.sql` files, check mydumper parameter matches black-white-list in task config")
 	}
 
 	return nil

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -662,6 +662,7 @@ func (l *Loader) prepareDbFiles(files map[string]struct{}) error {
 	// reset some variables
 	l.db2Tables = make(map[string]Tables2DataFiles)
 	l.totalFileCount.Set(0) // reset
+	schemaFileCount := 0
 	for file := range files {
 		if !strings.HasSuffix(file, "-schema-create.sql") {
 			continue
@@ -669,6 +670,7 @@ func (l *Loader) prepareDbFiles(files map[string]struct{}) error {
 
 		idx := strings.Index(file, "-schema-create.sql")
 		if idx > 0 {
+			schemaFileCount++
 			db := file[:idx]
 			if l.skipSchemaAndTable(&filter.Table{Schema: db}) {
 				log.Warnf("ignore schema file %s", file)
@@ -680,8 +682,11 @@ func (l *Loader) prepareDbFiles(files map[string]struct{}) error {
 		}
 	}
 
-	if len(l.db2Tables) == 0 {
+	if schemaFileCount == 0 {
 		return errors.New("invalid mydumper files for there are no `-schema-create.sql` files found")
+	}
+	if len(l.db2Tables) == 0 {
+		return errors.New("no available `-schema-create.sql` files, check mydumper parameters and bwlist config")
 	}
 
 	return nil
@@ -789,13 +794,13 @@ func (l *Loader) prepare() error {
 		if strings.HasSuffix(l.cfg.Dir, dirSuffix) {
 			dirPrefix := strings.TrimSuffix(l.cfg.Dir, dirSuffix)
 			if utils.IsDirExists(dirPrefix) {
-				log.Warnf("[loader] %s is not exists, trying to load data from %s", l.cfg.Dir, dirPrefix)
+				log.Warnf("[loader] %s does not exist, trying to load data from %s", l.cfg.Dir, dirPrefix)
 				l.cfg.Dir = dirPrefix
 				trimmed = true
 			}
 		}
 		if !trimmed {
-			return errors.Errorf("%s is not exists or it's not a dir", l.cfg.Dir)
+			return errors.Errorf("%s does not exist or it's not a dir", l.cfg.Dir)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`dump` and `load` unit in DM-worker use different black-white list config,  so dumped files may not contain SQL files we want to use in loader.

### What is changed and how it works?

The root solution should unify the task config used in `dump` unit and `load` unit, which needs a lot of work and will not be done in this pr.
In this pr we only refine the error messages to help DBA to distinguish different error scenario.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    - start a fresh task with `full` mode, set `extra-args: "-m"` config in dump unit. see error message.
    - start a fresh task with `full` mode, dump schema that does not list in load unit do-dbs. see error message.
