### PR TITLE
loader: fix concurrent usage of checkpoint's DBconn.

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -256,7 +256,7 @@ func (w *Worker) dispatchSQL(ctx context.Context, file string, offset int64, tab
 	baseFile := filepath.Base(file)
 	err = w.checkPoint.Init(w.tctx.WithContext(ctx), baseFile, finfo.Size())
 	if err != nil {
-		w.tctx.L().Error("fail to initial checkpoint", zap.String("data file", file), log.ShortError(err))
+		w.tctx.L().Error("fail to initial checkpoint", zap.String("data file", file), zap.Int64("offset", offset), log.ShortError(err))
 		return err
 	}
 
@@ -273,7 +273,7 @@ func (w *Worker) dispatchSQL(ctx context.Context, file string, offset int64, tab
 	for {
 		select {
 		case <-ctx.Done():
-			w.tctx.L().Info("sql dispatcher is ready to quit.", zap.String("data file", file))
+			w.tctx.L().Info("sql dispatcher is ready to quit.", zap.String("data file", file), zap.Int64("offset", offset))
 			return nil
 		default:
 			// do nothing
@@ -282,7 +282,7 @@ func (w *Worker) dispatchSQL(ctx context.Context, file string, offset int64, tab
 		cur += int64(len(line))
 
 		if err == io.EOF {
-			w.tctx.L().Info("data are scanned finished.", zap.String("data file", file))
+			w.tctx.L().Info("data are scanned finished.", zap.String("data file", file), zap.Int64("offset", offset))
 			break
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix #553 

- for load unit, only one `RemoteCheckPoint` exists.
- for `RemoteCheckPoint`, only one `DBConn` exist.
- but `DBConn` is not concurrency-safe.

so, some checkpoint operations like `Init` may cause a problem.

### What is changed and how it works?

add `sync.Mutex` to protect operations for `DBConn`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - Possible performance regression
 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
