### PR TITLE
*: only retry for special message with 1105

### DIFF
--- a/syncer/db.go
+++ b/syncer/db.go
@@ -238,7 +238,7 @@ func (conn *DBConn) executeSQLWithIgnore(tctx *tcontext.Context, ignoreError fun
 				sqlRetriesTotal.WithLabelValues("stmt_exec", conn.cfg.Name).Add(1)
 				return true
 			}
-			if retry.IsRetryableErrorFastFailFilter(err) {
+			if retry.IsRetryableError(err) {
 				tctx.L().Warn("execute statements", zap.Int("retry", retryTime),
 					zap.String("queries", utils.TruncateInterface(queries, -1)),
 					zap.String("arguments", utils.TruncateInterface(args, -1)))

--- a/syncer/error_test.go
+++ b/syncer/error_test.go
@@ -40,7 +40,6 @@ func (s *testSyncerSuite) TestIsRetryableError(c *C) {
 	}{
 		{newMysqlErr(tmysql.ErrNoDB, "no baseConn error"), false},
 		{errors.New("unknown error"), false},
-		{newMysqlErr(tmysql.ErrUnknown, "i/o timeout"), true},
 		{newMysqlErr(tmysql.ErrDBCreateExists, "baseConn already exists"), false},
 		{driver.ErrBadConn, false},
 		{newMysqlErr(gmysql.ER_LOCK_DEADLOCK, "Deadlock found when trying to get lock; try restarting transaction"), true},
@@ -49,6 +48,10 @@ func (s *testSyncerSuite) TestIsRetryableError(c *C) {
 		{newMysqlErr(tmysql.ErrTiKVServerBusy, "tikv server busy"), true},
 		{newMysqlErr(tmysql.ErrResolveLockTimeout, "resolve lock timeout"), true},
 		{newMysqlErr(tmysql.ErrRegionUnavailable, "region unavailable"), true},
+		{newMysqlErr(tmysql.ErrUnknown, "i/o timeout"), false},
+		{newMysqlErr(tmysql.ErrUnknown, "can't drop column with index"), false},
+		{newMysqlErr(tmysql.ErrUnknown, "Information schema is out of date"), true},
+		{newMysqlErr(tmysql.ErrUnknown, "Information schema is changed"), true},
 	}
 
 	for _, t := range cases {

--- a/tests/load_interrupt/run.sh
+++ b/tests/load_interrupt/run.sh
@@ -60,7 +60,7 @@ function run() {
     check_row_count 2
 
     # only failed at the first two time, will retry later and success
-    export GO_FAILPOINTS='github.com/pingcap/dm/loader/LoadExecCreateTableFailed=3*return("1105")'
+    export GO_FAILPOINTS='github.com/pingcap/dm/loader/LoadExecCreateTableFailed=3*return("1213")' # ER_LOCK_DEADLOCK, retryable error code
     run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
     run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`1105` means an unknown error in MySQL/TiDB. some of these errors are retryable, but some are not (like `error="Error 1105: statement count 5001 exceeds the transaction limitation`).

### What is changed and how it works?

only retry for retryable errors, now including:
- `Information schema is out of date`
- `Information schema is changed`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
