### PR TITLE
*: refine dmctl output for `DM-master`, `task-name` and `config-file`

### DIFF
--- a/dm/ctl/master/check_task.go
+++ b/dm/ctl/master/check_task.go
@@ -28,7 +28,7 @@ import (
 // NewCheckTaskCmd creates a CheckTask command
 func NewCheckTaskCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "check-task <config_file>",
+		Use:   "check-task <config-file>",
 		Short: "check a task with config file",
 		Run:   checkTaskFunc,
 	}

--- a/dm/ctl/master/pause_task.go
+++ b/dm/ctl/master/pause_task.go
@@ -26,7 +26,7 @@ import (
 // NewPauseTaskCmd creates a PauseTask command
 func NewPauseTaskCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "pause-task [-w worker ...] <task_name>",
+		Use:   "pause-task [-w worker ...] <task-name>",
 		Short: "pause a running task with name",
 		Run:   pauseTaskFunc,
 	}

--- a/dm/ctl/master/query_error.go
+++ b/dm/ctl/master/query_error.go
@@ -27,7 +27,7 @@ import (
 // NewQueryErrorCmd creates a QueryError command
 func NewQueryErrorCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "query-error [-w worker ...] [task_name]",
+		Use:   "query-error [-w worker ...] [task-name]",
 		Short: "query task's error",
 		Run:   queryErrorFunc,
 	}

--- a/dm/ctl/master/query_status.go
+++ b/dm/ctl/master/query_status.go
@@ -27,7 +27,7 @@ import (
 // NewQueryStatusCmd creates a QueryStatus command
 func NewQueryStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "query-status [-w worker ...] [task_name]",
+		Use:   "query-status [-w worker ...] [task-name]",
 		Short: "query task's status",
 		Run:   queryStatusFunc,
 	}

--- a/dm/ctl/master/resume_task.go
+++ b/dm/ctl/master/resume_task.go
@@ -26,7 +26,7 @@ import (
 // NewResumeTaskCmd creates a ResumeTask command
 func NewResumeTaskCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "resume-task [-w worker ...] <task_name>",
+		Use:   "resume-task [-w worker ...] <task-name>",
 		Short: "resume a paused task with name",
 		Run:   resumeTaskFunc,
 	}

--- a/dm/ctl/master/show_ddl_locks.go
+++ b/dm/ctl/master/show_ddl_locks.go
@@ -27,7 +27,7 @@ import (
 // NewShowDDLLocksCmd creates a ShowDDlLocks command
 func NewShowDDLLocksCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show-ddl-locks [-w worker ...] [task_name]",
+		Use:   "show-ddl-locks [-w worker ...] [task-name]",
 		Short: "show un-resolved DDL locks",
 		Run:   showDDLLocksFunc,
 	}

--- a/dm/ctl/master/sql_inject.go
+++ b/dm/ctl/master/sql_inject.go
@@ -28,7 +28,7 @@ import (
 // NewSQLInjectCmd creates a SQLInject command
 func NewSQLInjectCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "sql-inject <-w worker> <task_name> <sql1;sql2;>",
+		Use:   "sql-inject <-w worker> <task-name> <sql1;sql2;>",
 		Short: "sql-inject injects (limited) sqls into syncer as binlog event",
 		Run:   sqlInjectFunc,
 	}
@@ -54,7 +54,7 @@ func sqlInjectFunc(cmd *cobra.Command, _ []string) {
 
 	taskName := cmd.Flags().Arg(0)
 	if strings.TrimSpace(taskName) == "" {
-		common.PrintLines("task_name is empty")
+		common.PrintLines("task-name is empty")
 		return
 	}
 

--- a/dm/ctl/master/start_task.go
+++ b/dm/ctl/master/start_task.go
@@ -28,7 +28,7 @@ import (
 // NewStartTaskCmd creates a StartTask command
 func NewStartTaskCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "start-task [-w worker ...] <config_file>",
+		Use:   "start-task [-w worker ...] <config-file>",
 		Short: "start a task with config file",
 		Run:   startTaskFunc,
 	}

--- a/dm/ctl/master/stop_task.go
+++ b/dm/ctl/master/stop_task.go
@@ -26,7 +26,7 @@ import (
 // NewStopTaskCmd creates a StopTask command
 func NewStopTaskCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "stop-task [-w worker ...] <task_name>",
+		Use:   "stop-task [-w worker ...] <task-name>",
 		Short: "stop a task with name",
 		Run:   stopTaskFunc,
 	}

--- a/dm/ctl/master/update_masterconfig.go
+++ b/dm/ctl/master/update_masterconfig.go
@@ -27,8 +27,8 @@ import (
 // NewUpdateMasterConfigCmd creates a UpdateMasterConfig command
 func NewUpdateMasterConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update-master-config <config_file>",
-		Short: "update configure of dm-master",
+		Use:   "update-master-config <config-file>",
+		Short: "update configure of DM-master",
 		Run:   updateMasterConfigFunc,
 	}
 	return cmd

--- a/dm/ctl/master/update_relay.go
+++ b/dm/ctl/master/update_relay.go
@@ -27,7 +27,7 @@ import (
 // NewUpdateRelayCmd creates a UpdateRelay command
 func NewUpdateRelayCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update-relay [-w worker ...] <config_file>",
+		Use:   "update-relay [-w worker ...] <config-file>",
 		Short: "update dm-worker's relay unit configure",
 		Run:   updateRelayFunc,
 	}

--- a/dm/ctl/master/update_task.go
+++ b/dm/ctl/master/update_task.go
@@ -28,7 +28,7 @@ import (
 // NewUpdateTaskCmd creates a UpdateTask command
 func NewUpdateTaskCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update-task [-w worker ...] <config_file>",
+		Use:   "update-task [-w worker ...] <config-file>",
 		Short: "update a task's config for routes, filters, column-mappings, black-white-list",
 		Run:   updateTaskFunc,
 	}

--- a/tests/dmctl_advance/check_list/query_error.sh
+++ b/tests/dmctl_advance/check_list/query_error.sh
@@ -3,7 +3,7 @@
 function query_error_wrong_arg() {
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
         "query-error wrong_args_count more_than_one" \
-        "query-error \[-w worker ...\] \[task_name\]" 1
+        "query-error \[-w worker ...\] \[task-name\]" 1
 }
 
 function query_error_while_master_down() {

--- a/tests/dmctl_basic/check_list/check_task.sh
+++ b/tests/dmctl_basic/check_list/check_task.sh
@@ -3,7 +3,7 @@
 function check_task_wrong_arg() {
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
         "check-task" \
-        "check-task <config_file> \[flags\]" 1
+        "check-task <config-file> \[flags\]" 1
 }
 
 function check_task_wrong_config_file() {

--- a/tests/dmctl_basic/check_list/pause_task.sh
+++ b/tests/dmctl_basic/check_list/pause_task.sh
@@ -3,7 +3,7 @@
 function pause_task_wrong_arg() {
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
         "pause-task" \
-        "pause-task \[-w worker ...\] <task_name> \[flags\]" 1
+        "pause-task \[-w worker ...\] <task-name> \[flags\]" 1
 }
 
 function pause_task_while_master_down() {

--- a/tests/dmctl_basic/check_list/query_status.sh
+++ b/tests/dmctl_basic/check_list/query_status.sh
@@ -3,7 +3,7 @@
 function query_status_wrong_arg() {
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
         "query-status wrong_args_count more_than_one" \
-        "query-status \[-w worker ...\] \[task_name\]" 1
+        "query-status \[-w worker ...\] \[task-name\]" 1
 }
 
 function query_status_wrong_params() {

--- a/tests/dmctl_basic/check_list/resume_task.sh
+++ b/tests/dmctl_basic/check_list/resume_task.sh
@@ -3,7 +3,7 @@
 function resume_task_wrong_arg() {
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
         "resume-task" \
-        "resume-task \[-w worker ...\] <task_name> \[flags\]" 1
+        "resume-task \[-w worker ...\] <task-name> \[flags\]" 1
 }
 
 function resume_task_while_master_down() {

--- a/tests/dmctl_basic/check_list/show_ddl_locks.sh
+++ b/tests/dmctl_basic/check_list/show_ddl_locks.sh
@@ -3,13 +3,13 @@
 function show_ddl_locks_wrong_arg() {
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
         "show-ddl-locks a b" \
-        "show-ddl-locks \[-w worker ...\] \[task_name\] \[flags\]" 1
+        "show-ddl-locks \[-w worker ...\] \[task-name\] \[flags\]" 1
 }
 
 function show_ddl_locks_while_master_down() {
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
-        "show-ddl-locks task_name -w 127.0.0.1:8262" \
-        "can not show DDL locks for task task_name and workers \[127.0.0.1:8262\]" 1
+        "show-ddl-locks task-name -w 127.0.0.1:8262" \
+        "can not show DDL locks for task task-name and workers \[127.0.0.1:8262\]" 1
 }
 
 function show_ddl_locks_no_locks() {

--- a/tests/dmctl_basic/check_list/start_task.sh
+++ b/tests/dmctl_basic/check_list/start_task.sh
@@ -3,7 +3,7 @@
 function start_task_wrong_arg() {
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
         "start-task" \
-        "start-task \[-w worker ...\] <config_file> \[flags\]" 1
+        "start-task \[-w worker ...\] <config-file> \[flags\]" 1
 }
 
 function start_task_wrong_config_file() {

--- a/tests/dmctl_basic/check_list/stop_task.sh
+++ b/tests/dmctl_basic/check_list/stop_task.sh
@@ -3,7 +3,7 @@
 function stop_task_wrong_arg() {
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
         "stop-task" \
-        "stop-task \[-w worker ...\] <task_name> \[flags\]" 1
+        "stop-task \[-w worker ...\] <task-name> \[flags\]" 1
 }
 
 function stop_task_while_master_down() {

--- a/tests/dmctl_basic/check_list/update_master_config.sh
+++ b/tests/dmctl_basic/check_list/update_master_config.sh
@@ -3,7 +3,7 @@
 function update_master_config_wrong_arg() {
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
         "update-master-config" \
-        "update-master-config <config_file> \[flags\]" 1
+        "update-master-config <config-file> \[flags\]" 1
 }
 
 function update_master_config_wrong_config_file() {

--- a/tests/dmctl_basic/check_list/update_relay.sh
+++ b/tests/dmctl_basic/check_list/update_relay.sh
@@ -3,7 +3,7 @@
 function update_relay_wrong_arg() {
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
         "update-relay" \
-        "update-relay \[-w worker ...\] <config_file> \[flags\]" 1
+        "update-relay \[-w worker ...\] <config-file> \[flags\]" 1
 }
 
 function update_relay_wrong_config_file() {

--- a/tests/dmctl_basic/check_list/update_task.sh
+++ b/tests/dmctl_basic/check_list/update_task.sh
@@ -3,7 +3,7 @@
 function update_task_wrong_arg() {
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
         "update-task" \
-        "update-task \[-w worker ...\] <config_file> \[flags\]" 1
+        "update-task \[-w worker ...\] <config-file> \[flags\]" 1
 }
 
 function update_task_wrong_config_file() {


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

refine some name in the output of dmctl to match https://github.com/pingcap/docs-cn/pull/1878

### What is changed and how it works?

- rename `dm-master` to `DM-master`
- rename `task_name` to `task-name`
- rename `config_file` to `config-file`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
	 - run commands in dmctl, observe the output

Related changes

 - Need to cherry-pick to the release branch
