### PR TITLE
Add syncer sharding test

### DIFF
--- a/cmd/dm-worker/main.go
+++ b/cmd/dm-worker/main.go
@@ -37,7 +37,7 @@ func main() {
 	case flag.ErrHelp:
 		os.Exit(0)
 	default:
-		log.L().Error("parse cmd flags", log.ShortError(err))
+		fmt.Printf("parse cmd flags err: %s", err)
 		os.Exit(2)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/pingcap/parser v0.0.0-20190613082312-d2cf6071823d
 	github.com/pingcap/pd v2.1.12+incompatible // indirect
 	github.com/pingcap/tidb v0.0.0-20190613131440-c59a108c28b7
-	github.com/pingcap/tidb-tools v3.0.0-beta.1.0.20190626065910-16523947c844+incompatible
+	github.com/pingcap/tidb-tools v3.0.0-beta.1.0.20190709045846-a3fe9b9aaf6f+incompatible
 	github.com/prometheus/client_golang v0.9.4
 	github.com/remyoudompheng/bigfft v0.0.0-20190512091148-babf20351dd7 // indirect
 	github.com/satori/go.uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,10 @@ github.com/pingcap/tidb v0.0.0-20190613131440-c59a108c28b7/go.mod h1:c4qUUwEF9VS
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tidb-tools v3.0.0-beta.1.0.20190626065910-16523947c844+incompatible h1:kiYtLakPd2GKNHiYnfa6XCNRoRLRLndavuGhA7kBslA=
 github.com/pingcap/tidb-tools v3.0.0-beta.1.0.20190626065910-16523947c844+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
+github.com/pingcap/tidb-tools v3.0.0-beta.1.0.20190709045846-a3fe9b9aaf6f+incompatible h1:+Nr9JhbkVEcEiQYchHex/UlMcurFLsq9P1Ocqe1ItAc=
+github.com/pingcap/tidb-tools v3.0.0-beta.1.0.20190709045846-a3fe9b9aaf6f+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
+github.com/pingcap/tidb-tools v3.0.0+incompatible h1:LbnRRZ9Dyrvopn3aC4HTbqMOWjMOfpZlsAdyz3+VrGk=
+github.com/pingcap/tidb-tools v3.0.0+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330 h1:rRMLMjIMFulCX9sGKZ1hoov/iROMsKyC8Snc02nSukw=
 github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -1190,8 +1190,6 @@ func (s *testSyncerSuite) TestSharding(c *C) {
 		}
 		syncer := NewSyncer(s.cfg)
 		syncer.Init()
-		syncer.syncer = s.syncer
-		syncer.streamer = s.streamer
 
 		c.Assert(syncer.checkpoint.GlobalPoint(), Equals, minCheckpoint)
 		c.Assert(syncer.checkpoint.FlushedGlobalPoint(), Equals, minCheckpoint)
@@ -1275,6 +1273,7 @@ func (s *testSyncerSuite) TestSharding(c *C) {
 		cancel()
 
 		syncer.Close()
+		c.Assert(syncer.isClosed(), IsTrue)
 
 		flushedGP := syncer.checkpoint.FlushedGlobalPoint().Pos
 		GP := syncer.checkpoint.GlobalPoint().Pos
@@ -1303,7 +1302,6 @@ func (s *testSyncerSuite) TestSharding(c *C) {
 			c.Errorf("there were unfulfilled expectations: %s", err)
 		}
 		runSQL(dropSQLs)
-		c.Assert(syncer.isClosed(), IsTrue)
 	}
 }
 

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -1252,6 +1252,9 @@ func (s *testSyncerSuite) TestSharding(c *C) {
 
 		select {
 		case r := <-resultCh:
+			for _, err := range r.Errors {
+				c.Errorf("Process:", err)
+			}
 			c.Assert(len(r.Errors), Equals, 0)
 		case <-time.After(2 * time.Second):
 		}

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -1279,24 +1279,6 @@ func (s *testSyncerSuite) TestSharding(c *C) {
 		GP := syncer.checkpoint.GlobalPoint().Pos
 		c.Assert(GP, Equals, flushedGP)
 
-		// Xid Event has 31 bytes
-		// check whether last event before flushed globalPoint is Xid event
-		query := fmt.Sprintf("SHOW BINLOG EVENTS FROM %d LIMIT 1", GP-31)
-		c.Logf(query)
-		r, err := s.db.Query(query)
-		c.Assert(err, IsNil)
-
-		var pos, endLogPos uint32
-		var name, eventType string
-		var unusedVal interface{}
-		unused := &unusedVal
-
-		for r.Next() {
-			r.Scan(&name, &pos, &eventType, &unused, &endLogPos, &unused)
-		}
-
-		c.Assert(eventType, Equals, "Xid")
-
 		// check expectations for mock db
 		if err := mock.ExpectationsWereMet(); err != nil {
 			c.Errorf("there were unfulfilled expectations: %s", err)

--- a/tests/safe_mode/conf/dm-task.yaml
+++ b/tests/safe_mode/conf/dm-task.yaml
@@ -73,7 +73,7 @@ mydumpers:
     threads: 4
     chunk-filesize: 64
     skip-tz-utc: true
-    #extra-args: "-B safe_mode_test"
+    extra-args: "-B safe_mode_test"
 
 loaders:
   global:

--- a/tests/safe_mode/conf/dm-task.yaml
+++ b/tests/safe_mode/conf/dm-task.yaml
@@ -73,6 +73,7 @@ mydumpers:
     threads: 4
     chunk-filesize: 64
     skip-tz-utc: true
+    #extra-args: "-B safe_mode_test"
 
 loaders:
   global:

--- a/tests/sequence_safe_mode/conf/dm-task.yaml
+++ b/tests/sequence_safe_mode/conf/dm-task.yaml
@@ -73,6 +73,7 @@ mydumpers:
     threads: 4
     chunk-filesize: 64
     skip-tz-utc: true
+    extra-args: "-B sequence_safe_mode_test"
 
 loaders:
   global:


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. Add syncer sharding test to increase syncer test coverage
2. Update tidb-tool go module
3. Update safe_mode/sequence_safe_mode mydumper config in integration test

### What is changed and how it works?
Add TestSharding function to test
Simulate two tables(t1,t2) in one dm-worker syncer to one target table
```t1 insert -> t2 insert -> t1 add column -> t2 insert -> t2 add column -> t1, t2 insert (new schema)```
and check mock result as wish

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
