### PR TITLE
tests: fix sync diff config in test cases

### DIFF
--- a/tests/dmctl_basic/conf/diff_config.toml
+++ b/tests/dmctl_basic/conf/diff_config.toml
@@ -22,7 +22,7 @@ tables = ["t_target"]
 [[table-config]]
 schema = "dmctl"
 table = "t_target"
-remove-columns = ["id"]
+ignore-columns = ["id"]
 is-sharding = true
 index-fields = "b"
 

--- a/tests/print_status/conf/diff_config.toml
+++ b/tests/print_status/conf/diff_config.toml
@@ -25,7 +25,7 @@ tables = ["~t.*"]
 schema = "print_status"
 table = "t_1"
 # currently ignore check float and timestamp field
-remove-columns = ["c5", "c9", "c11", "c15"]
+ignore-columns = ["c5", "c9", "c11", "c15"]
 
 [[table-config.source-tables]]
 instance-id = "source-1"

--- a/tests/sequence_sharding/conf/diff_config.toml
+++ b/tests/sequence_sharding/conf/diff_config.toml
@@ -22,7 +22,7 @@ tables = ["t_target"]
 [[table-config]]
 schema = "sharding_target2"
 table = "t_target"
-remove-columns = ["id"]
+ignore-columns = ["id"]
 is-sharding = true
 index-fields = "uid"
 # range-placeholder

--- a/tests/sharding/conf/diff_config.toml
+++ b/tests/sharding/conf/diff_config.toml
@@ -23,7 +23,7 @@ tables = ["t_target"]
 schema = "db_target"
 table = "t_target"
 # currently sync_diff does not support json fields well
-remove-columns = ["id", "info_json"]
+ignore-columns = ["id", "info_json"]
 is-sharding = true
 index-fields = "uid"
 # range-placeholder


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
After this pr https://github.com/pingcap/tidb-tools/pull/248, `remove-columns` is removed from `sync_diff_inspector`, let's make test cases compatible with the latest `sync_diff_inspector`

### What is changed and how it works?
Replace `remove-columns` with `ignore-columns` in `sync_diff_inspector` config in test cases

NOTE:
- to pass the CI for this pr, we should change the dm_ghpr_test test script, use the latest download link for `syncer_diff_inspector`, http://download.pingcap.org/tidb-enterprise-tools-latest-linux-amd64.tar.gz
- after this pr is merged, we can change the download link permanently, both in dm_ghpr_test and test_dm_master

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

Side effects

Related changes
