### PR TITLE
syncer: fast fail on some error in ddl execution

### DIFF
--- a/pkg/retry/errors.go
+++ b/pkg/retry/errors.go
@@ -14,10 +14,35 @@
 package retry
 
 import (
+	"strings"
+
 	"github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	tmysql "github.com/pingcap/parser/mysql"
 	gmysql "github.com/siddontang/go-mysql/mysql"
+)
+
+var (
+	// UnsupportedDDLMsgs list the error messages of some unsupported DDL in TiDB
+	UnsupportedDDLMsgs = []string{
+		"can't drop column with index",
+		"unsupported add column",
+		"unsupported modify column",
+		"unsupported modify",
+		"unsupported drop integer primary key",
+	}
+
+	// UnsupportedDMLMsgs list the error messages of some un-recoverable DML, which is used in task auto recovery
+	UnsupportedDMLMsgs = []string{
+		"Error 1062: Duplicate entry",
+		"Error 1406: Data too long for column",
+	}
+
+	// ParseRelayLogErrMsgs list the error messages of some un-recoverable relay log parsing error, which is used in task auto recovery.
+	ParseRelayLogErrMsgs = []string{
+		"binlog checksum mismatch, data may be corrupted",
+		"get event err EOF",
+	}
 )
 
 // IsRetryableError tells whether this error should retry
@@ -34,4 +59,19 @@ func IsRetryableError(err error) bool {
 		}
 	}
 	return false
+}
+
+// IsRetryableErrorFastFailFilter tells whether this error should retry,
+// filtering some incompatible DDL error to achieve fast fail.
+func IsRetryableErrorFastFailFilter(err error) bool {
+	err2 := errors.Cause(err) // check the original error
+	if mysqlErr, ok := err2.(*mysql.MySQLError); ok && mysqlErr.Number == tmysql.ErrUnknown {
+		for _, msg := range UnsupportedDDLMsgs {
+			if strings.Contains(mysqlErr.Message, msg) {
+				return false
+			}
+		}
+	}
+
+	return IsRetryableError(err)
 }

--- a/syncer/db.go
+++ b/syncer/db.go
@@ -159,7 +159,7 @@ func (conn *Conn) executeSQLWithIgnore(tctx *tcontext.Context, ignoreError func(
 		FirstRetryDuration: retryTimeout,
 		BackoffStrategy:    retry.Stable,
 		IsRetryableFn: func(retryTime int, err error) bool {
-			if retry.IsRetryableError(err) {
+			if retry.IsRetryableErrorFastFailFilter(err) {
 				tctx.L().Warn("execute statements", zap.Int("retry", retryTime),
 					zap.String("queries", utils.TruncateInterface(queries, -1)),
 					zap.String("arguments", utils.TruncateInterface(args, -1)))


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

syncer doesn't need to retry on the unsupported DDL execution error, such as `can't drop column with index`, `unsupported drop integer primary key`, etc. Pause task directly with error is enough when meeting these errors.

### What is changed and how it works?

add error blacklist in db operation retryable decision

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
    Fast fail on some TiDB unsupported DDL error in the binlog replication unit.
