### PR TITLE
 Fix the missing var dm_worker_instances for rolling_update_monitor

### DIFF
--- a/dm/dm-ansible/rolling_update_monitor.yml
+++ b/dm/dm-ansible/rolling_update_monitor.yml
@@ -114,6 +114,7 @@
             datasource: "{{ cluster_name }}"
             titles:
               dm_worker: "{{ cluster_name | title }}-DM-worker"
+              dm_worker_instances: "{{ cluster_name | title }}-DM-worker-instances"
 
     - name: import grafana dashboards - run import script
       delegate_to: localhost


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix the missing var "dm_worker_instances "  for rolling_update_monitor

### What is changed and how it works?

Add the var " dm_worker_instances " with the same logical as start.yml



