### PR TITLE
dm-worker: Should use fmt.Printf instead of the uninitialized logger

### DIFF
--- a/cmd/dm-worker/main.go
+++ b/cmd/dm-worker/main.go
@@ -37,7 +37,7 @@ func main() {
 	case flag.ErrHelp:
 		os.Exit(0)
 	default:
-		log.L().Error("parse cmd flags", log.ShortError(err))
+		fmt.Printf("parse cmd flags err: %s", err)
 		os.Exit(2)
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In [TOOL-1417](https://internal.pingcap.net/jira/browse/TOOL-1417), a
user complained that dm-worker failed to start but output no logs.

This is a bug introduced in #195, which use the logger before it's
initialized.


### What is changed and how it works?

Use fmt.Printf instead.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test
   Run dm-worker with some invalid flag and make sure error messages are
printed.

Code changes


Side effects


Related changes