### PR TITLE
syncer: fix ignore canceled error

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -953,7 +953,9 @@ func (s *Syncer) sync(ctx *tcontext.Context, queueBucket string, db *DBConn, job
 
 	fatalF := func(err error, errType pb.ErrorType) {
 		s.execErrorDetected.Set(true)
-		s.runFatalChan <- unit.NewProcessError(errType, err)
+		if !utils.IsContextCanceledError(err) {
+			s.runFatalChan <- unit.NewProcessError(errType, err)
+		}
 		clearF()
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

in #355, ignore canceled errors for executing SQLs is introduced.

but miss to ignore the canceled errors for executing DMLs.

### What is changed and how it works?

check `!utils.IsContextCanceledError(err)` before `s.runFatalChan <- unit.NewProcessError(errType, err)` for executing DMLs as we did for DDL.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
     - hack the code for executing DMLs and return an error in one goroutine
     - obverse the log and result of `query-status` for `context canceled` error

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note (with #355)
