### PR TITLE
dm-worker: fix lock acquire starvation

### DIFF
--- a/dm/worker/worker.go
+++ b/dm/worker/worker.go
@@ -530,8 +530,8 @@ func (w *Worker) ForbidPurge() (bool, string) {
 	}
 
 	// forbid purging if some sub tasks are paused, so we can debug the system easily
-	// This function is not protected by `w.lock`, this may lead to sub tasks information
-	// not up to date, but this does not affect correctness.
+	// This function is not protected by `w.RWMutex`, which may lead to sub tasks information
+	// not up to date, but do not affect correctness.
 	for _, st := range w.subTaskHolder.getAllSubTasks() {
 		stage := st.Stage()
 		if stage == pb.Stage_New || stage == pb.Stage_Paused {


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

DM-worker must be shutdown gracefully after receiving `kill` or `kill -hup`, but some condition exists lock acquire starvation and `worker.Close()` will not end.

one scenario is as follows:

`worker.Close()`, w acquired a lock -> `w.relayPurger.Close()` -> relayPurger.wg.Wait(), wait relayPurger.run ends
`relayPurger.run` -> ticker trigger, tryPurge -> interceptor, aka `*Worker` call `ForbidPurge()`, which will try to acquire `worker.RLock`

we can wrap Mutex with some atomic operation to achieve `TryLock` feature, but I think it is over-optimization for this scenario.

### What is changed and how it works?

remove lock protection in `ForbidPurge`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes
