### PR TITLE
pkg/retry: add some retryable error

### DIFF
--- a/pkg/retry/errors.go
+++ b/pkg/retry/errors.go
@@ -27,7 +27,7 @@ func IsRetryableError(err error) bool {
 	if ok {
 		switch mysqlErr.Number {
 		// ER_LOCK_DEADLOCK can retry to commit while meet deadlock
-		case tmysql.ErrUnknown, gmysql.ER_LOCK_DEADLOCK, tmysql.ErrPDServerTimeout, tmysql.ErrTiKVServerTimeout, tmysql.ErrTiKVServerBusy, tmysql.ErrResolveLockTimeout, tmysql.ErrRegionUnavailable:
+		case tmysql.ErrUnknown, gmysql.ER_LOCK_DEADLOCK, tmysql.ErrPDServerTimeout, tmysql.ErrTiKVServerTimeout, tmysql.ErrTiKVServerBusy, tmysql.ErrResolveLockTimeout, tmysql.ErrRegionUnavailable, tmysql.ErrQueryInterrupted, tmysql.ErrWriteConflictInTiDB, tmysql.ErrTableLocked, tmysql.ErrWriteConflict:
 			return true
 		default:
 			return false


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
some tidb error can be resolved  by retry, add some retryable error type

### What is changed and how it works?
add some error

ErrQueryInterrupted: query execution was interrupted by user
ErrWriteConflictInTiDB: commit meets an write conflict error
ErrWriteConflict:  similar with ErrWriteConflictInTiDB
ErrTableLocked:  the table was locked by other session, can retry success when other session release the lock.
