### PR TITLE
dm-ansible: don't add config in config file if not setted in inventory.ini

### DIFF
--- a/dm/dm-ansible/roles/dm-worker/templates/dm-worker.toml.j2
+++ b/dm/dm-ansible/roles/dm-worker/templates/dm-worker.toml.j2
@@ -1,11 +1,25 @@
 # Worker Configuration.
 
+{% if server_id|default(false) %}
 server-id = {{ server_id }}
+{% endif %}
+
 source-id = "{{ source_id }}"
+
+{% if flavor|default(false) %}
 flavor = "{{ flavor }}"
+{% endif %}
+
 enable-gtid = {{ enable_gtid }}
+
+{% if relay_binlog_name|default(false) %}
 relay-binlog-name = "{{ relay_binlog_name }}"
+{% endif %}
+
+{% if relay_binlog_gtid|default(false) %}
 relay-binlog-gtid = "{{ relay_binlog_gtid }}"
+{% endif %}
+
 #charset of DSN of source mysql/mariadb instance
 charset = ""
 meta-dir = ""


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
server-id, flavor, relay-binlog-name and relay-binlog-gtid is not necessary any more, so user may not set in inventory.ini when use ansible to deploy, but now it will return error "AnsibleUndefinedVariable: 'server_id' is undefined"

### test

manual test

### What is changed and how it works?
don't add config in config file if not setted in inventory.ini

Related changes

 - Need to cherry-pick to the release branch
