### PR TITLE
ansible: update wrong error message

### DIFF
--- a/dm/dm-ansible/roles/check_config_static/tasks/main.yml
+++ b/dm/dm-ansible/roles/check_config_static/tasks/main.yml
@@ -9,7 +9,7 @@
   when: groups['dm_worker_servers'] | length < 1
 
 - name: Ensure prometheus host exists
-  fail: msg="One dm-master host should be specified in inventory.ini file."
+  fail: msg="One prometheus host should be specified in inventory.ini file."
   when: groups['prometheus_servers'] | length != 1
 
 - name: Ensure grafana host exists


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

when users don't set prometheus host in inventory.ini, will print error messgae about dm-worker

### What is changed and how it works?

fix this wrong message


Related changes

 - Need to cherry-pick to the release branch
