### PR TITLE
worker: generate index flavor automatically by querying version info from DB (#323)

### DIFF
--- a/tests/all_mode/conf/dm-worker1.toml
+++ b/tests/all_mode/conf/dm-worker1.toml
@@ -2,7 +2,7 @@
 
 server-id = 101
 source-id = "mysql-replica-01"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/all_mode/conf/dm-worker2.toml
+++ b/tests/all_mode/conf/dm-worker2.toml
@@ -2,7 +2,7 @@
 
 server-id = 102
 source-id = "mysql-replica-02"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/compatibility/conf/dm-worker1.toml
+++ b/tests/compatibility/conf/dm-worker1.toml
@@ -2,7 +2,7 @@
 
 server-id = 101
 source-id = "mysql-replica-01"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/compatibility/conf/dm-worker2.toml
+++ b/tests/compatibility/conf/dm-worker2.toml
@@ -2,7 +2,7 @@
 
 server-id = 102
 source-id = "mysql-replica-02"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/dmctl_basic/conf/dm-worker1.toml
+++ b/tests/dmctl_basic/conf/dm-worker1.toml
@@ -2,7 +2,7 @@
 
 server-id = 101
 source-id = "mysql-replica-01"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/dmctl_basic/conf/dm-worker2.toml
+++ b/tests/dmctl_basic/conf/dm-worker2.toml
@@ -2,7 +2,7 @@
 
 server-id = 102
 source-id = "mysql-replica-02"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/http_apis/conf/dm-worker1.toml
+++ b/tests/http_apis/conf/dm-worker1.toml
@@ -2,7 +2,7 @@
 
 server-id = 101
 source-id = "mysql-replica-01"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/incremental_mode/conf/dm-worker1.toml
+++ b/tests/incremental_mode/conf/dm-worker1.toml
@@ -2,7 +2,7 @@
 
 server-id = 101
 source-id = "mysql-replica-01"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/incremental_mode/conf/dm-worker2.toml
+++ b/tests/incremental_mode/conf/dm-worker2.toml
@@ -2,7 +2,7 @@
 
 server-id = 102
 source-id = "mysql-replica-02"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/initial_unit/conf/dm-worker1.toml
+++ b/tests/initial_unit/conf/dm-worker1.toml
@@ -2,7 +2,7 @@
 
 server-id = 101
 source-id = "mysql-replica-01"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/load_interrupt/conf/dm-worker1.toml
+++ b/tests/load_interrupt/conf/dm-worker1.toml
@@ -2,7 +2,7 @@
 
 server-id = 101
 source-id = "mysql-replica-01"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/load_interrupt/conf/dm-worker2.toml
+++ b/tests/load_interrupt/conf/dm-worker2.toml
@@ -2,7 +2,7 @@
 
 server-id = 102
 source-id = "mysql-replica-02"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/online_ddl/conf/dm-worker1.toml
+++ b/tests/online_ddl/conf/dm-worker1.toml
@@ -2,7 +2,7 @@
 
 server-id = 101
 source-id = "mysql-replica-01"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/online_ddl/conf/dm-worker2.toml
+++ b/tests/online_ddl/conf/dm-worker2.toml
@@ -2,7 +2,7 @@
 
 server-id = 102
 source-id = "mysql-replica-02"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/print_status/conf/dm-worker1.toml
+++ b/tests/print_status/conf/dm-worker1.toml
@@ -2,7 +2,7 @@
 
 server-id = 101
 source-id = "mysql-replica-01"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/relay_interrupt/conf/dm-worker1.toml
+++ b/tests/relay_interrupt/conf/dm-worker1.toml
@@ -2,7 +2,7 @@
 
 server-id = 101
 source-id = "mysql-replica-01"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/safe_mode/conf/dm-worker1.toml
+++ b/tests/safe_mode/conf/dm-worker1.toml
@@ -2,7 +2,7 @@
 
 server-id = 101
 source-id = "mysql-replica-01"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/safe_mode/conf/dm-worker2.toml
+++ b/tests/safe_mode/conf/dm-worker2.toml
@@ -2,7 +2,7 @@
 
 server-id = 102
 source-id = "mysql-replica-02"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/sequence_safe_mode/conf/dm-worker1.toml
+++ b/tests/sequence_safe_mode/conf/dm-worker1.toml
@@ -2,7 +2,7 @@
 
 server-id = 101
 source-id = "mysql-replica-01"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/sequence_safe_mode/conf/dm-worker2.toml
+++ b/tests/sequence_safe_mode/conf/dm-worker2.toml
@@ -2,7 +2,7 @@
 
 server-id = 102
 source-id = "mysql-replica-02"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/sequence_sharding/conf/dm-worker1.toml
+++ b/tests/sequence_sharding/conf/dm-worker1.toml
@@ -2,7 +2,7 @@
 
 server-id = 101
 source-id = "mysql-replica-01"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/sequence_sharding/conf/dm-worker2.toml
+++ b/tests/sequence_sharding/conf/dm-worker2.toml
@@ -2,7 +2,7 @@
 
 server-id = 102
 source-id = "mysql-replica-02"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/sharding/conf/dm-worker1.toml
+++ b/tests/sharding/conf/dm-worker1.toml
@@ -2,7 +2,7 @@
 
 server-id = 101
 source-id = "mysql-replica-01"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/sharding/conf/dm-worker2.toml
+++ b/tests/sharding/conf/dm-worker2.toml
@@ -2,7 +2,7 @@
 
 server-id = 102
 source-id = "mysql-replica-02"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""

--- a/tests/start_task/conf/dm-worker1.toml
+++ b/tests/start_task/conf/dm-worker1.toml
@@ -2,7 +2,7 @@
 
 server-id = 101
 source-id = "mysql-replica-01"
-flavor = "mysql"
+flavor = ""
 enable-gtid = false
 relay-binlog-name = ""
 relay-binlog-gtid = ""


### PR DESCRIPTION
cherry-pick #323 to release-1.0

---

<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
[TOOL-1166](https://internal.pingcap.net/jira/browse/TOOL-1166)
Now, we need to set flavor for DM-worker manually, but it may be set incorrectly.

### What is changed and how it works?
use `dbutil.ShowVersion` and `check.IsMariaDB` from [tidb-tools](https://github.com/pingcap/tidb-tools) to detect upstream MySQL/MariaDB server type and set flavor automatically.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
