### PR TITLE
loader: fix break in forloop and some minor refine

### DIFF
--- a/loader/db.go
+++ b/loader/db.go
@@ -221,10 +221,6 @@ func isErrTableExists(err error) bool {
 	return isMySQLError(err, tmysql.ErrTableExists)
 }
 
-func isErrTableNotExists(err error) bool {
-	return isMySQLError(err, tmysql.ErrNoSuchTable)
-}
-
 func isErrDupEntry(err error) bool {
 	return isMySQLError(err, tmysql.ErrDupEntry)
 }

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -419,15 +419,9 @@ func (l *Loader) Process(ctx context.Context, pr chan pb.ProcessResult) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for {
-			select {
-			case err, ok := <-l.runFatalChan:
-				if !ok {
-					return
-				}
-				cancel() // cancel l.Restore
-				errs = append(errs, err)
-			}
+		for err := range l.runFatalChan {
+			cancel() // cancel l.Restore
+			errs = append(errs, err)
 		}
 	}()
 
@@ -1035,7 +1029,7 @@ func (l *Loader) restoreData(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			log.Infof("stop dispatch data file job because %v", ctx.Err())
-			break
+			return nil
 		case l.fileJobQueue <- j:
 		}
 	}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -509,6 +509,9 @@ func (l *Loader) Restore(ctx context.Context) error {
 	go l.PrintStatus(ctx)
 
 	if err := l.restoreData(ctx); err != nil {
+		if errors.Cause(err) == context.Canceled {
+			return nil
+		}
 		return errors.Trace(err)
 	}
 
@@ -998,7 +1001,7 @@ func (l *Loader) restoreData(ctx context.Context) error {
 				select {
 				case <-ctx.Done():
 					log.Infof("stop generate data file job because %v", ctx.Err())
-					return nil
+					return ctx.Err()
 				default:
 					// do nothing
 				}
@@ -1030,7 +1033,7 @@ func (l *Loader) restoreData(ctx context.Context) error {
 		case <-ctx.Done():
 			log.Infof("stop dispatch data file job because %v", ctx.Err())
 			l.closeFileJobQueue()
-			return nil
+			return ctx.Err()
 		case l.fileJobQueue <- j:
 		}
 	}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -1029,6 +1029,7 @@ func (l *Loader) restoreData(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			log.Infof("stop dispatch data file job because %v", ctx.Err())
+			l.closeFileJobQueue()
 			return nil
 		case l.fileJobQueue <- j:
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

"break" statement terminates execution of the innermost "for", "switch" or "select" statement. We should cancel execution when `context.Done` is detected.


### What is changed and how it works?

1. fix a break wrong usage
2. remove some unused code
3. use a range operator to simplify single case in `for { select {} }`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

