### PR TITLE
syncer: fix lock in streamer controller(#470)

### DIFF
--- a/dm/worker/worker_test.go
+++ b/dm/worker/worker_test.go
@@ -161,11 +161,13 @@ func (t *testServer) TestTaskAutoResume(c *C) {
 
 	// check task will be auto resumed
 	c.Assert(utils.WaitSomething(10, 100*time.Millisecond, func() bool {
-		for _, st := range s.getWorker(true).QueryStatus(taskName) {
+		sts := s.getWorker(true).QueryStatus(taskName)
+		for _, st := range sts {
 			if st.Name == taskName && st.Stage == pb.Stage_Running {
 				return true
 			}
 		}
+		c.Log(sts)
 		return false
 	}), IsTrue)
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

1. GetEvent may cost too many time, and will lock the StreamerController, need refine it
2. both Start and Close have lock, but when Start failed will call the Close function, need fix the dead lock

### What is changed and how it works?

cherry-pick from #470 and resolve conflicts

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test 


