### PR TITLE
syncer: ignore error may skip execute some ddls

### DIFF
--- a/syncer/db_test.go
+++ b/syncer/db_test.go
@@ -175,6 +175,8 @@ func (s *testSyncerSuite) TestExecuteSQLSWithIgnore(c *C) {
 	n, err = conn.executeSQL(tctx, sqls)
 	c.Assert(err, ErrorMatches, ".*column a already exists")
 	c.Assert(n, Equals, 0)
+
+	c.Assert(mock.ExpectationsWereMet(), IsNil)
 }
 
 func (s *testDBSuite) TestTimezone(c *C) {

--- a/syncer/db_test.go
+++ b/syncer/db_test.go
@@ -171,6 +171,7 @@ func (s *testSyncerSuite) TestExecuteSQLSWithIgnore(c *C) {
 	// will return error when execute the first sql
 	mock.ExpectBegin()
 	mock.ExpectExec("alter table t1 add column a int").WillReturnError(newMysqlErr(uint16(infoschema.ErrColumnExists.Code()), "column a already exists"))
+	mock.ExpectRollback()
 
 	n, err = conn.executeSQL(tctx, sqls)
 	c.Assert(err, ErrorMatches, ".*column a already exists")

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -890,10 +890,7 @@ func (s *Syncer) sync(ctx *tcontext.Context, queueBucket string, db *Conn, jobCh
 				if sqlJob.ddlExecItem != nil && sqlJob.ddlExecItem.req != nil && !sqlJob.ddlExecItem.req.Exec {
 					s.tctx.L().Info("ignore sharding DDLs", zap.Strings("ddls", sqlJob.ddls))
 				} else {
-					_, err = db.executeSQL(s.tctx, sqlJob.ddls)
-					if err != nil && ignoreDDLError(err) {
-						err = nil
-					}
+					_, err = db.executeSQLWithIgnore(s.tctx, ignoreDDLError, sqlJob.ddls)
 
 					if s.tracer.Enable() {
 						syncerJobState := s.tracer.FinishedSyncerJobState(err)

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -1247,7 +1247,7 @@ func (s *testSyncerSuite) TestSharding(c *C) {
 		mock.ExpectBegin()
 		e := newMysqlErr(1050, "Table exist")
 		mock.ExpectExec("CREATE TABLE").WillReturnError(e)
-		mock.ExpectRollback()
+		mock.ExpectCommit()
 
 		// mock get table in first handle RowEvent
 		mock.ExpectQuery("SHOW COLUMNS").WillReturnRows(


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
for example:
execute ddl in upstream `alter table t1 add column a int, add column b int`, syncer will split it to two ddls:
ddl1 `alter table t1 add column a int`
ddl2 `alter table t1 add column b int`

syncer will execute sqls ddl1 and ddl2 together, and if execute ddl1 meet error and this error can be ignored, will skip execute ddl2. 

### What is changed and how it works?
fix it, judge whether error can be ignored when execute sql, if can ignore will continue execute next sql.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
