### PR TITLE
*: some static check fix

### DIFF
--- a/dm/config/subtask_test.go
+++ b/dm/config/subtask_test.go
@@ -49,11 +49,12 @@ func (t *testConfig) TestSubTask(c *C) {
 	c.Assert(clone2, DeepEquals, clone1)
 
 	cfg.From.Password = "xxx"
-	clone3, err := cfg.DecryptPassword()
+	_, err = cfg.DecryptPassword()
 	c.Assert(err, NotNil)
 
 	cfg.From.Password = ""
-	clone3, err = cfg.DecryptPassword()
+	clone3, err := cfg.DecryptPassword()
+	c.Assert(err, IsNil)
 	c.Assert(clone3, DeepEquals, cfg)
 
 	err = cfg.Adjust()

--- a/dm/master/server.go
+++ b/dm/master/server.go
@@ -39,9 +39,8 @@ import (
 )
 
 var (
-	retryTimeout       = 5 * time.Second
-	tryResolveInterval = 30 * time.Second
-	cmuxReadTimeout    = 10 * time.Second
+	retryTimeout    = 5 * time.Second
+	cmuxReadTimeout = 10 * time.Second
 )
 
 // Server handles RPC requests for dm-master

--- a/dm/tracer/server.go
+++ b/dm/tracer/server.go
@@ -16,7 +16,6 @@ package tracer
 import (
 	"context"
 	"net"
-	"net/http"
 	"sync"
 	"time"
 
@@ -38,7 +37,6 @@ var (
 // Server accepts tracing RPC requests and sends RPC responses back
 type Server struct {
 	sync.Mutex
-	wg     sync.WaitGroup
 	closed sync2.AtomicBool
 
 	cfg *Config
@@ -46,9 +44,8 @@ type Server struct {
 	rootLis net.Listener
 	svr     *grpc.Server
 
-	eventStore   *EventStore
-	idGen        *tracing.IDGenerator
-	statusServer *http.Server
+	eventStore *EventStore
+	idGen      *tracing.IDGenerator
 }
 
 // NewServer creates a new Server

--- a/dm/worker/config_test.go
+++ b/dm/worker/config_test.go
@@ -66,11 +66,12 @@ func (t *testServer) TestConfig(c *C) {
 	c.Assert(clone2, DeepEquals, clone1)
 
 	cfg.From.Password = "xxx"
-	clone3, err := cfg.DecryptPassword()
+	_, err = cfg.DecryptPassword()
 	c.Assert(err, NotNil)
 
 	cfg.From.Password = ""
-	clone3, err = cfg.DecryptPassword()
+	clone3, err := cfg.DecryptPassword()
+	c.Assert(err, IsNil)
 	c.Assert(clone3, DeepEquals, cfg)
 }
 

--- a/dm/worker/log_test.go
+++ b/dm/worker/log_test.go
@@ -241,6 +241,7 @@ func (t *testLog) TestTaskLogGC(c *C) {
 	logger.doGC(db, 59)
 
 	logs, err := logger.Initial(db)
+	c.Assert(err, IsNil)
 	c.Assert(logs, DeepEquals, []*pb.TaskLog{taskLog4})
 	c.Assert(logger.handledPointer.Location, Equals, int64(59))
 	c.Assert(logger.endPointer.Location, Equals, int64(61))

--- a/dm/worker/meta_test.go
+++ b/dm/worker/meta_test.go
@@ -92,7 +92,7 @@ func (t *testMeta) TestNewMetaDB(c *C) {
 	// test fail to recover from old fashion meta
 	err = ioutil.WriteFile(path.Join(dir, "meta"), []byte("xxxx"), 0644)
 	c.Assert(err, IsNil)
-	metaDB, err = NewMetadata(dir, db)
+	_, err = NewMetadata(dir, db)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, ".*decode old metadata.*")
 
@@ -254,14 +254,17 @@ func (t *testMeta) TestTaskOperation(c *C) {
 	c.Assert(log1C, DeepEquals, log1)
 
 	log2, err := meta.GetTaskLog(2)
+	c.Assert(err, IsNil)
 	c.Assert(log2.Task, DeepEquals, testTask2Meta)
 	c.Assert(log2.Id, DeepEquals, int64(2))
 
 	log1s, err := meta.GetTaskLog(3)
+	c.Assert(err, IsNil)
 	c.Assert(log1s.Task, DeepEquals, testTask1MetaC)
 	c.Assert(log1s.Id, DeepEquals, int64(3))
 
 	log2s, err := meta.GetTaskLog(4)
+	c.Assert(err, IsNil)
 	c.Assert(log2s.Task, DeepEquals, testTask2MetaC)
 	c.Assert(log2s.Id, DeepEquals, int64(4))
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -732,8 +732,8 @@ func (l *Loader) prepareTableFiles(files map[string]struct{}) error {
 
 func (l *Loader) prepareDataFiles(files map[string]struct{}) error {
 	for file := range files {
-		if !strings.HasSuffix(file, ".sql") || strings.Index(file, "-schema.sql") >= 0 ||
-			strings.Index(file, "-schema-create.sql") >= 0 {
+		if !strings.HasSuffix(file, ".sql") || strings.ContainsAny(file, "-schema.sql") ||
+			strings.Contains(file, "-schema-create.sql") {
 			continue
 		}
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -732,7 +732,7 @@ func (l *Loader) prepareTableFiles(files map[string]struct{}) error {
 
 func (l *Loader) prepareDataFiles(files map[string]struct{}) error {
 	for file := range files {
-		if !strings.HasSuffix(file, ".sql") || strings.ContainsAny(file, "-schema.sql") ||
+		if !strings.HasSuffix(file, ".sql") || strings.Contains(file, "-schema.sql") ||
 			strings.Contains(file, "-schema-create.sql") {
 			continue
 		}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -738,8 +738,8 @@ func (l *Loader) prepareDataFiles(files map[string]struct{}) error {
 		}
 
 		// ignore view / triggers
-		if strings.Index(file, "-schema-view.sql") >= 0 || strings.Index(file, "-schema-triggers.sql") >= 0 ||
-			strings.Index(file, "-schema-post.sql") >= 0 {
+		if strings.Contains(file, "-schema-view.sql") || strings.Contains(file, "-schema-triggers.sql") ||
+			strings.Contains(file, "-schema-post.sql") {
 			log.Warnf("[loader] ignore unsupport view/trigger: %s", file)
 			continue
 		}

--- a/pkg/binlog/reader/file_test.go
+++ b/pkg/binlog/reader/file_test.go
@@ -211,6 +211,7 @@ func (t *testFileReaderSuite) TestGetEvent(c *C) {
 	c.Assert(e.RawData, DeepEquals, formatDescEv.RawData) // always got a FormatDescriptionEvent first
 	e, err = r.GetEvent(timeoutCtx)
 	c.Assert(err, ErrorMatches, ".*EOF.*")
+	c.Assert(e, IsNil)
 }
 
 func (t *testFileReaderSuite) TestWithChannelBuffer(c *C) {

--- a/pkg/binlog/reader/tcp_test.go
+++ b/pkg/binlog/reader/tcp_test.go
@@ -190,6 +190,7 @@ func (t *testTCPReaderSuite) TestSyncPos(c *C) {
 
 	// get current position for master
 	pos, _, err = utils.GetMasterStatus(t.db, flavor)
+	c.Assert(err, IsNil)
 
 	// execute another DML again
 	query := fmt.Sprintf("INSERT INTO `%s`.`%s` VALUES (%d)", dbName, tableName, columnValue+1)
@@ -274,6 +275,7 @@ func (t *testTCPReaderSuite) TestSyncGTID(c *C) {
 
 	// get current GTID set for master
 	_, gSet, err = utils.GetMasterStatus(t.db, flavor)
+	c.Assert(err, IsNil)
 
 	// execute another DML again
 	query := fmt.Sprintf("INSERT INTO `%s`.`%s` VALUES (%d)", dbName, tableName, columnValue+2)

--- a/pkg/encrypt/encrypt.go
+++ b/pkg/encrypt/encrypt.go
@@ -74,7 +74,7 @@ func Decrypt(ciphertext []byte) ([]byte, error) {
 		return nil, errors.NotValidf("ciphertext's length should be greater than %d, but got %d", block.BlockSize()+len(ivSep), len(ciphertext))
 	}
 
-	if bytes.Compare(ciphertext[block.BlockSize():block.BlockSize()+len(ivSep)], ivSep) != 0 {
+	if !bytes.Equal(ciphertext[block.BlockSize():block.BlockSize()+len(ivSep)], ivSep) {
 		return nil, errors.NotValidf("ciphertext's content")
 	}
 

--- a/pkg/streamer/file_test.go
+++ b/pkg/streamer/file_test.go
@@ -231,7 +231,7 @@ func (t *testFileSuite) TestGetFirstBinlogName(c *C) {
 	filename := "invalid.bin"
 	err = ioutil.WriteFile(filepath.Join(subDir, filename), nil, 0600)
 	c.Assert(err, IsNil)
-	name, err = getFirstBinlogName(baseDir, uuid)
+	_, err = getFirstBinlogName(baseDir, uuid)
 	c.Assert(err, ErrorMatches, ".*not valid.*")
 	err = os.Remove(filepath.Join(subDir, filename))
 	c.Assert(err, IsNil)

--- a/pkg/streamer/streamer_test.go
+++ b/pkg/streamer/streamer_test.go
@@ -58,6 +58,7 @@ func (t *testStreamerSuite) TestStreamer(c *C) {
 	// can not get event anymore because got error
 	ev2, err = s.GetEvent(ctx)
 	c.Assert(err, Equals, ErrNeedSyncAgain)
+	c.Assert(ev2, IsNil)
 
 	// 2. close with error
 	s = newLocalStreamer()
@@ -70,6 +71,7 @@ func (t *testStreamerSuite) TestStreamer(c *C) {
 	// can not get event anymore
 	ev2, err = s.GetEvent(ctx)
 	c.Assert(err, Equals, ErrNeedSyncAgain)
+	c.Assert(ev2, IsNil)
 
 	// 3. close without error
 	s = newLocalStreamer()
@@ -81,6 +83,7 @@ func (t *testStreamerSuite) TestStreamer(c *C) {
 	// can not get event anymore
 	ev2, err = s.GetEvent(ctx)
 	c.Assert(err, Equals, ErrNeedSyncAgain)
+	c.Assert(ev2, IsNil)
 
 	// 4. close with nil error
 	s = newLocalStreamer()
@@ -92,4 +95,5 @@ func (t *testStreamerSuite) TestStreamer(c *C) {
 	// can not get event anymore
 	ev2, err = s.GetEvent(ctx)
 	c.Assert(err, Equals, ErrNeedSyncAgain)
+	c.Assert(ev2, IsNil)
 }

--- a/pkg/tracing/tracer_test.go
+++ b/pkg/tracing/tracer_test.go
@@ -46,7 +46,6 @@ type TraceEvent struct {
 // MockServer is a mock tracing server
 type MockServer struct {
 	sync.Mutex
-	wg     sync.WaitGroup
 	closed sync2.AtomicBool
 
 	addr string

--- a/relay/metrics.go
+++ b/relay/metrics.go
@@ -147,16 +147,13 @@ func reportRelayLogSpaceInBackground(dirpath string) error {
 		ticker := time.NewTicker(time.Second * 10)
 		defer ticker.Stop()
 
-		for {
-			select {
-			case <-ticker.C:
-				size, err := utils.GetStorageSize(dirpath)
-				if err != nil {
-					log.Error("update sotrage size err: ", err)
-				} else {
-					relayLogSpaceGauge.WithLabelValues("capacity").Set(float64(size.Capacity))
-					relayLogSpaceGauge.WithLabelValues("available").Set(float64(size.Available))
-				}
+		for range ticker.C {
+			size, err := utils.GetStorageSize(dirpath)
+			if err != nil {
+				log.Error("update sotrage size err: ", err)
+			} else {
+				relayLogSpaceGauge.WithLabelValues("capacity").Set(float64(size.Capacity))
+				relayLogSpaceGauge.WithLabelValues("available").Set(float64(size.Available))
 			}
 		}
 	}()

--- a/relay/writer/file_test.go
+++ b/relay/writer/file_test.go
@@ -196,7 +196,6 @@ func (t *testFileWriterSuite) TestFormatDescriptionEvent(c *check.C) {
 	c.Assert(result.Ignore, check.IsFalse)
 	fileSize += int64(len(queryEv.RawData))
 	t.verifyFilenameOffset(c, w, cfg.Filename, fileSize)
-	latestPos = queryEv.Header.LogPos
 
 	// write FormatDescriptionEvent again, ignore
 	result, err = w.WriteEvent(formatDescEv)
@@ -309,10 +308,12 @@ func (t *testFileWriterSuite) TestRotateEventWithFormatDescriptionEvent(c *check
 	defer w3.Close()
 	c.Assert(w3.Start(), check.IsNil)
 	result, err = w3.WriteEvent(formatDescEv)
+	c.Assert(err, check.IsNil)
 	c.Assert(result, check.NotNil)
 	c.Assert(result.Ignore, check.IsFalse)
 
 	result, err = w3.WriteEvent(fakeRotateEv)
+	c.Assert(err, check.IsNil)
 	c.Assert(result, check.NotNil)
 	c.Assert(result.Ignore, check.IsTrue)
 
@@ -334,6 +335,7 @@ func (t *testFileWriterSuite) TestRotateEventWithFormatDescriptionEvent(c *check
 	defer w4.Close()
 	c.Assert(w4.Start(), check.IsNil)
 	result, err = w4.WriteEvent(formatDescEv)
+	c.Assert(err, check.IsNil)
 	c.Assert(result, check.NotNil)
 	c.Assert(result.Ignore, check.IsFalse)
 

--- a/relay/writer/file_util.go
+++ b/relay/writer/file_util.go
@@ -151,7 +151,8 @@ func checkIsDuplicateEvent(filename string, ev *replication.BinlogEvent) (bool, 
 	_, err = f.ReadAt(buf, evStartPos)
 	if err != nil {
 		return false, errors.Annotatef(err, "read data from %d in %s with length %d", evStartPos, filename, len(buf))
-	} else if bytes.Compare(buf, ev.RawData) != 0 {
+		// } else if bytes.Compare(buf, ev.RawData) != 0 {
+	} else if !bytes.Equal(buf, ev.RawData) {
 		return false, errors.Errorf("event from %d in %s diff from passed-in event %+v", evStartPos, filename, ev.Header)
 	}
 

--- a/syncer/ddl_exec_info.go
+++ b/syncer/ddl_exec_info.go
@@ -109,12 +109,9 @@ func (i *DDLExecInfo) cancelAndWaitSending() {
 	// wait Send to return
 	timer := time.NewTicker(1 * time.Millisecond)
 	defer timer.Stop()
-	for {
-		select {
-		case <-timer.C:
-			if !i.status.CompareAndSwap(ddlExecSending, ddlExecSending) {
-				return // return from select and for
-			}
+	for range timer.C {
+		if !i.status.CompareAndSwap(ddlExecSending, ddlExecSending) {
+			return // return from select and for
 		}
 	}
 }

--- a/syncer/ddl_exec_info_test.go
+++ b/syncer/ddl_exec_info_test.go
@@ -42,7 +42,7 @@ func (t *testDDLExecInfoSuite) TestDDLExecItem(c *C) {
 		defer wg.Done()
 
 		select {
-		case _ = <-ddlExecInfo.Chan(ddls):
+		case <-ddlExecInfo.Chan(ddls):
 		case <-time.After(time.Second):
 			c.Fatal("timeout")
 		}

--- a/syncer/dml.go
+++ b/syncer/dml.go
@@ -297,7 +297,7 @@ func genColumnList(columns []*column) string {
 }
 
 func genColumnPlaceholders(length int) string {
-	values := make([]string, length, length)
+	values := make([]string, length)
 	for i := 0; i < length; i++ {
 		values[i] = "?"
 	}

--- a/syncer/util.go
+++ b/syncer/util.go
@@ -38,28 +38,25 @@ func toBinlogType(bt string) BinlogType {
 
 // tableNameForDML gets table name from INSERT/UPDATE/DELETE statement
 func tableNameForDML(dml ast.DMLNode) (schema, table string, err error) {
-	switch dml.(type) {
+	switch stmt := dml.(type) {
 	case *ast.InsertStmt:
-		is := dml.(*ast.InsertStmt)
-		if is.Table == nil || is.Table.TableRefs == nil || is.Table.TableRefs.Left == nil {
-			return "", "", errors.NotValidf("INSERT statement %s", is.Text())
+		if stmt.Table == nil || stmt.Table.TableRefs == nil || stmt.Table.TableRefs.Left == nil {
+			return "", "", errors.NotValidf("INSERT statement %s", stmt.Text())
 		}
-		schema, table, err = tableNameResultSet(is.Table.TableRefs.Left)
-		return schema, table, errors.Annotatef(err, "INSERT statement %s", is.Text())
+		schema, table, err = tableNameResultSet(stmt.Table.TableRefs.Left)
+		return schema, table, errors.Annotatef(err, "INSERT statement %s", stmt.Text())
 	case *ast.UpdateStmt:
-		us := dml.(*ast.UpdateStmt)
-		if us.TableRefs == nil || us.TableRefs.TableRefs == nil || us.TableRefs.TableRefs.Left == nil {
-			return "", "", errors.NotValidf("UPDATE statement %s", us.Text())
+		if stmt.TableRefs == nil || stmt.TableRefs.TableRefs == nil || stmt.TableRefs.TableRefs.Left == nil {
+			return "", "", errors.NotValidf("UPDATE statement %s", stmt.Text())
 		}
-		schema, table, err = tableNameResultSet(us.TableRefs.TableRefs.Left)
-		return schema, table, errors.Annotatef(err, "UPDATE statement %s", us.Text())
+		schema, table, err = tableNameResultSet(stmt.TableRefs.TableRefs.Left)
+		return schema, table, errors.Annotatef(err, "UPDATE statement %s", stmt.Text())
 	case *ast.DeleteStmt:
-		ds := dml.(*ast.DeleteStmt)
-		if ds.TableRefs == nil || ds.TableRefs.TableRefs == nil || ds.TableRefs.TableRefs.Left == nil {
-			return "", "", errors.NotValidf("DELETE statement %s", ds.Text())
+		if stmt.TableRefs == nil || stmt.TableRefs.TableRefs == nil || stmt.TableRefs.TableRefs.Left == nil {
+			return "", "", errors.NotValidf("DELETE statement %s", stmt.Text())
 		}
-		schema, table, err = tableNameResultSet(ds.TableRefs.TableRefs.Left)
-		return schema, table, errors.Annotatef(err, "DELETE statement %s", ds.Text())
+		schema, table, err = tableNameResultSet(stmt.TableRefs.TableRefs.Left)
+		return schema, table, errors.Annotatef(err, "DELETE statement %s", stmt.Text())
 	}
 	return "", "", errors.NotSupportedf("DMLNode %v", dml)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

use `staticcheck` tool (`staticcheck $(go list ./...)`) finds some minor warnings

### What is changed and how it works?
1. most changes are syntax refine
2. `bytes.Equal()` is faster than `bytes.Compare() != 0`

```
goos: linux
goarch: amd64
BenchmarkCompare-2      300000000                6.01 ns/op
BenchmarkEqual-2        300000000                5.21 ns/op
PASS
ok      command-line-arguments  4.492s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
