### PR TITLE
syncer: support case insensitive binlog event in filter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/pingcap/parser v0.0.0-20190613082312-d2cf6071823d
 	github.com/pingcap/pd v2.1.12+incompatible // indirect
 	github.com/pingcap/tidb v0.0.0-20190613131440-c59a108c28b7
-	github.com/pingcap/tidb-tools v3.0.0-beta.1.0.20190522080351-b06622ae57fd+incompatible
+	github.com/pingcap/tidb-tools v3.0.0-beta.1.0.20190626065910-16523947c844+incompatible
 	github.com/prometheus/client_golang v0.9.4
 	github.com/prometheus/common v0.4.1
 	github.com/remyoudompheng/bigfft v0.0.0-20190512091148-babf20351dd7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/pingcap/pd v2.1.12+incompatible/go.mod h1:nD3+EoYes4+aNNODO99ES59V83M
 github.com/pingcap/tidb v0.0.0-20190613131440-c59a108c28b7 h1:WzzifUZ1nRsZMijRrLznb2TKh6JYGi/9pgvVT7mnl2w=
 github.com/pingcap/tidb v0.0.0-20190613131440-c59a108c28b7/go.mod h1:c4qUUwEF9VSWePAPB7qFEVdaytJBcc2Tf/yuKKhCErA=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
-github.com/pingcap/tidb-tools v3.0.0-beta.1.0.20190522080351-b06622ae57fd+incompatible h1:87HclE+yA7xYE3VhMZh+PPT541ZHqB6WiFKOgK3C/4w=
-github.com/pingcap/tidb-tools v3.0.0-beta.1.0.20190522080351-b06622ae57fd+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
+github.com/pingcap/tidb-tools v3.0.0-beta.1.0.20190626065910-16523947c844+incompatible h1:kiYtLakPd2GKNHiYnfa6XCNRoRLRLndavuGhA7kBslA=
+github.com/pingcap/tidb-tools v3.0.0-beta.1.0.20190626065910-16523947c844+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330 h1:rRMLMjIMFulCX9sGKZ1hoov/iROMsKyC8Snc02nSukw=
 github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -514,6 +515,11 @@ func (s *testSyncerSuite) TestSkipDML(c *C) {
 			TablePattern:  "bar1",
 			Events:        []bf.EventType{bf.DeleteEvent},
 			Action:        bf.Ignore,
+		}, {
+			SchemaPattern: "foo1",
+			TablePattern:  "bar2",
+			Events:        []bf.EventType{bf.EventType(strings.ToUpper(string(bf.DeleteEvent)))},
+			Action:        bf.Ignore,
 		},
 	}
 	s.cfg.BWList = nil
@@ -535,6 +541,10 @@ func (s *testSyncerSuite) TestSkipDML(c *C) {
 		{"insert into foo1.bar1 values(1)", true, false},
 		{"update foo1.bar1 set id=2", true, true},
 		{"delete from foo1.bar1 where id=2", true, true},
+		{"create table foo1.bar2(id int)", false, false},
+		{"insert into foo1.bar2 values(1)", true, false},
+		{"update foo1.bar2 set id=2", true, true},
+		{"delete from foo1.bar2 where id=2", true, true},
 	}
 
 	for i := range sqls {


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
support case insensitive binlog event in binlog event filter. fix issue https://github.com/pingcap/dm/issues/181

### What is changed and how it works?

upgrade the version of tidb-tools to this commit https://github.com/pingcap/tidb-tools/tree/16523947c844b1b1aa2996f56dbdc4251bb5c452

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test