### PR TITLE
worker/: don't quit worker immediately when dialed master is offline

### DIFF
--- a/cmd/dm-worker/main.go
+++ b/cmd/dm-worker/main.go
@@ -64,7 +64,7 @@ func main() {
 	s := worker.NewServer(cfg)
 	err = s.JoinMaster(worker.GetJoinURLs(cfg.Join))
 	if err != nil {
-		log.L().Info("join the cluster meet error %v", zap.Error(err))
+		log.L().Info("join the cluster meet error", zap.Error(err))
 		os.Exit(2)
 	}
 

--- a/dm/master/scheduler/scheduler_test.go
+++ b/dm/master/scheduler/scheduler_test.go
@@ -163,10 +163,10 @@ func (t *testScheduler) TestScheduler(c *C) {
 		c.Assert(ha.KeepAlive(ctx1, etcdTestCli, workerName1, keepAliveTTL), IsNil)
 	}()
 	// wait for source1 bound to worker1.
-	utils.WaitSomething(30, 10*time.Millisecond, func() bool {
+	c.Assert(utils.WaitSomething(30, 10*time.Millisecond, func() bool {
 		bounds := s.BoundSources()
 		return len(bounds) == 1 && bounds[0] == sourceID1
-	})
+	}), IsTrue)
 	t.sourceBounds(c, s, []string{sourceID1}, []string{})
 	t.workerBound(c, s, ha.NewSourceBound(sourceID1, workerName1))
 	// expect relay stage become Running after the first bound.
@@ -233,10 +233,10 @@ func (t *testScheduler) TestScheduler(c *C) {
 	cancel1()
 	wg.Wait()
 	// wait for source1 unbound from worker1.
-	utils.WaitSomething(int(3*keepAliveTTL), time.Second, func() bool {
+	c.Assert(utils.WaitSomething(int(3*keepAliveTTL), time.Second, func() bool {
 		unbounds := s.UnboundSources()
 		return len(unbounds) == 1 && unbounds[0] == sourceID1
-	})
+	}), IsTrue)
 	t.sourceBounds(c, s, []string{}, []string{sourceID1})
 	// static information are still there.
 	t.sourceCfgExist(c, s, sourceCfg1)
@@ -276,10 +276,10 @@ func (t *testScheduler) TestScheduler(c *C) {
 		c.Assert(ha.KeepAlive(ctx1, etcdTestCli, workerName1, keepAliveTTL), IsNil)
 	}()
 	// wait for source1 bound to worker1.
-	utils.WaitSomething(30, 10*time.Millisecond, func() bool {
+	c.Assert(utils.WaitSomething(30, 10*time.Millisecond, func() bool {
 		bounds := s.BoundSources()
 		return len(bounds) == 1 && bounds[0] == sourceID1
-	})
+	}), IsTrue)
 	// source1 bound to worker1.
 	t.sourceBounds(c, s, []string{sourceID1}, []string{})
 	t.workerBound(c, s, ha.NewSourceBound(sourceID1, workerName1))
@@ -324,10 +324,10 @@ func (t *testScheduler) TestScheduler(c *C) {
 		c.Assert(ha.KeepAlive(ctx2, etcdTestCli, workerName2, keepAliveTTL), IsNil)
 	}()
 	// wait for worker2 become Free.
-	utils.WaitSomething(30, 10*time.Millisecond, func() bool {
+	c.Assert(utils.WaitSomething(30, 10*time.Millisecond, func() bool {
 		w := s.GetWorkerByName(workerName2)
 		return w.Stage() == WorkerFree
-	})
+	}), IsTrue)
 	t.workerFree(c, s, workerName2)
 
 	// CASE 4.4: add source config2.
@@ -412,11 +412,11 @@ func (t *testScheduler) TestScheduler(c *C) {
 	// cancel keep-alive.
 	cancel1()
 	// wait for worker1 become offline.
-	utils.WaitSomething(int(3*keepAliveTTL), time.Second, func() bool {
+	c.Assert(utils.WaitSomething(int(3*keepAliveTTL), time.Second, func() bool {
 		w := s.GetWorkerByName(workerName1)
 		c.Assert(w, NotNil)
 		return w.Stage() == WorkerOffline
-	})
+	}), IsTrue)
 	t.workerOffline(c, s, workerName1)
 	// source1 should bound to worker2.
 	t.sourceBounds(c, s, []string{sourceID1}, []string{})
@@ -446,11 +446,11 @@ func (t *testScheduler) TestScheduler(c *C) {
 	cancel2()
 	wg.Wait()
 	// wait for worker2 become offline.
-	utils.WaitSomething(int(3*keepAliveTTL), time.Second, func() bool {
+	c.Assert(utils.WaitSomething(int(3*keepAliveTTL), time.Second, func() bool {
 		w := s.GetWorkerByName(workerName2)
 		c.Assert(w, NotNil)
 		return w.Stage() == WorkerOffline
-	})
+	}), IsTrue)
 	t.workerOffline(c, s, workerName2)
 	// source1 should unbound
 	t.sourceBounds(c, s, []string{}, []string{sourceID1})
@@ -672,10 +672,10 @@ func (t *testScheduler) TestRestartScheduler(c *C) {
 	}()
 	// step 2.3: scheduler should bound source to worker
 	// wait for source1 bound to worker1.
-	utils.WaitSomething(30, 10*time.Millisecond, func() bool {
+	c.Assert(utils.WaitSomething(30, 10*time.Millisecond, func() bool {
 		bounds := s.BoundSources()
 		return len(bounds) == 1 && bounds[0] == sourceID1
-	})
+	}), IsTrue)
 	checkSourceBoundCh := func() {
 		time.Sleep(300 * time.Millisecond)
 		c.Assert(sourceBoundCh, HasLen, 1)

--- a/dm/worker/join.go
+++ b/dm/worker/join.go
@@ -36,32 +36,36 @@ func GetJoinURLs(addrs string) []string {
 // JoinMaster let dm-worker join the cluster with the specified master endpoints.
 func (s *Server) JoinMaster(endpoints []string) error {
 	// TODO: grpc proxy
-	var client pb.MasterClient
-	for _, endpoint := range endpoints {
-		conn, err := grpc.Dial(endpoint, grpc.WithInsecure(), grpc.WithBackoffMaxDelay(3*time.Second))
-		if err != nil {
-			return err
-		}
-		client = pb.NewMasterClient(conn)
-		break
-	}
-	if client == nil {
-		return errors.Errorf("cannot connect with master endpoints: %v", endpoints)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
+
 	req := &pb.RegisterWorkerRequest{
 		Name:    s.cfg.Name,
 		Address: s.cfg.AdvertiseAddr,
 	}
-	resp, err := client.RegisterWorker(ctx, req)
-	if err != nil {
-		return err
+
+	var client pb.MasterClient
+	for _, endpoint := range endpoints {
+		conn, err := grpc.Dial(endpoint, grpc.WithBlock(), grpc.WithInsecure(), grpc.WithBackoffMaxDelay(3*time.Second))
+		if err != nil {
+			log.L().Error("fail to dial dm-master", zap.Error(err))
+			continue
+		}
+		client = pb.NewMasterClient(conn)
+		ctx1, cancel1 := context.WithTimeout(ctx, 3*time.Second)
+		resp, err := client.RegisterWorker(ctx1, req)
+		cancel1()
+		if err != nil {
+			log.L().Error("fail to register worker: %s", zap.Error(err))
+			continue
+		}
+		if !resp.GetResult() {
+			log.L().Error("fail to register worker: %s", zap.String("error", resp.Msg))
+			continue
+		}
+		return nil
 	}
-	if !resp.GetResult() {
-		return errors.Errorf("fail to register worker: %s", resp.GetMsg())
-	}
-	return nil
+	return errors.Errorf("cannot connect with master endpoints: %v", endpoints)
 }
 
 // KeepAlive attempts to keep the lease of the server alive forever.

--- a/dm/worker/join.go
+++ b/dm/worker/join.go
@@ -58,11 +58,11 @@ func (s *Server) JoinMaster(endpoints []string) error {
 		resp, err := client.RegisterWorker(ctx1, req)
 		cancel1()
 		if err != nil {
-			log.L().Error("fail to register worker: %s", zap.Error(err))
+			log.L().Error("fail to register worker", zap.Error(err))
 			continue
 		}
 		if !resp.GetResult() {
-			log.L().Error("fail to register worker: %s", zap.String("error", resp.Msg))
+			log.L().Error("fail to register worker", zap.String("error", resp.Msg))
 			continue
 		}
 		return nil

--- a/dm/worker/join.go
+++ b/dm/worker/join.go
@@ -44,7 +44,6 @@ func (s *Server) JoinMaster(endpoints []string) error {
 		Address: s.cfg.AdvertiseAddr,
 	}
 
-	var client pb.MasterClient
 	for _, endpoint := range endpoints {
 		ctx1, cancel1 := context.WithTimeout(ctx, 3*time.Second)
 		conn, err := grpc.DialContext(ctx1, endpoint, grpc.WithBlock(), grpc.WithInsecure(), grpc.WithBackoffMaxDelay(3*time.Second))
@@ -53,7 +52,7 @@ func (s *Server) JoinMaster(endpoints []string) error {
 			log.L().Error("fail to dial dm-master", zap.Error(err))
 			continue
 		}
-		client = pb.NewMasterClient(conn)
+		client := pb.NewMasterClient(conn)
 		ctx1, cancel1 = context.WithTimeout(ctx, 3*time.Second)
 		resp, err := client.RegisterWorker(ctx1, req)
 		cancel1()
@@ -67,6 +66,7 @@ func (s *Server) JoinMaster(endpoints []string) error {
 		}
 		return nil
 	}
+	// TODO: use terror here
 	return errors.Errorf("cannot connect with master endpoints: %v", endpoints)
 }
 

--- a/tests/ha_master/run.sh
+++ b/tests/ha_master/run.sh
@@ -31,10 +31,25 @@ function run() {
     check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT4
     check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT5
 
+    # kill dm-master1 and dm-master2 to simulate the first two dm-master addr in join config are invalid
+    echo "kill dm-master1 and kill dm-master2"
+    ps aux | grep dm-master1 |awk '{print $2}'|xargs kill || true
+    check_port_offline $MASTER_PORT1 20
+    ps aux | grep dm-master2 |awk '{print $2}'|xargs kill || true
+    check_port_offline $MASTER_PORT2 20
+
     run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
     run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
     check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
+
+    # start dm_master1 and dm-master2 again
+    echo "start dm-master1 and dm-master2 again"
+    run_dm_master $WORK_DIR/master1 $MASTER_PORT1 $cur/conf/dm-master1.toml
+    run_dm_master $WORK_DIR/master2 $MASTER_PORT2 $cur/conf/dm-master2.toml
+    check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT1
+    check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT2
+
     echo "operate mysql config to worker"
     cp $cur/conf/source1.toml $WORK_DIR/source1.toml
     cp $cur/conf/source2.toml $WORK_DIR/source2.toml


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/dm/issues/560
When worker dials an offline master, it will returns error directly and stop the worker process.

### What is changed and how it works?
1. add `WithBlock` option for grpc dial to avoid dialing an offline master.
2. don't return error immediately when dialed master is offline. Try to dial other endpoint in `cfg.Join`.
3. do the register request in the loop to avoid dialing an online master which is blocked from other dm-masters.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
