### PR TITLE
worker: fix potential panic when restoring subtask from meta

### DIFF
--- a/dm/worker/worker.go
+++ b/dm/worker/worker.go
@@ -82,7 +82,7 @@ func NewWorker(cfg *Config) (w *Worker, err error) {
 	w.ctx, w.cancel = context.WithCancel(context.Background())
 
 	defer func(w2 *Worker) {
-		if err != nil { // when err !=nil, `w` will become nil in this func, so we pass `w` in defer.
+		if err != nil { // when err != nil, `w` will become nil in this func, so we pass `w` in defer.
 			// release resources, NOTE: we need to refactor New/Init/Start/Close for components later.
 			w2.cancel()
 			w2.subTaskHolder.closeAllSubTasks()

--- a/dm/worker/worker.go
+++ b/dm/worker/worker.go
@@ -71,14 +71,29 @@ type Worker struct {
 }
 
 // NewWorker creates a new Worker
-func NewWorker(cfg *Config) (*Worker, error) {
-	w := &Worker{
+func NewWorker(cfg *Config) (w *Worker, err error) {
+	w = &Worker{
 		cfg:           cfg,
 		relayHolder:   NewRelayHolder(cfg),
 		tracer:        tracing.InitTracerHub(cfg.Tracer),
 		subTaskHolder: newSubTaskHolder(),
 		l:             log.With(zap.String("component", "worker controller")),
 	}
+	w.ctx, w.cancel = context.WithCancel(context.Background())
+
+	defer func(w2 *Worker) {
+		if err != nil { // when err !=nil, `w` will become nil in this func, so we pass `w` in defer.
+			// release resources, NOTE: we need to refactor New/Init/Start/Close for components later.
+			w2.cancel()
+			w2.subTaskHolder.closeAllSubTasks()
+			if w2.meta != nil {
+				w2.meta.Close()
+			}
+			if w2.db != nil {
+				w2.db.Close()
+			}
+		}
+	}(w)
 
 	// initial relay holder
 	purger, err := w.relayHolder.Init([]purger.PurgeInterceptor{
@@ -107,22 +122,36 @@ func NewWorker(cfg *Config) (*Worker, error) {
 	}
 
 	// open kv db
-	w.db, err = openDB(dbDir, defaultKVConfig)
+	metaDB, err := openDB(dbDir, defaultKVConfig)
 	if err != nil {
 		return nil, err
 	}
+	w.db = metaDB
 
 	// initial metadata
-	w.meta, err = NewMetadata(dbDir, w.db)
+	meta, err := NewMetadata(dbDir, w.db)
 	if err != nil {
 		return nil, err
 	}
+	w.meta = meta
 
 	InitConditionHub(w)
 
 	err = w.restoreSubTask()
 	if err != nil {
 		return nil, err
+	}
+
+	w.l.Info("initialized")
+
+	return w, nil
+}
+
+// Start starts working
+func (w *Worker) Start() {
+	if w.closed.Get() == closedTrue {
+		w.l.Warn("already closed")
+		return
 	}
 
 	// start relay
@@ -139,20 +168,6 @@ func NewWorker(cfg *Config) (*Worker, error) {
 	// start tracer
 	if w.tracer.Enable() {
 		w.tracer.Start()
-	}
-
-	w.ctx, w.cancel = context.WithCancel(context.Background())
-
-	w.l.Info("initialzed")
-
-	return w, nil
-}
-
-// Start starts working
-func (w *Worker) Start() {
-	if w.closed.Get() == closedTrue {
-		w.l.Warn("already closed")
-		return
 	}
 
 	w.wg.Add(2)

--- a/dm/worker/worker_test.go
+++ b/dm/worker/worker_test.go
@@ -108,7 +108,7 @@ func (t *testServer) testWorkerHandleTask(c *C) {
 		w.handleTask()
 	}()
 
-	c.Assert(utils.WaitSomething(5, 10*time.Millisecond, func() bool {
+	c.Assert(utils.WaitSomething(10, 100*time.Millisecond, func() bool {
 		w.meta.Lock()
 		defer w.meta.Unlock()
 		return len(w.meta.logs) == 0
@@ -154,7 +154,7 @@ func (t *testServer) TestTaskAutoResume(c *C) {
 		defer s.Close()
 		c.Assert(s.Start(), IsNil)
 	}()
-	c.Assert(utils.WaitSomething(30, 10*time.Millisecond, func() bool {
+	c.Assert(utils.WaitSomething(10, 100*time.Millisecond, func() bool {
 		return !s.closed.Get()
 	}), IsTrue)
 
@@ -165,7 +165,7 @@ func (t *testServer) TestTaskAutoResume(c *C) {
 	c.Assert(err, IsNil)
 
 	// check task in paused state
-	c.Assert(utils.WaitSomething(10, 10*time.Millisecond, func() bool {
+	c.Assert(utils.WaitSomething(10, 100*time.Millisecond, func() bool {
 		for _, st := range s.worker.QueryStatus(taskName) {
 			if st.Name == taskName && st.Stage == pb.Stage_Paused {
 				return true


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```golang
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x53b07e]

goroutine 47 [running]:
context.WithDeadline(0x0, 0x0, 0xbf5be448e73dc52d, 0x463dd73766, 0x2ad5a60, 0x0, 0x0, 0x0)
/usr/local/go/src/context/context.go:384 +0x4e
context.WithTimeout(0x0, 0x0, 0x45d964b800, 0xc001974200, 0x2, 0x2)
/usr/local/go/src/context/context.go:451 +0x6b
github.com/pingcap/dm/dm/worker.(*SubTask).unitTransWaitCondition(0xc000372e40, 0x0, 0x0)
/home/jenkins/workspace/build_dm_master/go/src/github.com/pingcap/dm/dm/worker/subtask.go:627 +0x3ca
github.com/pingcap/dm/dm/worker.(*SubTask).run(0xc000372e40)
/home/jenkins/workspace/build_dm_master/go/src/github.com/pingcap/dm/dm/worker/subtask.go:182 +0x5c
github.com/pingcap/dm/dm/worker.(*SubTask).fetchResult(0xc000372e40, 0xc0004a7560)
/home/jenkins/workspace/build_dm_master/go/src/github.com/pingcap/dm/dm/worker/subtask.go:248 +0xb28
created by github.com/pingcap/dm/dm/worker.(*SubTask).run
/home/jenkins/workspace/build_dm_master/go/src/github.com/pingcap/dm/dm/worker/subtask.go:196 +0x4a8
```

### What is changed and how it works?

before this PR, we have the following order in _worker.go_:
1. `InitConditionHub` registers `Worker` instances
2. `restoreSubTask` restores subtasks from meta
3. `w.ctx, w.cancel = context.WithCancel(context.Background())` inits `w.ctx` and `w.cancel`

but when restoring subtasks from meta, `w.ctx` may be used, then `nil` pointer will be accessed and panicked.

in this PR, we make sure have the following order:
1. `w.ctx, w.cancel = context.WithCancel(context.Background())` inits `w.ctx` and `w.cancel`
2. `InitConditionHub` registers `Worker` instances
3. `restoreSubTask` restores subtasks from meta

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
