### PR TITLE
dm-operator: add configmap, pv, pvc and cleaner functions

### DIFF
--- a/operator/pkg/controller/cleaner.go
+++ b/operator/pkg/controller/cleaner.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"strings"
+
+	pv1alpha1 "github.com/pingcap/dm/operator/pkg/apis/pingcap.com/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog"
+)
+
+const (
+	skipReasonOrphanPodsCleanerIsNotMasterOrWorker = "orphan pods cleaner: member type is not master or worker"
+	skipReasonOrphanPodsCleanerMasterNoPVC         = "orphan pods cleaner: no PVC created for master"
+	skipReasonOrphanPodsCleanerPVCNameIsEmpty      = "orphan pods cleaner: pvcName is empty"
+	skipReasonOrphanPodsCleanerPVCIsFound          = "orphan pods cleaner: pvc is found"
+)
+
+func (c *Controller) cleanOrphanPods(node *pv1alpha1.DMNode) (map[string]string, error) {
+	ns := node.Namespace
+	// for unit test
+	skipReason := map[string]string{}
+	instanceName := node.Labels[instanceKey]
+	selector := labels.Set{instanceKey: instanceName}.AsSelector()
+	pods, err := c.podLister.Pods(ns).List(selector)
+	if err != nil {
+		return skipReason, err
+	}
+
+	for _, pod := range pods {
+		podName := pod.Name
+		if pod.Labels == nil {
+			continue
+		}
+		v := pod.Labels[componentKey]
+		if v != componentMaster && v != componentWorker {
+			skipReason[podName] = skipReasonOrphanPodsCleanerIsNotMasterOrWorker
+			continue
+		}
+		if v == componentMaster && !c.masterPVC {
+			skipReason[podName] = skipReasonOrphanPodsCleanerMasterNoPVC
+			continue
+		}
+
+		var pvcName string
+		for _, vol := range pod.Spec.Volumes {
+			if vol.PersistentVolumeClaim != nil {
+				pvcName = vol.PersistentVolumeClaim.ClaimName
+				break
+			}
+		}
+		if pvcName == "" {
+			skipReason[podName] = skipReasonOrphanPodsCleanerPVCNameIsEmpty
+			continue
+		}
+
+		_, err := c.pvcLister.PersistentVolumeClaims(ns).Get(pvcName)
+		if err == nil {
+			skipReason[podName] = skipReasonOrphanPodsCleanerPVCIsFound
+			continue
+		}
+
+		if !errors.IsNotFound(err) {
+			return skipReason, err
+		}
+
+		err = c.deletePod(node, pod.Name)
+		if err != nil {
+			return skipReason, err
+		}
+	}
+
+	return skipReason, nil
+}
+
+func (c *Controller) deletePod(node *pv1alpha1.DMNode, podName string) error {
+	ns := node.Namespace
+	nodeName := node.Name
+	err := c.kubeclientset.CoreV1().Pods(ns).Delete(podName, nil)
+	if err != nil {
+		klog.Errorf("failed to delete Pod: [%s/%s], DMNode: %s, %v", ns, podName, nodeName, err)
+	} else {
+		klog.V(4).Infof("delete Pod: [%s/%s] successfully, DMNode: %s", ns, podName, nodeName)
+	}
+	c.recordPodEvent("delete", node, podName, err)
+	return err
+}
+
+func (c *Controller) recordPodEvent(verb string, node *pv1alpha1.DMNode, podName string, err error) {
+	nodeName := node.GetName()
+	if err == nil {
+		reason := fmt.Sprintf("Successful%s", strings.Title(verb))
+		msg := fmt.Sprintf("%s Pod %s in DMNode %s successful",
+			strings.ToLower(verb), podName, nodeName)
+		c.recorder.Event(node, corev1.EventTypeNormal, reason, msg)
+	} else {
+		reason := fmt.Sprintf("Failed%s", strings.Title(verb))
+		msg := fmt.Sprintf("%s Pod %s in DMNode %s failed error: %s",
+			strings.ToLower(verb), podName, nodeName, err)
+		c.recorder.Event(node, corev1.EventTypeWarning, reason, msg)
+	}
+}

--- a/operator/pkg/controller/configmap.go
+++ b/operator/pkg/controller/configmap.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"strings"
+
+	pv1alpha1 "github.com/pingcap/dm/operator/pkg/apis/pingcap.com/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog"
+)
+
+func (c *Controller) syncNodeConfigMap(node *pv1alpha1.DMNode) error {
+	var newCM corev1.ConfigMap
+	var err error
+	ns := node.Namespace
+	name := node.Name
+	component := node.Labels[componentKey]
+	if component == componentMaster {
+		newCM, err = getNewMasterNodeConfigMap(node)
+		if err != nil {
+			return err
+		}
+	} else {
+		newCM, err = getNewWorkerNodeConfigMap(node)
+		if err != nil {
+			return err
+		}
+	}
+
+	oldCMTmp, err := c.configmapsLister.ConfigMaps(ns).Get(name)
+	if errors.IsNotFound(err) {
+		err = setConfigMapLastAppliedConfigAnnotation(&newCM)
+		if err != nil {
+			return err
+		}
+		return c.CreateConfigMap(node, &newCM)
+	}
+	if err != nil {
+		return err
+	}
+
+	oldCM := oldCMTmp.DeepCopy()
+
+	equal, err := configmapEqual(&newCM, oldCM)
+	if err != nil {
+		return err
+	}
+	if !equal {
+		cm := *oldCM
+		cm.Data = newCM.Data
+		// TODO add unit test
+		err = setConfigMapLastAppliedConfigAnnotation(&cm)
+		if err != nil {
+			return err
+		}
+		_, err = c.UpdateConfigMap(node, &cm)
+		return err
+	}
+
+	return nil
+}
+
+//CreateConfigMap create new configmap
+func (c *Controller) CreateConfigMap(node *pv1alpha1.DMNode, cm *corev1.ConfigMap) error {
+	_, err := c.kubeclientset.CoreV1().ConfigMaps(cm.Namespace).Create(cm)
+	if errors.IsAlreadyExists(err) {
+		return err
+	}
+	c.recordConfigMapEvent("create", node, cm, err)
+	return err
+}
+
+//UpdateConfigMap update a configmap
+func (c *Controller) UpdateConfigMap(node *pv1alpha1.DMNode, cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	ns := cm.Namespace
+	cmName := cm.Name
+	cmData := make(map[string]string)
+	for k, v := range cm.Data {
+		cmData[k] = v
+	}
+
+	var updateCM *corev1.ConfigMap
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var updateErr error
+		updateCM, updateErr = c.kubeclientset.CoreV1().ConfigMaps(ns).Update(cm)
+		if updateErr == nil {
+			klog.Infof("update ConfigMap: [%s/%s] successfully", ns, cmName)
+			return nil
+		}
+		klog.Errorf("update ConfigMap: [%s/%s] error: %v", ns, cmName, updateErr)
+		if updated, err := c.configmapsLister.ConfigMaps(ns).Get(cmName); err != nil {
+			utilruntime.HandleError(fmt.Errorf("error getting updated ConfigMap %s/%s from lister: %v", ns, cmName, err))
+		} else {
+			cm = updated.DeepCopy()
+			cm.Data = cmData
+		}
+
+		return updateErr
+	})
+	c.recordConfigMapEvent("update", node, cm, err)
+	return updateCM, err
+}
+
+//DeleteConfigMap delete a configmap
+func (c *Controller) DeleteConfigMap(node *pv1alpha1.DMNode, cm *corev1.ConfigMap) error {
+	err := c.kubeclientset.CoreV1().ConfigMaps(cm.Namespace).Delete(cm.Name, nil)
+	c.recordConfigMapEvent("delete", node, cm, err)
+	return err
+}
+
+func (c *Controller) recordConfigMapEvent(verb string, node *pv1alpha1.DMNode, cm *corev1.ConfigMap, err error) {
+	name := cm.Name
+	ns := cm.Namespace
+	if err == nil {
+		reason := fmt.Sprintf("Successful%s", strings.Title(verb))
+		msg := fmt.Sprintf("%s ConfigMap %s/%s successful",
+			strings.ToLower(verb), ns, name)
+		c.recorder.Event(node, corev1.EventTypeNormal, reason, msg)
+	} else {
+		reason := fmt.Sprintf("Failed%s", strings.Title(verb))
+		msg := fmt.Sprintf("%s ConfigMap %s/%s failed error: %s",
+			strings.ToLower(verb), ns, name, err)
+		c.recorder.Event(node, corev1.EventTypeWarning, reason, msg)
+	}
+}

--- a/operator/pkg/controller/pvc.go
+++ b/operator/pkg/controller/pvc.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"strings"
+
+	pv1alpha1 "github.com/pingcap/dm/operator/pkg/apis/pingcap.com/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+)
+
+func (c *Controller) syncReclaimPolicy(node *pv1alpha1.DMNode) error {
+	ns := node.Namespace
+	instanceName := node.Labels[instanceKey]
+
+	l := labels.Set{instanceKey: instanceName}.AsSelector()
+
+	pvcs, err := c.pvcLister.PersistentVolumeClaims(ns).List(l)
+	if err != nil {
+		return err
+	}
+
+	for _, pvc := range pvcs {
+		if pvc.Spec.VolumeName == "" {
+			continue
+		}
+		pvName := pvc.Spec.VolumeName
+		pv, err := c.pvLister.Get(pvName)
+		if err != nil {
+			return err
+		}
+
+		if pv.Spec.PersistentVolumeReclaimPolicy == node.Spec.PVReclaimPolicy {
+			continue
+		}
+
+		patchBytes := []byte(fmt.Sprintf(`{"spec":{"persistentVolumeReclaimPolicy":"%s"}}`, node.Spec.PVReclaimPolicy))
+
+		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			_, err := c.kubeclientset.CoreV1().PersistentVolumes().Patch(pvName, types.StrategicMergePatchType, patchBytes)
+			return err
+		})
+		c.recordPVEvent("patch", node, pvName, err)
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Controller) recordPVEvent(verb string, node *pv1alpha1.DMNode, pvName string, err error) {
+	nodeName := node.Name
+	if err == nil {
+		reason := fmt.Sprintf("Successful%s", strings.Title(verb))
+		msg := fmt.Sprintf("%s PV %s in DMNode %s successful",
+			strings.ToLower(verb), pvName, nodeName)
+		c.recorder.Event(node, corev1.EventTypeNormal, reason, msg)
+	} else {
+		reason := fmt.Sprintf("Failed%s", strings.Title(verb))
+		msg := fmt.Sprintf("%s PV %s in DMNode %s failed error: %s",
+			strings.ToLower(verb), pvName, nodeName, err)
+		c.recorder.Event(node, corev1.EventTypeWarning, reason, msg)
+	}
+}


### PR DESCRIPTION
Support dm on k8s

<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add configmap, pv, pvc and cleaner functions

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
