### PR TITLE
syncer: fix lock in streamer controller

### DIFF
--- a/dm/portal/api_test.go
+++ b/dm/portal/api_test.go
@@ -133,7 +133,7 @@ func (t *testPortalSuite) TestCheck(c *C) {
 	err := readJSON(resp.Body, checkResult)
 	c.Assert(err, IsNil)
 	c.Assert(checkResult.Result, Equals, failed)
-	c.Assert(checkResult.Error, Matches, `Error 1045: Access denied for user 'root'@'(127\.0\.0\.1|localhost)' \(using password: YES\)`)
+	c.Assert(checkResult.Error, Matches, `Error 1045: Access denied for user.*`)
 
 	getDBConnFunc = t.getMockDB
 	defer func() {
@@ -162,7 +162,7 @@ func (t *testPortalSuite) TestGetSchemaInfo(c *C) {
 	err := readJSON(resp.Body, schemaInfoResult)
 	c.Assert(err, IsNil)
 	c.Assert(schemaInfoResult.Result, Equals, failed)
-	c.Assert(schemaInfoResult.Error, Matches, `Error 1045: Access denied for user 'root'@'(127\.0\.0\.1|localhost)' \(using password: YES\)`)
+	c.Assert(schemaInfoResult.Error, Matches, `Error 1045: Access denied for user.*`)
 	c.Assert(schemaInfoResult.Tables, IsNil)
 
 	getDBConnFunc = t.getMockDB

--- a/dm/worker/worker_test.go
+++ b/dm/worker/worker_test.go
@@ -189,11 +189,13 @@ func (t *testServer) TestTaskAutoResume(c *C) {
 
 	// check task will be auto resumed
 	c.Assert(utils.WaitSomething(10, 100*time.Millisecond, func() bool {
-		for _, st := range s.worker.QueryStatus(taskName) {
+		sts := s.worker.QueryStatus(taskName)
+		for _, st := range sts {
 			if st.Name == taskName && st.Stage == pb.Stage_Running {
 				return true
 			}
 		}
+		c.Log(sts)
 		return false
 	}), IsTrue)
 }

--- a/syncer/streamer_controller.go
+++ b/syncer/streamer_controller.go
@@ -214,9 +214,6 @@ func (c *StreamerController) RedirectStreamer(tctx *tcontext.Context, pos mysql.
 
 // GetEvent returns binlog event, should only have one thread call this function.
 func (c *StreamerController) GetEvent(tctx *tcontext.Context) (event *replication.BinlogEvent, err error) {
-	c.Lock()
-	defer c.Unlock()
-
 	ctx, cancel := context.WithTimeout(tctx.Context(), eventTimeout)
 	failpoint.Inject("SyncerEventTimeout", func(val failpoint.Value) {
 		if seconds, ok := val.(int); ok {
@@ -226,11 +223,17 @@ func (c *StreamerController) GetEvent(tctx *tcontext.Context) (event *replicatio
 		}
 	})
 
-	event, err = c.streamer.GetEvent(ctx)
+	c.RLock()
+	streamer := c.streamer
+	c.RUnlock()
+
+	event, err = streamer.GetEvent(ctx)
 	cancel()
 	if err != nil {
 		if err != context.Canceled && err != context.DeadlineExceeded {
+			c.Lock()
 			c.meetError = true
+			c.Unlock()
 		}
 
 		return nil, err

--- a/syncer/streamer_controller.go
+++ b/syncer/streamer_controller.go
@@ -245,6 +245,7 @@ func (c *StreamerController) GetEvent(tctx *tcontext.Context) (event *replicatio
 		// if is remote binlog, need to add uuid information in binlog's name
 		c.Lock()
 		containUUID := c.setUUIDIfExists(string(ev.NextLogName))
+		uuidSuffix := c.uuidSuffix
 		c.Unlock()
 
 		if !containUUID {
@@ -253,7 +254,7 @@ func (c *StreamerController) GetEvent(tctx *tcontext.Context) (event *replicatio
 				if err != nil {
 					return nil, terror.Annotate(err, "fail to parse binlog file name from rotate event")
 				}
-				ev.NextLogName = []byte(binlog.ConstructFilenameWithUUIDSuffix(filename, c.uuidSuffix))
+				ev.NextLogName = []byte(binlog.ConstructFilenameWithUUIDSuffix(filename, uuidSuffix))
 				event.Event = ev
 			}
 		}

--- a/syncer/streamer_controller.go
+++ b/syncer/streamer_controller.go
@@ -243,7 +243,11 @@ func (c *StreamerController) GetEvent(tctx *tcontext.Context) (event *replicatio
 	case *replication.RotateEvent:
 		// if is local binlog, binlog's name contain uuid information, need to save it
 		// if is remote binlog, need to add uuid information in binlog's name
-		if !c.setUUIDIfExists(string(ev.NextLogName)) {
+		c.Lock()
+		containUUID := c.setUUIDIfExists(string(ev.NextLogName))
+		c.Unlock()
+
+		if !containUUID {
 			if len(c.uuidSuffix) != 0 {
 				filename, err := binlog.ParseFilename(string(ev.NextLogName))
 				if err != nil {

--- a/syncer/streamer_controller.go
+++ b/syncer/streamer_controller.go
@@ -249,7 +249,7 @@ func (c *StreamerController) GetEvent(tctx *tcontext.Context) (event *replicatio
 		c.Unlock()
 
 		if !containUUID {
-			if len(c.uuidSuffix) != 0 {
+			if len(uuidSuffix) != 0 {
 				filename, err := binlog.ParseFilename(string(ev.NextLogName))
 				if err != nil {
 					return nil, terror.Annotate(err, "fail to parse binlog file name from rotate event")

--- a/syncer/streamer_controller.go
+++ b/syncer/streamer_controller.go
@@ -145,7 +145,7 @@ func (c *StreamerController) Start(tctx *tcontext.Context, pos mysql.Position) e
 		err = c.updateServerIDAndResetReplication(tctx, pos)
 	}
 	if err != nil {
-		c.Close(tctx)
+		c.close(tctx)
 		return err
 	}
 
@@ -302,8 +302,11 @@ func (c *StreamerController) closeBinlogSyncer(logtctx *tcontext.Context, binlog
 // Close closes streamer
 func (c *StreamerController) Close(tctx *tcontext.Context) {
 	c.Lock()
-	defer c.Unlock()
+	c.close(tctx)
+	c.Unlock()
+}
 
+func (c *StreamerController) close(tctx *tcontext.Context) {
 	if c.closed {
 		return
 	}


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. `GetEvent` may cost too many time, and will lock the `StreamerController`, need refine it
2. both `Start` and `Close` have lock, but when `Start` failed will call the `Close` function, need fix the dead lock

### What is changed and how it works?

fix the lock

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test 


Related changes

 - Need to cherry-pick to the release branch
