### PR TITLE
loader: generate db-schema-create.sql file if not exists

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -683,10 +683,10 @@ func (l *Loader) prepareDbFiles(files map[string]struct{}) error {
 	}
 
 	if schemaFileCount == 0 {
-		return errors.New("invalid mydumper files for there are no `-schema-create.sql` files found")
+		log.Warn("invalid mydumper files for there are no `-schema-create.sql` files found, and will generate later")
 	}
 	if len(l.db2Tables) == 0 {
-		return errors.New("no available `-schema-create.sql` files, check mydumper parameter matches black-white-list in task config")
+		log.Warn("no available `-schema-create.sql` files, check mydumper parameter matches black-white-list in task config, will generate later")
 	}
 
 	return nil
@@ -718,6 +718,7 @@ func (l *Loader) prepareTableFiles(files map[string]struct{}) error {
 				return errors.Trace(err)
 			}
 			l.db2Tables[db] = make(Tables2DataFiles)
+			tables = l.db2Tables[db]
 			l.totalFileCount.Add(1)
 		}
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -713,7 +713,12 @@ func (l *Loader) prepareTableFiles(files map[string]struct{}) error {
 		}
 		tables, ok := l.db2Tables[db]
 		if !ok {
-			return errors.Errorf("invalid table schema file, cannot find db - %s", file)
+			log.Warnf("cann't find schema create file for db %s, will generate one", db)
+			if err := generateSchemaCreateFile(l.cfg.Dir, db); err != nil {
+				return errors.Trace(err)
+			}
+			l.db2Tables[db] = make(Tables2DataFiles)
+			l.totalFileCount.Add(1)
 		}
 
 		if _, ok := tables[table]; ok {

--- a/loader/util.go
+++ b/loader/util.go
@@ -84,6 +84,6 @@ func generateSchemaCreateFile(dir string, schema string) error {
 	}
 	defer file.Close()
 
-	file.WriteString(fmt.Sprintf("CREATE DATABASE `%s`;\n", schema))
-	return nil
+	_, err = fmt.Fprintf(file, "CREATE DATABASE `%s`;\n", schema)
+	return errors.Trace(err)
 }

--- a/loader/util.go
+++ b/loader/util.go
@@ -18,8 +18,11 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/pingcap/errors"
 )
 
 // CollectDirFiles gets files in path
@@ -72,4 +75,15 @@ func shortSha1(s string) string {
 // percent calculates percentage of a/b.
 func percent(a int64, b int64) string {
 	return fmt.Sprintf("%.2f %%", float64(a)/float64(b)*100)
+}
+
+func generateSchemaCreateFile(dir string, schema string) error {
+	file, err := os.Create(path.Join(dir, fmt.Sprintf("%s-schema-create.sql", schema)))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer file.Close()
+
+	file.WriteString(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", schema))
+	return nil
 }

--- a/loader/util.go
+++ b/loader/util.go
@@ -84,6 +84,6 @@ func generateSchemaCreateFile(dir string, schema string) error {
 	}
 	defer file.Close()
 
-	file.WriteString(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", schema))
+	file.WriteString(fmt.Sprintf("CREATE DATABASE `%s`;\n", schema))
 	return nil
 }

--- a/loader/util.go
+++ b/loader/util.go
@@ -84,6 +84,10 @@ func generateSchemaCreateFile(dir string, schema string) error {
 	}
 	defer file.Close()
 
-	_, err = fmt.Fprintf(file, "CREATE DATABASE `%s`;\n", schema)
+	_, err = fmt.Fprintf(file, "CREATE DATABASE `%s`;\n", escapeName(schema))
 	return errors.Trace(err)
+}
+
+func escapeName(name string) string {
+	return strings.Replace(name, "`", "``", -1)
 }

--- a/loader/util_test.go
+++ b/loader/util_test.go
@@ -68,15 +68,27 @@ func (t *testUtilSuite) TestShortSha1(c *C) {
 
 func (t *testUtilSuite) TestGenerateSchemaCreateFile(c *C) {
 	dir := c.MkDir()
-	schema := "loader_test"
+	testCases := []struct {
+		schema    string
+		createSQL string
+	}{
+		{
+			"loader_test",
+			"CREATE DATABASE `loader_test`;\n",
+		}, {
+			"loader`test",
+			"CREATE DATABASE `loader``test`;\n",
+		},
+	}
+	for _, testCase := range testCases {
+		err := generateSchemaCreateFile(dir, testCase.schema)
+		c.Assert(err, IsNil)
 
-	err := generateSchemaCreateFile(dir, schema)
-	c.Assert(err, IsNil)
+		file, err := os.Open(path.Join(dir, fmt.Sprintf("%s-schema-create.sql", testCase.schema)))
+		c.Assert(err, IsNil)
 
-	file, err := os.Open(path.Join(dir, fmt.Sprintf("%s-schema-create.sql", schema)))
-	c.Assert(err, IsNil)
-
-	data, err := ioutil.ReadAll(file)
-	c.Assert(err, IsNil)
-	c.Assert(string(data), Equals, "CREATE DATABASE `loader_test`;\n")
+		data, err := ioutil.ReadAll(file)
+		c.Assert(err, IsNil)
+		c.Assert(string(data), Equals, testCase.createSQL)
+	}
 }

--- a/loader/util_test.go
+++ b/loader/util_test.go
@@ -14,6 +14,10 @@
 package loader
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
 	"testing"
 
 	. "github.com/pingcap/check"
@@ -60,4 +64,19 @@ func (t *testUtilSuite) TestSQLReplace(c *C) {
 
 func (t *testUtilSuite) TestShortSha1(c *C) {
 	c.Assert(shortSha1("/tmp/test_sha1_short_6"), Equals, "97b645")
+}
+
+func (t *testUtilSuite) TestGenerateSchemaCreateFile(c *C) {
+	dir := c.MkDir()
+	schema := "loader_test"
+
+	err := generateSchemaCreateFile(dir, schema)
+	c.Assert(err, IsNil)
+
+	file, err := os.Open(path.Join(dir, fmt.Sprintf("%s-schema-create.sql", schema)))
+	c.Assert(err, IsNil)
+
+	data, err := ioutil.ReadAll(file)
+	c.Assert(err, IsNil)
+	c.Assert(string(data), Equals, "CREATE DATABASE IF NOT EXISTS `loader_test`")
 }

--- a/loader/util_test.go
+++ b/loader/util_test.go
@@ -78,5 +78,5 @@ func (t *testUtilSuite) TestGenerateSchemaCreateFile(c *C) {
 
 	data, err := ioutil.ReadAll(file)
 	c.Assert(err, IsNil)
-	c.Assert(string(data), Equals, "CREATE DATABASE IF NOT EXISTS `loader_test`")
+	c.Assert(string(data), Equals, "CREATE DATABASE `loader_test`;\n")
 }


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
mydumper will not dump schema create sql sometimes, and then loader will return error.
fix issue https://internal.pingcap.net/jira/browse/TOOL-1316 

### What is changed and how it works?
create schema create sql file if not find

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test

Related changes

 - Need to cherry-pick to the release branch
