### PR TITLE
checker: keep the original database error in the error message (#276)

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -126,7 +126,7 @@ func (c *Checker) Init() (err error) {
 		}
 		instance.sourceDB, err = dbutil.OpenDB(*instance.sourceDBinfo)
 		if err != nil {
-			return terror.WithScope(terror.ErrTaskCheckFailedOpenDB.Generate(instance.cfg.From.User, instance.cfg.From.Host, instance.cfg.From.Port), terror.ScopeUpstream)
+			return terror.WithScope(terror.ErrTaskCheckFailedOpenDB.Delegate(err, instance.cfg.From.User, instance.cfg.From.Host, instance.cfg.From.Port), terror.ScopeUpstream)
 		}
 
 		instance.targetDBInfo = &dbutil.DBConfig{
@@ -137,7 +137,7 @@ func (c *Checker) Init() (err error) {
 		}
 		instance.targetDB, err = dbutil.OpenDB(*instance.targetDBInfo)
 		if err != nil {
-			return terror.WithScope(terror.ErrTaskCheckFailedOpenDB.Generate(instance.cfg.To.User, instance.cfg.To.Host, instance.cfg.To.Port), terror.ScopeDownstream)
+			return terror.WithScope(terror.ErrTaskCheckFailedOpenDB.Delegate(err, instance.cfg.To.User, instance.cfg.To.Host, instance.cfg.To.Port), terror.ScopeDownstream)
 		}
 
 		if _, ok := c.checkingItems[config.VersionChecking]; ok {


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

**cherry-pick #276**

keep the original database error in the error message for checker.

### What is changed and how it works?

use `Error.Delegate` to replace `Error.Generate`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
	 1. set a wrong password for DM-worker
	 2. `start-task`
	 	the original error message is 
		```
		[code=26002:class=dm-master:scope=upstream:level=high] fail to initial checker: failed to open DSN root:***@127.0.0.1:3306\ngithub.com/pingcap/dm/pkg/terror.(*Error).Generate\n\t/Users/zhangxc/gopath/src/github.com/pingcap/dm/pkg/terror/terror.go:232\ngithub.com/pingcap/dm/checker.(*Checker).Init\n\t/Users/zhangxc/gopath/src/github.com/pingcap/dm/checker/checker.go:129\ngithub.com/pingcap/dm/checker.CheckSyncConfig\n\t/Users/zhangxc/gopath/src/github.com/pingcap/dm/checker/cmd.go:50\ngithub.com/pingcap/dm/dm/master.(*Server).generateSubTask\n\t/Users/zhangxc/gopath/src/github.com/pingcap/dm/dm/master/server.go:1847\ngithub.com/pingcap/dm/dm/master.(*Server).StartTask\n\t/Users/zhangxc/gopath/src/github.com/pingcap/dm/dm/master/server.go:220\ngithub.com/pingcap/dm/dm/pb._Master_StartTask_Handler\n\t/Users/zhangxc/gopath/src/github.com/pingcap/dm/dm/pb/dmmaster.pb.go:1530\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/Users/zhangxc/gopath/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:995\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/Users/zhangxc/gopath/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:1275\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.1\n\t/Users/zhangxc/gopath/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:710\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1337
		```
		the error message now is
		```
		[code=26002:class=dm-master:scope=upstream:level=high] fail to initial checker: failed to open DSN root:***@127.0.0.1:3306: Error 1045: Access denied for user 'root'@'172.18.0.1' (using password: YES)\ngithub.com/pingcap/dm/pkg/terror.(*Error).Delegate\n\t/Users/zhangxc/gopath/src/github.com/pingcap/dm/pkg/terror/terror.go:267\ngithub.com/pingcap/dm/checker.(*Checker).Init\n\t/Users/zhangxc/gopath/src/github.com/pingcap/dm/checker/checker.go:129\ngithub.com/pingcap/dm/checker.CheckSyncConfig\n\t/Users/zhangxc/gopath/src/github.com/pingcap/dm/checker/cmd.go:50\ngithub.com/pingcap/dm/dm/master.(*Server).generateSubTask\n\t/Users/zhangxc/gopath/src/github.com/pingcap/dm/dm/master/server.go:1847\ngithub.com/pingcap/dm/dm/master.(*Server).StartTask\n\t/Users/zhangxc/gopath/src/github.com/pingcap/dm/dm/master/server.go:220\ngithub.com/pingcap/dm/dm/pb._Master_StartTask_Handler\n\t/Users/zhangxc/gopath/src/github.com/pingcap/dm/dm/pb/dmmaster.pb.go:1530\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/Users/zhangxc/gopath/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:995\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/Users/zhangxc/gopath/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:1275\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.1\n\t/Users/zhangxc/gopath/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:710\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1337
		```

Related changes

 - Need to cherry-pick to the release branch
