### PR TITLE
log: skip 1 caller in ErrorFilterContextCanceled()

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -90,7 +90,7 @@ func (l Logger) ErrorFilterContextCanceled(msg string, fields ...zap.Field) {
 			}
 		}
 	}
-	l.Logger.Error(msg, fields...)
+	l.Logger.WithOptions(zap.AddCallerSkip(1)).Error(msg, fields...)
 }
 
 // logger for DM


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Without the `AddCallerSkip(1)` all logs going through `ErrorFilterContextCanceled()` will show the source as `log.go:93`.

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    * Check the log after applying the patch

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
