### PR TITLE
worker: fix subtask initialized state

### DIFF
--- a/dm/worker/subtask.go
+++ b/dm/worker/subtask.go
@@ -109,6 +109,7 @@ func (st *SubTask) Init() error {
 
 	st.DDLInfo = make(chan *pb.DDLInfo, 1)
 
+	initializeUnitSuccess := true
 	// when error occurred, initialized units should be closed
 	// when continue sub task from loader / syncer, ahead units should be closed
 	var needCloseUnits []unit.Unit
@@ -117,7 +118,7 @@ func (st *SubTask) Init() error {
 			u.Close()
 		}
 
-		st.initialized.Set(len(needCloseUnits) == 0)
+		st.initialized.Set(initializeUnitSuccess)
 	}()
 
 	// every unit does base initialization in `Init`, and this must pass before start running the sub task
@@ -126,6 +127,7 @@ func (st *SubTask) Init() error {
 	for i, u := range st.units {
 		err := u.Init()
 		if err != nil {
+			initializeUnitSuccess = false
 			// when init fail, other units initialized before should be closed
 			for j := 0; j < i; j++ {
 				needCloseUnits = append(needCloseUnits, st.units[j])
@@ -140,6 +142,7 @@ func (st *SubTask) Init() error {
 		u := st.units[i]
 		isFresh, err := u.IsFreshTask()
 		if err != nil {
+			initializeUnitSuccess = false
 			return terror.Annotatef(err, "fail to get fresh status of subtask %s %s", st.cfg.Name, u.Type())
 		} else if !isFresh {
 			skipIdx = i

--- a/tests/initial_unit/run.sh
+++ b/tests/initial_unit/run.sh
@@ -75,7 +75,14 @@ function run() {
 
         check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
 
+        run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
+            "resume-task test" \
+            "\"result\": true" 1 \
+            "\"result\": false" 1 \
+            "current stage is not paused not valid" 1
+
         cleanup_process
+        cleanup_data initial_unit
         run_sql "drop database if exists dm_meta" $TIDB_PORT
     done
 }

--- a/tests/initial_unit/run.sh
+++ b/tests/initial_unit/run.sh
@@ -82,7 +82,7 @@ function run() {
             "current stage is not paused not valid" 1
 
         cleanup_process
-        cleanup_data initial_unit
+        run_sql "drop database if exists initial_unit" $TIDB_PORT
         run_sql "drop database if exists dm_meta" $TIDB_PORT
     done
 }


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

A subtask can transform from `paused` to `running` state by `resume-task`, but we should not allow a subtask to `resume` in running state.

<img width="438" alt="WX20190819-145932@2x" src="https://user-images.githubusercontent.com/1527315/63245207-18499500-c292-11e9-9350-626bfbc67467.png">

When we create a new subtask, its state is `New`, and then we call `Init` of this task to initialize all the units of it, then the `initialized` flag will be set to true.
In the old logic, assuming there is a subtask with mode `all` and is running under sync unit, we stop it and restart from task config. Then it will not correctly set the `initialized` value.

### What is changed and how it works?
Use a variable to record where subtask initialization is successful.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes
