### PR TITLE
dm-worker: split DDL sync from sync function

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -902,12 +902,12 @@ func (s *Syncer) syncDDL(ctx *tcontext.Context, queueBucket string, db *Conn, dd
 			}
 			s.ddlExecInfo.ClearBlockingDDL()
 		}
+		s.jobWg.Done()
 		if err != nil {
 			s.execErrorDetected.Set(true)
 			s.runFatalChan <- unit.NewProcessError(pb.ErrorType_ExecSQL, errors.ErrorStack(err))
 			continue
 		}
-		s.jobWg.Done()
 		s.addCount(true, queueBucket, sqlJob.tp, int64(len(sqlJob.ddls)))
 	}
 }

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -856,6 +856,62 @@ func (s *Syncer) flushCheckPoints() error {
 	return nil
 }
 
+// DDL synced one by one, so we only need to process one DDL at a time
+func (s *Syncer) syncDDL(ctx *tcontext.Context, queueBucket string, db *Conn, ddlJobChan chan *job) {
+	defer s.wg.Done()
+
+	var err error
+	for {
+		sqlJob, ok := <-ddlJobChan
+		if !ok {
+			return
+		}
+
+		if sqlJob.ddlExecItem != nil && sqlJob.ddlExecItem.req != nil && !sqlJob.ddlExecItem.req.Exec {
+			s.tctx.L().Info("ignore sharding DDLs", zap.Strings("ddls", sqlJob.ddls))
+		} else {
+			_, err = db.executeSQLWithIgnore(s.tctx, ignoreDDLError, sqlJob.ddls)
+			if err != nil {
+				err = terror.WithScope(err, terror.ScopeDownstream)
+			}
+
+			if s.tracer.Enable() {
+				syncerJobState := s.tracer.FinishedSyncerJobState(err)
+				var execDDLReq *pb.ExecDDLRequest
+				if sqlJob.ddlExecItem != nil {
+					execDDLReq = sqlJob.ddlExecItem.req
+				}
+				_, traceErr := s.tracer.CollectSyncerJobEvent(sqlJob.traceID, sqlJob.traceGID, int32(sqlJob.tp), sqlJob.pos, sqlJob.currentPos, queueBucket, sqlJob.sql, sqlJob.ddls, nil, execDDLReq, syncerJobState)
+				if traceErr != nil {
+					s.tctx.L().Error("fail to collect binlog replication job event", log.ShortError(traceErr))
+				}
+			}
+		}
+		if err != nil {
+			s.appendExecErrors(&ExecErrorContext{
+				err:  err,
+				pos:  sqlJob.currentPos,
+				jobs: fmt.Sprintf("%v", sqlJob.ddls),
+			})
+		}
+
+		if s.cfg.IsSharding {
+			// for sharding DDL syncing, send result back
+			if sqlJob.ddlExecItem != nil {
+				sqlJob.ddlExecItem.resp <- err
+			}
+			s.ddlExecInfo.ClearBlockingDDL()
+		}
+		if err != nil {
+			s.execErrorDetected.Set(true)
+			s.runFatalChan <- unit.NewProcessError(pb.ErrorType_ExecSQL, errors.ErrorStack(err))
+			continue
+		}
+		s.jobWg.Done()
+		s.addCount(true, queueBucket, sqlJob.tp, int64(len(sqlJob.ddls)))
+	}
+}
+
 func (s *Syncer) sync(ctx *tcontext.Context, queueBucket string, db *Conn, jobChan chan *job) {
 	defer s.wg.Done()
 
@@ -919,58 +975,7 @@ func (s *Syncer) sync(ctx *tcontext.Context, queueBucket string, db *Conn, jobCh
 			}
 			idx++
 
-			if sqlJob.tp == ddl {
-				err = executeSQLs()
-				if err != nil {
-					fatalF(err, pb.ErrorType_ExecSQL)
-					continue
-				}
-
-				if sqlJob.ddlExecItem != nil && sqlJob.ddlExecItem.req != nil && !sqlJob.ddlExecItem.req.Exec {
-					s.tctx.L().Info("ignore sharding DDLs", zap.Strings("ddls", sqlJob.ddls))
-				} else {
-					_, err = db.executeSQLWithIgnore(s.tctx, ignoreDDLError, sqlJob.ddls)
-					if err != nil {
-						err = terror.WithScope(err, terror.ScopeDownstream)
-					}
-
-					if s.tracer.Enable() {
-						syncerJobState := s.tracer.FinishedSyncerJobState(err)
-						var execDDLReq *pb.ExecDDLRequest
-						if sqlJob.ddlExecItem != nil {
-							execDDLReq = sqlJob.ddlExecItem.req
-						}
-						_, traceErr := s.tracer.CollectSyncerJobEvent(sqlJob.traceID, sqlJob.traceGID, int32(sqlJob.tp), sqlJob.pos, sqlJob.currentPos, queueBucket, sqlJob.sql, sqlJob.ddls, nil, execDDLReq, syncerJobState)
-						if traceErr != nil {
-							s.tctx.L().Error("fail to collect binlog replication job event", log.ShortError(traceErr))
-						}
-					}
-				}
-				if err != nil {
-					s.appendExecErrors(&ExecErrorContext{
-						err:  err,
-						pos:  sqlJob.currentPos,
-						jobs: fmt.Sprintf("%v", sqlJob.ddls),
-					})
-				}
-
-				if s.cfg.IsSharding {
-					// for sharding DDL syncing, send result back
-					if sqlJob.ddlExecItem != nil {
-						sqlJob.ddlExecItem.resp <- err
-					}
-					s.ddlExecInfo.ClearBlockingDDL()
-				}
-				if err != nil {
-					// errro then pause.
-					fatalF(err, pb.ErrorType_ExecSQL)
-					continue
-				}
-
-				tpCnt[sqlJob.tp] += int64(len(sqlJob.ddls))
-				clearF()
-
-			} else if sqlJob.tp != flush && len(sqlJob.sql) > 0 {
+			if sqlJob.tp != flush && len(sqlJob.sql) > 0 {
 				jobs = append(jobs, sqlJob)
 				tpCnt[sqlJob.tp]++
 			}
@@ -1065,7 +1070,7 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 	go func() {
 		ctx2, cancel := context.WithCancel(ctx)
 		ctctx := s.tctx.WithContext(ctx2)
-		s.sync(ctctx, adminQueueName, s.ddlDB, s.jobs[s.cfg.WorkerCount])
+		s.syncDDL(ctctx, adminQueueName, s.ddlDB, s.jobs[s.cfg.WorkerCount])
 		cancel()
 	}()
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Optimize sync function 

### What is changed and how it works?
Split sync DDL from `sync()` because sync DDL and sync DML don't have to many common logic.
Split them to make the code clear.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `dm/dm-ansible`
 - Need to be included in the release note
