### PR TITLE
election: reset oldLeaderID after retire from leader

### DIFF
--- a/pkg/election/election.go
+++ b/pkg/election/election.go
@@ -297,6 +297,7 @@ func (e *Election) campaignLoop(ctx context.Context, session *concurrency.Sessio
 		e.watchLeader(ctx, session, leaderKey)
 		e.l.Info("retire from leader", zap.Stringer("current member", e.info))
 		e.notifyLeader(ctx, nil) // need to re-campaign
+		oldLeaderID = ""
 
 		cancel2()
 		compaignWg.Wait()


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

when master retire from leader, not set `oldLeaderInfo = ""`, and if this master become leader again, will contine at L273 and not notify the master 

### What is changed and how it works?
set `oldLeaderInfo = ""` after retire from leader

