### PR TITLE
utils: fix `value out of range` for getting `server_id`

### DIFF
--- a/pkg/utils/db.go
+++ b/pkg/utils/db.go
@@ -303,7 +303,7 @@ func GetServerID(db *sql.DB) (uint32, error) {
 		return 0, err
 	}
 
-	serverID, err := strconv.ParseInt(serverIDStr, 10, 32)
+	serverID, err := strconv.ParseUint(serverIDStr, 10, 32)
 	return uint32(serverID), terror.ErrInvalidServerID.Delegate(err, serverIDStr)
 }
 

--- a/pkg/utils/db_test.go
+++ b/pkg/utils/db_test.go
@@ -32,6 +32,9 @@ func (t *testUtilsSuite) TestGetAllServerID(c *C) {
 		}, {
 			2,
 			[]uint32{},
+		}, {
+			4294967295, // max server-id.
+			[]uint32{},
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix #536 

### What is changed and how it works?

use `strconv.ParseUint` instead of `strconv.ParseInt` to parse `server_id`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
