### PR TITLE
dm-syncer: minor fix on password && print parse error

### DIFF
--- a/cmd/dm-syncer/config.go
+++ b/cmd/dm-syncer/config.go
@@ -167,7 +167,7 @@ func (c *commonConfig) newSubTaskConfig(args []string) (*config.SubTaskConfig, e
 
 	cfg.ServerID = uint32(serverID)
 
-	err := cfg.Parse(args)
+	err := cfg.Parse(args, false)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -359,7 +359,7 @@ func (oc *oldConfig) convertToNewFormat() (*config.SubTaskConfig, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	err = newTask.Adjust()
+	err = newTask.Adjust(false)
 	return newTask, err
 }
 

--- a/cmd/dm-syncer/main.go
+++ b/cmd/dm-syncer/main.go
@@ -63,13 +63,7 @@ func main() {
 		log.L().Info("", zap.Stringer("dm-syncer conf", conf))
 	})
 
-	conf2, err := conf.DecryptPassword()
-	if err != nil {
-		log.L().Error("decrypt password failed", zap.Error(err))
-		os.Exit(2)
-	}
-
-	sync := syncer.NewSyncer(conf2)
+	sync := syncer.NewSyncer(conf)
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 

--- a/cmd/dm-syncer/main.go
+++ b/cmd/dm-syncer/main.go
@@ -36,15 +36,13 @@ func main() {
 	// 1. init conf
 	commonConfig := newCommonConfig()
 	conf, err := commonConfig.parse(os.Args[1:])
-	if err != nil {
-		switch errors.Cause(err) {
-		case nil:
-		case flag.ErrHelp:
-			os.Exit(0)
-		default:
-			fmt.Printf("parse cmd flags err %s", err.Error())
-			os.Exit(2)
-		}
+	switch errors.Cause(err) {
+	case nil:
+	case flag.ErrHelp:
+		os.Exit(0)
+	default:
+		fmt.Printf("parse cmd flags err %s", err.Error())
+		os.Exit(2)
 	}
 
 	conf.Mode = config.ModeIncrement

--- a/dm/config/subtask.go
+++ b/dm/config/subtask.go
@@ -230,7 +230,7 @@ func (c *SubTaskConfig) DecodeFile(fpath string) error {
 		return terror.ErrConfigTomlTransform.Delegate(err, "decode subtask config from file")
 	}
 
-	return c.Adjust()
+	return c.Adjust(true)
 }
 
 // Decode loads config from file data
@@ -240,11 +240,11 @@ func (c *SubTaskConfig) Decode(data string) error {
 		return terror.ErrConfigTomlTransform.Delegate(err, "decode subtask config from data")
 	}
 
-	return c.Adjust()
+	return c.Adjust(true)
 }
 
 // Adjust adjusts configs
-func (c *SubTaskConfig) Adjust() error {
+func (c *SubTaskConfig) Adjust(decryptPassword bool) error {
 	if c.Name == "" {
 		return terror.ErrConfigTaskNameEmpty.Generate()
 	}
@@ -288,12 +288,18 @@ func (c *SubTaskConfig) Adjust() error {
 	c.From.Adjust()
 	c.To.Adjust()
 
-	_, err := c.DecryptPassword()
-	return err
+	if decryptPassword {
+		_, err1 := c.DecryptPassword()
+		if err1 != nil {
+			return err1
+		}
+	}
+
+	return nil
 }
 
 // Parse parses flag definitions from the argument list.
-func (c *SubTaskConfig) Parse(arguments []string) error {
+func (c *SubTaskConfig) Parse(arguments []string, decryptPassword bool) error {
 	// Parse first to get config file.
 	err := c.flagSet.Parse(arguments)
 	if err != nil {
@@ -323,7 +329,7 @@ func (c *SubTaskConfig) Parse(arguments []string) error {
 		return terror.ErrConfigParseFlagSet.Generatef("'%s' is an invalid flag", c.flagSet.Arg(0))
 	}
 
-	return c.Adjust()
+	return c.Adjust(decryptPassword)
 }
 
 // DecryptPassword tries to decrypt db password in config

--- a/dm/config/subtask_test.go
+++ b/dm/config/subtask_test.go
@@ -51,13 +51,17 @@ func (t *testConfig) TestSubTask(c *C) {
 	cfg.From.Password = "xxx"
 	_, err = cfg.DecryptPassword()
 	c.Assert(err, NotNil)
+	err = cfg.Adjust(true)
+	c.Assert(err, NotNil)
+	err = cfg.Adjust(false)
+	c.Assert(err, IsNil)
 
 	cfg.From.Password = ""
 	clone3, err := cfg.DecryptPassword()
 	c.Assert(err, IsNil)
 	c.Assert(clone3, DeepEquals, cfg)
 
-	err = cfg.Adjust()
+	err = cfg.Adjust(true)
 	c.Assert(err, IsNil)
 }
 
@@ -130,7 +134,7 @@ func (t *testConfig) TestSubTaskAdjustFail(c *C) {
 
 	for _, tc := range testCases {
 		cfg := tc.genFunc()
-		err := cfg.Adjust()
+		err := cfg.Adjust(true)
 		c.Assert(err, ErrorMatches, tc.errorFormat)
 	}
 }

--- a/dm/config/task.go
+++ b/dm/config/task.go
@@ -519,7 +519,7 @@ func (c *TaskConfig) SubTaskConfigs(sources map[string]DBConfig) ([]*SubTaskConf
 		cfg.LoaderConfig = *inst.Loader
 		cfg.SyncerConfig = *inst.Syncer
 
-		err := cfg.Adjust()
+		err := cfg.Adjust(true)
 		if err != nil {
 			return nil, terror.Annotatef(err, "source %s", inst.SourceID)
 		}

--- a/dm/worker/meta.go
+++ b/dm/worker/meta.go
@@ -71,7 +71,7 @@ func (m *Meta) Decode(data string) error {
 func (m *Meta) adjust() error {
 	// adjust the config
 	for name, subTask := range m.SubTasks {
-		err := subTask.Adjust()
+		err := subTask.Adjust(true)
 		if err != nil {
 			return terror.Annotatef(err, "task %s", name)
 		}

--- a/dm/worker/meta_test.go
+++ b/dm/worker/meta_test.go
@@ -54,8 +54,8 @@ type testMeta struct{}
 var _ = Suite(&testMeta{})
 
 func testSetUpDB(c *C) (*leveldb.DB, string) {
-	c.Assert(testTask1.Adjust(), IsNil)
-	c.Assert(testTask2.Adjust(), IsNil)
+	c.Assert(testTask1.Adjust(true), IsNil)
+	c.Assert(testTask2.Adjust(true), IsNil)
 
 	testTask1Str, err := testTask1.Toml()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

1. don't decrypt password, will connect to database failed
2.  log is not initial, need to use `fmt` to print parse error

### What is changed and how it works?

fix these two problems

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test 
