### PR TITLE
dmctl/:Clear workers cache before we run a command

### DIFF
--- a/dm/ctl/ctl.go
+++ b/dm/ctl/ctl.go
@@ -28,10 +28,7 @@ import (
 
 var (
 	commandMasterFlags = CommandMasterFlags{}
-	rootCmd            = &cobra.Command{
-		Use:   "dmctl",
-		Short: "DM control",
-	}
+	rootCmd            *cobra.Command
 )
 
 // CommandMasterFlags are flags that used in all commands for dm-master
@@ -45,6 +42,15 @@ func (c CommandMasterFlags) Reset() {
 }
 
 func init() {
+	rootCmd = NewRootCmd()
+}
+
+// NewRootCmd generates a new rootCmd
+func NewRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:   "dmctl",
+		Short: "DM control",
+	}
 	// --worker worker1 -w worker2 --worker=worker3,worker4 -w=worker5,worker6
 	rootCmd.PersistentFlags().StringSliceVarP(&commandMasterFlags.workers, "worker", "w", []string{}, "DM-worker ID")
 	rootCmd.AddCommand(
@@ -71,6 +77,7 @@ func init() {
 		master.NewPurgeRelayCmd(),
 		master.NewMigrateRelayCmd(),
 	)
+	return rootCmd
 }
 
 // Init initializes dm-control
@@ -122,6 +129,7 @@ func PrintHelp(args []string) {
 // Start starts running a command
 func Start(args []string) {
 	commandMasterFlags.Reset()
+	rootCmd = NewRootCmd()
 	rootCmd.SetArgs(args)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(rootCmd.UsageString())

--- a/dm/ctl/ctl.go
+++ b/dm/ctl/ctl.go
@@ -47,13 +47,13 @@ func init() {
 
 // NewRootCmd generates a new rootCmd
 func NewRootCmd() *cobra.Command {
-	rootCmd := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "dmctl",
 		Short: "DM control",
 	}
 	// --worker worker1 -w worker2 --worker=worker3,worker4 -w=worker5,worker6
-	rootCmd.PersistentFlags().StringSliceVarP(&commandMasterFlags.workers, "worker", "w", []string{}, "DM-worker ID")
-	rootCmd.AddCommand(
+	cmd.PersistentFlags().StringSliceVarP(&commandMasterFlags.workers, "worker", "w", []string{}, "DM-worker ID")
+	cmd.AddCommand(
 		master.NewStartTaskCmd(),
 		master.NewStopTaskCmd(),
 		master.NewPauseTaskCmd(),
@@ -77,7 +77,7 @@ func NewRootCmd() *cobra.Command {
 		master.NewPurgeRelayCmd(),
 		master.NewMigrateRelayCmd(),
 	)
-	return rootCmd
+	return cmd
 }
 
 // Init initializes dm-control

--- a/dm/ctl/ctl.go
+++ b/dm/ctl/ctl.go
@@ -116,6 +116,7 @@ func PrintHelp(args []string) {
 
 // Start starts running a command
 func Start(args []string) {
+	commandMasterFlags.workers = commandMasterFlags.workers[:0]
 	rootCmd.SetArgs(args)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(rootCmd.UsageString())

--- a/dm/ctl/ctl.go
+++ b/dm/ctl/ctl.go
@@ -39,6 +39,11 @@ type CommandMasterFlags struct {
 	workers []string // specify workers to control on these dm-workers
 }
 
+// Reset clears cache of CommandMasterFlags
+func (c CommandMasterFlags) Reset() {
+	c.workers = c.workers[:0]
+}
+
 func init() {
 	// --worker worker1 -w worker2 --worker=worker3,worker4 -w=worker5,worker6
 	rootCmd.PersistentFlags().StringSliceVarP(&commandMasterFlags.workers, "worker", "w", []string{}, "DM-worker ID")
@@ -116,7 +121,7 @@ func PrintHelp(args []string) {
 
 // Start starts running a command
 func Start(args []string) {
-	commandMasterFlags.workers = commandMasterFlags.workers[:0]
+	commandMasterFlags.Reset()
 	rootCmd.SetArgs(args)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(rootCmd.UsageString())


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. Every time we run command in dmctl with -w arg the argument worker will be accumulated which doesn't match our expectations.
![image](https://user-images.githubusercontent.com/21104942/69206336-57d09780-0b87-11ea-9a4d-000b80cb3b19.png)
2. After we set flag to rootCmd, the value will be kept. Although we don't specify this arg in the next time. it still has a value.
![image](https://user-images.githubusercontent.com/21104942/69208983-8acb5900-0b90-11ea-93d4-c011f5678f52.png)

### What is changed and how it works?
1. Clear workers array every time before we run a command.
2. New rootCmd every time before we run a command. I tried `rootCmd.ResetFlags()` but it will remove all flags and we can not specify any arg any more. Is there any better solution?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
1. ![image](https://user-images.githubusercontent.com/21104942/69206449-ab42e580-0b87-11ea-8ce7-e2b25ca9dacb.png)
2. ![image](https://user-images.githubusercontent.com/21104942/69209005-9c146580-0b90-11ea-940e-cf349ce7243d.png)


Related changes

 - Need to cherry-pick to the release branch
