### PR TITLE
dm-ctl/: add `--more` index for `query-status` command to get full task information

### DIFF
--- a/dm/ctl/master/query_status.go
+++ b/dm/ctl/master/query_status.go
@@ -42,10 +42,11 @@ type taskInfo struct {
 // NewQueryStatusCmd creates a QueryStatus command
 func NewQueryStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "query-status [-s source ...] [task-name]",
+		Use:   "query-status [-s source ...] [task-name] [--more]",
 		Short: "query task status",
 		Run:   queryStatusFunc,
 	}
+	cmd.Flags().BoolP("more", "", false, "whether print the detailed task information directly")
 	return cmd
 }
 
@@ -76,7 +77,13 @@ func queryStatusFunc(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	if resp.Result && taskName == "" && len(sources) == 0 {
+	more, err := cmd.Flags().GetBool("more")
+	if err != nil {
+		common.PrintLines("%s", errors.ErrorStack(err))
+		return
+	}
+
+	if resp.Result && taskName == "" && len(sources) == 0 && !more {
 		result := wrapTaskResult(resp)
 		common.PrettyPrintInterface(result)
 	} else {

--- a/dm/ctl/master/query_status.go
+++ b/dm/ctl/master/query_status.go
@@ -46,7 +46,7 @@ func NewQueryStatusCmd() *cobra.Command {
 		Short: "query task status",
 		Run:   queryStatusFunc,
 	}
-	cmd.Flags().BoolP("more", "", false, "whether print the detailed task information directly")
+	cmd.Flags().BoolP("more", "", false, "whether to print the detailed task information")
 	return cmd
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

UCP #505 

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add `--more` index for `query-status` command to get full task information.

### What is changed and how it works?

It will check `--more` index for `query-status` command. If this index exist, it will print full tasks information.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
