### PR TITLE
Combine syncer localReader into one interface

### DIFF
--- a/pkg/streamer/reader.go
+++ b/pkg/streamer/reader.go
@@ -383,12 +383,11 @@ func (r *BinlogReader) updateUUIDs() error {
 }
 
 // Close closes BinlogReader.
-func (r *BinlogReader) Close() error {
+func (r *BinlogReader) Close() {
 	r.tctx.L().Info("binlog reader closing")
 	r.running = false
 	r.cancel()
 	r.parser.Stop()
 	r.wg.Wait()
 	r.tctx.L().Info("binlog reader closed")
-	return nil
 }

--- a/pkg/streamer/reader_test.go
+++ b/pkg/streamer/reader_test.go
@@ -590,6 +590,7 @@ func (t *testReaderSuite) TestStartSync(c *C) {
 
 	// close the reader
 	c.Assert(err, IsNil)
+	r.Close()
 }
 
 func (t *testReaderSuite) TestStartSyncError(c *C) {
@@ -619,6 +620,7 @@ func (t *testReaderSuite) TestStartSyncError(c *C) {
 	ev, err := s.GetEvent(ctx)
 	c.Assert(err, ErrorMatches, ".*empty UUIDs not valid.*")
 	c.Assert(ev, IsNil)
+	r.Close()
 
 	// write UUIDs into index file
 	r = NewBinlogReader(tctx, cfg) // create a new reader
@@ -637,6 +639,7 @@ func (t *testReaderSuite) TestStartSyncError(c *C) {
 	s, err = r.StartSync(startPos)
 	c.Assert(errors.Cause(err), Equals, ErrReaderRunning)
 	c.Assert(s, IsNil)
+	r.Close()
 }
 
 func (t *testReaderSuite) genBinlogEvents(c *C, latestPos uint32) []*replication.BinlogEvent {

--- a/pkg/streamer/reader_test.go
+++ b/pkg/streamer/reader_test.go
@@ -589,7 +589,6 @@ func (t *testReaderSuite) TestStartSync(c *C) {
 	// NOTE: load new UUIDs dynamically not supported yet
 
 	// close the reader
-	c.Assert(err, IsNil)
 	r.Close()
 }
 

--- a/pkg/streamer/reader_test.go
+++ b/pkg/streamer/reader_test.go
@@ -589,7 +589,6 @@ func (t *testReaderSuite) TestStartSync(c *C) {
 	// NOTE: load new UUIDs dynamically not supported yet
 
 	// close the reader
-	err = r.Close()
 	c.Assert(err, IsNil)
 }
 
@@ -620,7 +619,6 @@ func (t *testReaderSuite) TestStartSyncError(c *C) {
 	ev, err := s.GetEvent(ctx)
 	c.Assert(err, ErrorMatches, ".*empty UUIDs not valid.*")
 	c.Assert(ev, IsNil)
-	c.Assert(r.Close(), IsNil)
 
 	// write UUIDs into index file
 	r = NewBinlogReader(tctx, cfg) // create a new reader
@@ -639,8 +637,6 @@ func (t *testReaderSuite) TestStartSyncError(c *C) {
 	s, err = r.StartSync(startPos)
 	c.Assert(errors.Cause(err), Equals, ErrReaderRunning)
 	c.Assert(s, IsNil)
-
-	c.Assert(r.Close(), IsNil)
 }
 
 func (t *testReaderSuite) genBinlogEvents(c *C, latestPos uint32) []*replication.BinlogEvent {

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -112,7 +112,7 @@ func (r *remoteBinlogReader) generateStreamer(pos mysql.Position) (streamer.Stre
 	}()
 	if r.EnableGTID {
 		// NOTE: our (per-table based) checkpoint does not support GTID yet
-		return nil, errors.New("[syncer] not support GTID mode yet")
+		return nil, errors.New("don't support open streamer with GTID mode")
 	}
 
 	streamer, err := r.reader.StartSync(pos)
@@ -2046,14 +2046,14 @@ func (s *Syncer) reopenWithRetry(cfg replication.BinlogSyncerConfig) error {
 
 func (s *Syncer) reopen(cfg replication.BinlogSyncerConfig) (streamer.Streamer, error) {
 	if s.streamerProducer != nil {
-		switch s.streamerProducer.(type) {
+		switch r := s.streamerProducer.(type) {
 		case *remoteBinlogReader:
-			err := s.closeBinlogSyncer(s.streamerProducer.(*remoteBinlogReader).reader)
+			err := s.closeBinlogSyncer(r.reader)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-		case *localBinlogReader:
-			return nil, errors.New("[syncer] not support local relay reader reopen currently")
+		default:
+			return nil, errors.Errorf("don’t support to reopen %T", r)
 		}
 	}
 	// TODO: refactor to support relay


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Combine two Syncer members (`Syncer.syncer` and `Syncer.localReader`) into one variable (streamerProducer), base on two reasons:

1. Obviously `Syncer.syncer` and `Syncer.localReader` has same ability to generate stream which can generate events, And Syncer only need one not two at any time
2.  And after put them in one interface, it's easy for any implementations who implement StreamerProducer and Stream interfaces to take place of `Syncer.streamerProducer`, such as a mock test

### What is changed and how it works?
Combine two Syncer members into one `streamerProducer`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
