### PR TITLE
*: fix `cannot convert type: decimal.Decimal`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/shirou/gopsutil v2.18.12+incompatible // indirect
-	github.com/shopspring/decimal v0.0.0-20190905144223-a36b5d85f337 // indirect
+	github.com/shopspring/decimal v0.0.0-20191125035519-b054a8dfd10d // indirect
 	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726
 	github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed // indirect
 	github.com/siddontang/go-mysql v0.0.0-20191009015310-f66c8b344478

--- a/go.sum
+++ b/go.sum
@@ -346,8 +346,8 @@ github.com/shirou/gopsutil v2.18.12+incompatible h1:1eaJvGomDnH74/5cF4CTmTbLHAri
 github.com/shirou/gopsutil v2.18.12+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24 h1:pntxY8Ary0t43dCZ5dqY4YTJCObLY1kIXl0uzMv+7DE=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
-github.com/shopspring/decimal v0.0.0-20190905144223-a36b5d85f337 h1:Da9XEUfFxgyDOqUfwgoTDcWzmnlOnCGi6i4iPS+8Fbw=
-github.com/shopspring/decimal v0.0.0-20190905144223-a36b5d85f337/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
+github.com/shopspring/decimal v0.0.0-20191125035519-b054a8dfd10d h1:976xhcFOjbSk2cmjzMkzePBLTAPkErAI5x/J6hsAEmw=
+github.com/shopspring/decimal v0.0.0-20191125035519-b054a8dfd10d/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/vfsgen v0.0.0-20181020040650-a97a25d856ca/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726 h1:xT+JlYxNGqyT+XcU8iUrN18JYed2TvG9yN5ULG2jATM=

--- a/tests/all_mode/data/db1.increment.sql
+++ b/tests/all_mode/data/db1.increment.sql
@@ -23,3 +23,7 @@ insert into t1 (id, name, info) values (7, 'gentest', '{"id": 126}');
 update t1 set name = 'gentestxxxxxx' where gen_id = 124;
 -- delete with unique key
 delete from t1 where gen_id > 124;
+
+-- test decimal type
+alter table t1 add column lat decimal(9,6) default '0.000000';
+insert into t1 (id, name, info, lat) values (8, 'gentest', '{"id":127}', '123.123')


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

in golang v1.13, the _Decimal decompose interface_ is introduced, see:
- https://github.com/golang/go/issues/30870
- https://github.com/golang/go/commit/683ffe09f66f0834baf039deeabe16eec6b09daa

in [shopspring/decimal@75bb2cb](https://github.com/shopspring/decimal/commit/75bb2cb98e710b1a43ff4611ebdbbbfa3d3314c3), it implements the _Decimal decompose interface_.

when executing a statement with decimal type columns, a possible execution path is:
1. https://github.com/golang/go/blob/cc8838d645/src/database/sql/sql.go#L2275
2. https://github.com/golang/go/blob/cc8838d645/src/database/sql/sql.go#L1515
3. https://github.com/golang/go/blob/cc8838d645/src/database/sql/convert.go#L177
4. https://github.com/go-sql-driver/mysql/blob/v1.4.1/connection_go18.go#L196
5. https://github.com/go-sql-driver/mysql/blob/v1.4.1/statement.go#L141
6. https://github.com/golang/go/blob/cc8838d645/src/database/sql/driver/types.go#L184

the code block

```golang
case decimalDecompose:
	return true
```

will cause the skip of the value fetching (**convert `decimal.Decimal` to `string`**) in <https://github.com/go-sql-driver/mysql/blob/v1.4.1/statement.go#L146>.

then continue the execution flow:

1. https://github.com/golang/go/blob/cc8838d645/src/database/sql/sql.go#L1538
    - (triggered with https://github.com/go-sql-driver/mysql/blob/v1.4.1/connection.go#L296)
2. https://github.com/golang/go/blob/cc8838d645/src/database/sql/sql.go#L2435
3. https://github.com/golang/go/blob/cc8838d645/src/database/sql/ctxutil.go#L65
4. https://github.com/go-sql-driver/mysql/blob/v1.4.1/connection_go18.go#L142
5. https://github.com/go-sql-driver/mysql/blob/v1.4.1/statement.go#L53
6. https://github.com/go-sql-driver/mysql/blob/v1.4.1/packets.go#L1071

another useful link https://github.com/golang/go/issues/34315.

### What is changed and how it works?

some methods can be used to fix this problem:
1. chose a _shopspring/decimal_ version without _Decimal decompose interface_ implementation
2. downgrade golang to v1.12

I chose the first one, and update _shopspring/decimal_ to https://github.com/shopspring/decimal/commit/b054a8dfd10d5e651f48ab20c6c9bee309805368. (revert _Decimal decompose interface_ implementation)

```
go get -u github.com/shopspring/decimal@b054a8dfd10d5e651f48ab20c6c9bee309805368
go mod tidy
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
