### PR TITLE
dm-portal: don't generate table list for mydumper  if DoTables is empty

### DIFF
--- a/dm/portal/api.go
+++ b/dm/portal/api.go
@@ -563,12 +563,17 @@ func generateMydumperCfg(bwList *filter.Rules) *config.MydumperConfig {
 		tables = append(tables, fmt.Sprintf("%s.%s", table.Schema, table.Name))
 	}
 
+	extraArgs := ""
+	if len(tables) != 0 {
+		extraArgs = fmt.Sprintf("-T %s", strings.Join(tables, ","))
+	}
+
 	return &config.MydumperConfig{
 		MydumperPath:  "bin/mydumper",
 		Threads:       4,
 		ChunkFilesize: 64,
 		SkipTzUTC:     true,
-		ExtraArgs:     fmt.Sprintf("-T %s", strings.Join(tables, ",")),
+		ExtraArgs:     extraArgs,
 	}
 }
 

--- a/dm/portal/api_test.go
+++ b/dm/portal/api_test.go
@@ -329,6 +329,10 @@ func (t *testPortalSuite) TestGenerateMydumperTableCfg(c *C) {
 	}
 	mydumperCfg := generateMydumperCfg(bwList)
 	c.Assert(mydumperCfg.ExtraArgs, Equals, "-T db_1.t_1,db_1.t_2")
+
+	bwList = &filter.Rules{}
+	mydumperCfg = generateMydumperCfg(bwList)
+	c.Assert(mydumperCfg.ExtraArgs, Equals, "")
 }
 
 func (t *testPortalSuite) TestGenerateMydumperCfgName(c *C) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

fix a bug, when DoTables is empty will generate "-T " for Mydumper, which is invalid.

### What is changed and how it works?

fix it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test
 - Unit test

Related changes

 - Need to cherry-pick to the release branch
