### PR TITLE
dm-worker: fix panic in query status

### DIFF
--- a/dm/worker/status.go
+++ b/dm/worker/status.go
@@ -93,7 +93,7 @@ func (w *Worker) Status(stName string) []*pb.SubTaskStatus {
 			if cu != nil {
 				stStatus.Unit = cu.Type()
 				// oneof status
-				us := st.Status()
+				us := cu.Status()
 				switch stStatus.Unit {
 				case pb.UnitType_Check:
 					stStatus.Status = &pb.SubTaskStatus_Check{Check: us.(*pb.CheckStatus)}

--- a/dm/worker/status.go
+++ b/dm/worker/status.go
@@ -161,7 +161,7 @@ func (w *Worker) Error(stName string) []*pb.SubTaskError {
 			}
 
 			// oneof error
-			us := st.Error()
+			us := cu.Error()
 			switch cu.Type() {
 			case pb.UnitType_Check:
 				stError.Error = &pb.SubTaskError_Check{Check: us.(*pb.CheckError)}


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix panic

```
panic: interface conversion: interface {} is *pb.LoadStatus, not *pb.DumpStatus

goroutine 176025 [running]:
github.com/pingcap/dm/dm/worker.(*Worker).Status(0xc000108000, 0x0, 0x0, 0x2, 0x2, 0xc0003202c0)
        /home/jenkins/workspace/build_dm_master/go/src/github.com/pingcap/dm/dm/worker/status.go:101 +0xb1d
github.com/pingcap/dm/dm/worker.(*Worker).QueryStatus(0xc000108000, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/jenkins/workspace/build_dm_master/go/src/github.com/pingcap/dm/dm/worker/worker.go:312 +0xf5
github.com/pingcap/dm/dm/worker.(*Server).QueryStatus(0xc000554040, 0x18dee00, 0xc00556e6c0, 0xc00bd48170, 0xc000554040, 0xc00556e6c0, 0xc0002a3bd0)
        /home/jenkins/workspace/build_dm_master/go/src/github.com/pingcap/dm/dm/worker/server.go:244 +0x2a0
github.com/pingcap/dm/dm/pb._Worker_QueryStatus_Handler(0x15fcd80, 0xc000554040, 0x18dee00, 0xc00556e6c0, 0xc0088b9e60, 0x0, 0x18dee00, 0xc00556e6c0, 0x0, 0x0)
        /home/jenkins/workspace/build_dm_master/go/src/github.com/pingcap/dm/dm/pb/dmworker.pb.go:3851 +0x23e
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0003622c0, 0x18f3760, 0xc0004f5e00, 0xc00043ee00, 0xc00041bad0, 0x2a8aca8, 0x0, 0x0, 0x0)
        /go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:995 +0x4ab
google.golang.org/grpc.(*Server).handleStream(0xc0003622c0, 0x18f3760, 0xc0004f5e00, 0xc00043ee00, 0x0)
        /go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:1275 +0xda6
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0003f4ae0, 0xc0003622c0, 0x18f3760, 0xc0004f5e00, 0xc00043ee00)
        /go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:710 +0x9f
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:708 +0xa1
```

### What is changed and how it works?
use the same `unit.Unit` object when we check its type and status

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
   - Fix a potential panic bug when we query-status during subtask unit transforming between different units.
