### PR TITLE
dmctl: update the ouput of `operate-worker`

### DIFF
--- a/dm/ctl/master/break_ddl_lock.go
+++ b/dm/ctl/master/break_ddl_lock.go
@@ -34,7 +34,7 @@ func NewBreakDDLLockCmd() *cobra.Command {
 	}
 	cmd.Flags().StringP("remove-id", "i", "", "DDLLockInfo's ID which need to remove")
 	cmd.Flags().BoolP("exec", "e", false, "whether execute DDL which is blocking")
-	cmd.Flags().BoolP("skip", "s", false, "whether skip DDL which in blocking")
+	cmd.Flags().BoolP("skip", "", false, "whether skip DDL which in blocking")
 	return cmd
 }
 
@@ -53,7 +53,7 @@ func breakDDLLockFunc(cmd *cobra.Command, _ []string) {
 		return
 	}
 	if len(sources) == 0 {
-		fmt.Println("must specify at least one DM-worker (`-s` / `--source`)")
+		fmt.Println("must specify at least one source (`-s` / `--source`)")
 		return
 	}
 

--- a/dm/ctl/master/operate_mysql_worker.go
+++ b/dm/ctl/master/operate_mysql_worker.go
@@ -70,7 +70,5 @@ func operateMysqlWorkerFunc(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	if !common.PrettyPrintResponseWithCheckTask(resp, checker.ErrorMsgHeader) {
-		common.PrettyPrintResponse(resp)
-	}
+	common.PrettyPrintResponse(resp)
 }

--- a/dm/ctl/master/operate_mysql_worker.go
+++ b/dm/ctl/master/operate_mysql_worker.go
@@ -70,9 +70,7 @@ func operateMysqlWorkerFunc(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	if !resp.Result {
-		common.PrintLines("operate worker failed:\n%v", resp.Msg)
-	} else {
+	if !common.PrettyPrintResponseWithCheckTask(resp, checker.ErrorMsgHeader) {
 		common.PrettyPrintResponse(resp)
 	}
 }

--- a/dm/ctl/master/operate_mysql_worker.go
+++ b/dm/ctl/master/operate_mysql_worker.go
@@ -72,5 +72,7 @@ func operateMysqlWorkerFunc(cmd *cobra.Command, _ []string) {
 
 	if !resp.Result {
 		common.PrintLines("operate worker failed:\n%v", resp.Msg)
+	} else {
+		common.PrettyPrintResponse(resp)
 	}
 }

--- a/dm/worker/server.go
+++ b/dm/worker/server.go
@@ -98,9 +98,10 @@ func (s *Server) Start() error {
 		// worker keepalive with master
 		// If worker loses connect from master, it would stop all task and try to connect master again.
 		shouldExit := false
+		var err1 error
 		for !shouldExit {
-			shouldExit, err = s.KeepAlive()
-			if err != nil || !shouldExit {
+			shouldExit, err1 = s.KeepAlive()
+			if err1 != nil || !shouldExit {
 				if s.retryConnectMaster.Get() {
 					// Try to connect master again before stop worker
 					s.retryConnectMaster.Set(false)


### PR DESCRIPTION


### What problem does this PR solve? <!--add issue link with summary if exists-->

if `result` of `operate-worker` is true, will print nothing

### What is changed and how it works?

fix it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test


