### PR TITLE
worker: close kv db when worker exits

### DIFF
--- a/dm/worker/worker.go
+++ b/dm/worker/worker.go
@@ -187,6 +187,11 @@ func (w *Worker) Close() {
 	// close meta
 	w.meta.Close()
 
+	// close kv db
+	if w.db != nil {
+		w.db.Close()
+	}
+
 	// close tracer
 	if w.tracer.Enable() {
 		w.tracer.Stop()


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

I found DM-worker sometimes faild to start if start-stop-start in sequence frequently, with levelDB error `LOCK: Resource temporarily unavailable`, it is always a good habit to release resource in exit function. 


### What is changed and how it works?
close levelDB when `worker.Worker` closes.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
