### PR TITLE
syncer: fix in-memory tps count

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -687,6 +687,7 @@ func (s *Syncer) getTable(schema string, table string) (*table, []string, error)
 func (s *Syncer) addCount(isFinished bool, queueBucket string, tp opType, n int64) {
 	m := addedJobsTotal
 	if isFinished {
+		s.count.Add(n)
 		m = finishedJobsTotal
 	}
 
@@ -708,8 +709,6 @@ func (s *Syncer) addCount(isFinished bool, queueBucket string, tp opType, n int6
 	default:
 		s.tctx.L().Warn("unknown job operation type", zap.Stringer("type", tp))
 	}
-
-	s.count.Add(n)
 }
 
 func (s *Syncer) checkWait(job *job) bool {


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

in-memory job counter counts on both added jobs and finished jobs.

### What is changed and how it works?

count finished jobs only.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
