### PR TITLE
*: split unit test according to upstream MySQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ GO       := GO111MODULE=on go
 GOBUILD  := CGO_ENABLED=0 $(GO) build
 GOTEST   := CGO_ENABLED=1 $(GO) test
 PACKAGES  := $$(go list ./... | grep -vE 'tests|cmd|vendor|pbmock')
-PACKAGES_RELAY := $$(go list ./... | grep -vE 'tests|cmd|vendor|pbmock' | grep 'github.com/pingcap/dm/relay')
-PACKAGES_SYNCER := $$(go list ./... | grep -vE 'tests|cmd|vendor|pbmock' | grep 'github.com/pingcap/dm/syncer')
-PACKAGES_PKG_BINLOG := $$(go list ./... | grep -vE 'tests|cmd|vendor|pbmock' | grep 'github.com/pingcap/dm/pkg/binlog')
+PACKAGES_RELAY := $$(go list ./... | grep 'github.com/pingcap/dm/relay')
+PACKAGES_SYNCER := $$(go list ./... | grep 'github.com/pingcap/dm/syncer')
+PACKAGES_PKG_BINLOG := $$(go list ./... | grep 'github.com/pingcap/dm/pkg/binlog')
 PACKAGES_OTHERS  := $$(go list ./... | grep -vE 'tests|cmd|vendor|pbmock|github.com/pingcap/dm/relay|github.com/pingcap/dm/syncer|github.com/pingcap/dm/pkg/binlog')
 FILES    := $$(find . -name "*.go" | grep -vE "vendor")
 TOPDIRS  := $$(ls -d */ | grep -vE "vendor")

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ debug-tools:
 test: unit_test integration_test
 
 define run_unit_test
-	@echo "runing unit test for packages:" $(1)
+	@echo "running unit test for packages:" $(1)
 	bash -x ./tests/wait_for_mysql.sh
 	mkdir -p $(TEST_DIR)
 	which $(FAILPOINT) >/dev/null 2>&1 || $(GOBUILD) -o $(FAILPOINT) github.com/pingcap/failpoint/failpoint-ctl

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ coverage_fix_cover_mode:
 coverage: coverage_fix_cover_mode
 	GO111MODULE=off go get github.com/zhouqiang-cl/gocovmerge
 	gocovmerge "$(TEST_DIR)"/cov.* | grep -vE ".*.pb.go|.*.__failpoint_binding__.go" > "$(TEST_DIR)/all_cov.out"
-	grep -vE ".*.pb.go|.*.__failpoint_binding__.go" $(TEST_DIR)/cov.unit_test.out > $(TEST_DIR)/unit_test.out
+	gocovmerge "$(TEST_DIR)"/cov.unit_test*.out | grep -vE ".*.pb.go|.*.__failpoint_binding__.go" > $(TEST_DIR)/unit_test.out
 ifeq ("$(JenkinsCI)", "1")
 	GO111MODULE=off go get github.com/mattn/goveralls
 	@goveralls -coverprofile=$(TEST_DIR)/all_cov.out -service=jenkins-ci -repotoken $(COVERALLS_TOKEN)

--- a/dm/worker/worker_test.go
+++ b/dm/worker/worker_test.go
@@ -167,7 +167,7 @@ func (t *testServer) TestTaskAutoResume(c *C) {
 	c.Assert(err, IsNil)
 
 	// check task in paused state
-	c.Assert(utils.WaitSomething(10, 100*time.Millisecond, func() bool {
+	c.Assert(utils.WaitSomething(100, 100*time.Millisecond, func() bool {
 		for _, st := range s.worker.QueryStatus(taskName) {
 			if st.Name == taskName && st.Stage == pb.Stage_Paused {
 				return true


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- when multi test cases in different test suite write data in the upstream, the binlog may become out of order.
- run all unit test cases in one job in CI is a  little slow.

### What is changed and how it works?

- split unit tests according to pkg (in _Makefile_), and now split them into:
  - unit_test_relay
  - unit_test_syncer
  - unit_test_pkg_binlog
  - unit_test_others
- update jenkins pipeline

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to cherry-pick to the release branch
