### PR TITLE
ha: set etcdClient to component at the beginning initialization

### DIFF
--- a/_utils/terror_gen/errors_release.txt
+++ b/_utils/terror_gen/errors_release.txt
@@ -334,6 +334,7 @@ ErrMasterAdvertiseAddrNotValid,[code=38042:class=dm-master:scope=internal:level=
 ErrMasterRequestIsNotForwardToLeader,[code=38043:class=dm-master:scope=internal:level=high],"master is not leader, and can't forward request to leader"
 ErrMasterIsNotAsyncRequest,[code=38044:class=dm-master:scope=internal:level=medium],"request %s is not an async one, needn't wait for ok"
 ErrMasterFailToGetExpectResult,[code=38045:class=dm-master:scope=internal:level=medium],"fail to get expected result"
+ErrMasterPessimistNotStarted,[code=38046:class=dm-master:scope=internal:level=medium],"the shardddl pessimist has not started"
 ErrWorkerParseFlagSet,[code=40001:class=dm-worker:scope=internal:level=medium],"parse dm-worker config flag set"
 ErrWorkerInvalidFlag,[code=40002:class=dm-worker:scope=internal:level=medium],"'%s' is an invalid flag"
 ErrWorkerDecodeConfigFromFile,[code=40003:class=dm-worker:scope=internal:level=medium],"toml decode file"

--- a/dm/master/scheduler/scheduler.go
+++ b/dm/master/scheduler/scheduler.go
@@ -156,7 +156,8 @@ func (s *Scheduler) Start(pCtx context.Context, etcdCli *clientv3.Client) error 
 		return terror.ErrSchedulerStarted.Generate()
 	}
 
-	s.reset() // reset previous status.
+	s.etcdCli = etcdCli // set s.etcdCli first for safety, observeWorkerEvent will use s.etcdCli in retry
+	s.reset()           // reset previous status.
 
 	// recover previous status from etcd.
 	err := s.recoverSources(etcdCli)
@@ -184,7 +185,6 @@ func (s *Scheduler) Start(pCtx context.Context, etcdCli *clientv3.Client) error 
 
 	s.started = true // started now
 	s.cancel = cancel
-	s.etcdCli = etcdCli
 	s.logger.Info("the scheduler has started")
 	return nil
 }

--- a/dm/master/scheduler/scheduler_test.go
+++ b/dm/master/scheduler/scheduler_test.go
@@ -70,6 +70,11 @@ var (
 )
 
 func (t *testScheduler) TestScheduler(c *C) {
+	t.testSchedulerProgress(c, false)
+	t.testSchedulerProgress(c, true)
+}
+
+func (t *testScheduler) testSchedulerProgress(c *C, rebuild bool) {
 	defer clearTestInfoOperation(c)
 
 	var (
@@ -88,6 +93,14 @@ func (t *testScheduler) TestScheduler(c *C) {
 		sourceCfg1   config.SourceConfig
 		subtaskCfg1  config.SubTaskConfig
 		keepAliveTTL = int64(1) // NOTE: this should be >= minLeaseTTL, in second.
+
+		rebuildScheduler = func(ctx context.Context) {
+			if rebuild {
+				s.Close()
+				*s = *NewScheduler(&logger)
+				c.Assert(s.Start(ctx, etcdTestCli), IsNil)
+			}
+		}
 	)
 	c.Assert(sourceCfg1.LoadFromFile(sourceSampleFile), IsNil)
 	sourceCfg1.SourceID = sourceID1
@@ -137,6 +150,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	t.sourceCfgExist(c, s, sourceCfg1)
 	// one unbound source exist (because no free worker).
 	t.sourceBounds(c, s, []string{}, []string{sourceID1})
+	rebuildScheduler(ctx)
 
 	// CASE 2.2: add the first worker.
 	// no worker exist before added.
@@ -152,6 +166,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	t.sourceBounds(c, s, []string{}, []string{sourceID1})
 	// no expect relay stage exist (because the source has never been bounded).
 	t.relayStageMatch(c, s, sourceID1, pb.Stage_InvalidStage)
+	rebuildScheduler(ctx)
 
 	// CASE 2.3: the worker become online.
 	// do keep-alive for worker1.
@@ -171,6 +186,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	t.workerBound(c, s, ha.NewSourceBound(sourceID1, workerName1))
 	// expect relay stage become Running after the first bound.
 	t.relayStageMatch(c, s, sourceID1, pb.Stage_Running)
+	rebuildScheduler(ctx)
 
 	// CASE 2.4: pause the relay.
 	c.Assert(s.UpdateExpectRelayStage(pb.Stage_Paused, sourceID1), IsNil)
@@ -186,10 +202,12 @@ func (t *testScheduler) TestScheduler(c *C) {
 	// can't update stage with not existing sources now.
 	c.Assert(terror.ErrSchedulerRelayStageSourceNotExist.Equal(s.UpdateExpectRelayStage(pb.Stage_Running, sourceID1, sourceID2)), IsTrue)
 	t.relayStageMatch(c, s, sourceID1, pb.Stage_Paused)
+	rebuildScheduler(ctx)
 
 	// CASE 2.5: resume the relay.
 	c.Assert(s.UpdateExpectRelayStage(pb.Stage_Running, sourceID1), IsNil)
 	t.relayStageMatch(c, s, sourceID1, pb.Stage_Running)
+	rebuildScheduler(ctx)
 
 	// CASE 2.6: start a task with only one source.
 	// no subtask config exists before start.
@@ -209,6 +227,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	t.subTaskStageMatch(c, s, taskName2, sourceID1, pb.Stage_InvalidStage)
 	t.subTaskCfgNotExist(c, s, taskName2, sourceID2)
 	t.subTaskStageMatch(c, s, taskName2, sourceID2, pb.Stage_InvalidStage)
+	rebuildScheduler(ctx)
 
 	// CASE 2.7: pause/resume task1.
 	c.Assert(s.UpdateExpectSubTaskStage(pb.Stage_Paused, taskName1, sourceID1), IsNil)
@@ -227,6 +246,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	// can't update stage with not existing sources now.
 	c.Assert(terror.ErrSchedulerSubTaskOpSourceNotExist.Equal(s.UpdateExpectSubTaskStage(pb.Stage_Paused, taskName1, sourceID1, sourceID2)), IsTrue)
 	t.relayStageMatch(c, s, sourceID1, pb.Stage_Running)
+	rebuildScheduler(ctx)
 
 	// CASE 2.8: worker1 become offline.
 	// cancel keep-alive.
@@ -247,13 +267,9 @@ func (t *testScheduler) TestScheduler(c *C) {
 	// expect relay stage keep Running.
 	t.relayStageMatch(c, s, sourceID1, pb.Stage_Running)
 	t.subTaskStageMatch(c, s, taskName1, sourceID1, pb.Stage_Running)
-
-	// shutdown the scheduler.
-	s.Close()
+	rebuildScheduler(ctx)
 
 	// CASE 3: start again with previous `Offline` worker, relay stage, subtask stage.
-	c.Assert(s.Start(ctx, etcdTestCli), IsNil)
-
 	// CASE 3.1: previous information should recover.
 	// source1 is still unbound.
 	t.sourceBounds(c, s, []string{}, []string{sourceID1})
@@ -266,6 +282,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	// expect relay stage keep Running.
 	t.relayStageMatch(c, s, sourceID1, pb.Stage_Running)
 	t.subTaskStageMatch(c, s, taskName1, sourceID1, pb.Stage_Running)
+	rebuildScheduler(ctx)
 
 	// CASE 3.2: start worker1 again.
 	// do keep-alive for worker1 again.
@@ -286,12 +303,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	// expect stages keep Running.
 	t.relayStageMatch(c, s, sourceID1, pb.Stage_Running)
 	t.subTaskStageMatch(c, s, taskName1, sourceID1, pb.Stage_Running)
-
-	// shutdown the scheduler.
-	s.Close()
-
-	// CASE 4: start again with previous `Bound` worker, relay stage, subtask stage.
-	c.Assert(s.Start(ctx, etcdTestCli), IsNil)
+	rebuildScheduler(ctx)
 
 	// CASE 4.1: previous information should recover.
 	// source1 is still bound.
@@ -305,6 +317,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	// expect stages keep Running.
 	t.relayStageMatch(c, s, sourceID1, pb.Stage_Running)
 	t.subTaskStageMatch(c, s, taskName1, sourceID1, pb.Stage_Running)
+	rebuildScheduler(ctx)
 
 	// CASE 4.2: add another worker into the cluster.
 	// worker2 not exists before added.
@@ -314,6 +327,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	// the worker added, but is offline.
 	t.workerExist(c, s, workerInfo2)
 	t.workerOffline(c, s, workerName2)
+	rebuildScheduler(ctx)
 
 	// CASE 4.3: the worker2 become online.
 	// do keep-alive for worker2.
@@ -329,6 +343,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 		return w.Stage() == WorkerFree
 	})
 	t.workerFree(c, s, workerName2)
+	rebuildScheduler(ctx)
 
 	// CASE 4.4: add source config2.
 	// source2 not exists before.
@@ -341,6 +356,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	t.workerBound(c, s, ha.NewSourceBound(sourceID2, workerName2))
 	t.sourceBounds(c, s, []string{sourceID1, sourceID2}, []string{})
 	t.relayStageMatch(c, s, sourceID2, pb.Stage_Running)
+	rebuildScheduler(ctx)
 
 	// CASE 4.4: start a task with two sources.
 	// can't add more than one tasks at a time now.
@@ -357,6 +373,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	t.subTaskCfgExist(c, s, subtaskCfg22)
 	t.subTaskStageMatch(c, s, taskName2, sourceID1, pb.Stage_Running)
 	t.subTaskStageMatch(c, s, taskName2, sourceID2, pb.Stage_Running)
+	rebuildScheduler(ctx)
 
 	// CASE 4.4.1 fail to stop any task.
 	// can call without tasks or sources, return without error, but take no effect.
@@ -379,6 +396,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	c.Assert(s.UpdateExpectSubTaskStage(pb.Stage_Running, taskName2, sourceID1, sourceID2), IsNil)
 	t.subTaskStageMatch(c, s, taskName2, sourceID1, pb.Stage_Running)
 	t.subTaskStageMatch(c, s, taskName2, sourceID2, pb.Stage_Running)
+	rebuildScheduler(ctx)
 
 	// CASE 4.6: try remove source when subtasks exist.
 	c.Assert(terror.ErrSchedulerSourceOpTaskExist.Equal(s.RemoveSourceCfg(sourceID2)), IsTrue)
@@ -388,6 +406,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	t.workerBound(c, s, ha.NewSourceBound(sourceID2, workerName2))
 	t.sourceBounds(c, s, []string{sourceID1, sourceID2}, []string{})
 	t.relayStageMatch(c, s, sourceID2, pb.Stage_Running)
+	rebuildScheduler(ctx)
 
 	// CASE 4.7: stop task2.
 	c.Assert(s.RemoveSubTasks(taskName2, sourceID1, sourceID2), IsNil)
@@ -395,6 +414,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	t.subTaskCfgNotExist(c, s, taskName2, sourceID2)
 	t.subTaskStageMatch(c, s, taskName2, sourceID1, pb.Stage_InvalidStage)
 	t.subTaskStageMatch(c, s, taskName2, sourceID2, pb.Stage_InvalidStage)
+	rebuildScheduler(ctx)
 
 	// CASE 4.7: remove source2.
 	c.Assert(s.RemoveSourceCfg(sourceID2), IsNil)
@@ -405,6 +425,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	t.workerFree(c, s, workerName2)
 	t.sourceBounds(c, s, []string{sourceID1}, []string{})
 	t.relayStageMatch(c, s, sourceID2, pb.Stage_InvalidStage)
+	rebuildScheduler(ctx)
 
 	// CASE 4.8: worker1 become offline.
 	// before shutdown, worker1 bound source
@@ -424,23 +445,27 @@ func (t *testScheduler) TestScheduler(c *C) {
 	// expect stages keep Running.
 	t.relayStageMatch(c, s, sourceID1, pb.Stage_Running)
 	t.subTaskStageMatch(c, s, taskName1, sourceID1, pb.Stage_Running)
+	rebuildScheduler(ctx)
 
 	// CASE 4.9: remove worker1.
 	c.Assert(s.RemoveWorker(workerName1), IsNil)
 	c.Assert(terror.ErrSchedulerWorkerNotExist.Equal(s.RemoveWorker(workerName1)), IsTrue) // can't remove multiple times.
 	// worker1 not exists now.
 	t.workerNotExist(c, s, workerName1)
+	rebuildScheduler(ctx)
 
 	// CASE 4.10: stop task1.
 	c.Assert(s.RemoveSubTasks(taskName1, sourceID1), IsNil)
 	t.subTaskCfgNotExist(c, s, taskName1, sourceID1)
 	t.subTaskStageMatch(c, s, taskName1, sourceID1, pb.Stage_InvalidStage)
+	rebuildScheduler(ctx)
 
 	// CASE 4.11: remove worker not supported when the worker is online.
 	c.Assert(terror.ErrSchedulerWorkerOnline.Equal(s.RemoveWorker(workerName2)), IsTrue)
 	t.sourceBounds(c, s, []string{sourceID1}, []string{})
 	t.workerBound(c, s, ha.NewSourceBound(sourceID1, workerName2))
 	t.relayStageMatch(c, s, sourceID1, pb.Stage_Running)
+	rebuildScheduler(ctx)
 
 	// CASE 4.12: worker2 become offline.
 	cancel2()
@@ -456,6 +481,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	t.sourceBounds(c, s, []string{}, []string{sourceID1})
 	// expect stages keep Running.
 	t.relayStageMatch(c, s, sourceID1, pb.Stage_Running)
+	rebuildScheduler(ctx)
 
 	// CASE 4.13: remove worker2.
 	c.Assert(s.RemoveWorker(workerName2), IsNil)
@@ -463,6 +489,7 @@ func (t *testScheduler) TestScheduler(c *C) {
 	// relay stage still there.
 	t.sourceBounds(c, s, []string{}, []string{sourceID1})
 	t.relayStageMatch(c, s, sourceID1, pb.Stage_Running)
+	rebuildScheduler(ctx)
 
 	// CASE 4.14: remove source1.
 	c.Assert(s.RemoveSourceCfg(sourceID1), IsNil)

--- a/dm/master/shardddl/pessimist.go
+++ b/dm/master/shardddl/pessimist.go
@@ -127,7 +127,6 @@ func (p *Pessimist) Start(pCtx context.Context, etcdCli *clientv3.Client) error 
 
 	p.closed = false // started now.
 	p.cancel = cancel
-	p.cli = etcdCli
 	p.logger.Info("the shard DDL pessimist has started")
 	return nil
 }

--- a/dm/master/shardddl/pessimist_test.go
+++ b/dm/master/shardddl/pessimist_test.go
@@ -184,7 +184,8 @@ func (t *testPessimist) TestPessimist(c *C) {
 		return remain == 1
 	}), IsTrue)
 
-	p.Close() // close the Pessimist.
+	p.Close()                          // close the Pessimist.
+	p = NewPessimist(&logger, sources) // rebuild another pessimist because pessimist will be rebuilt after interruption
 
 	// CASE 3: start again with some previous shard DDL info and the lock is un-synced.
 	c.Assert(p.Start(ctx, etcdTestCli), IsNil)
@@ -235,7 +236,8 @@ func (t *testPessimist) TestPessimist(c *C) {
 		return p.Locks()[ID2].IsDone(source1)
 	}), IsTrue)
 
-	p.Close() // close the Pessimist.
+	p.Close()                          // close the Pessimist.
+	p = NewPessimist(&logger, sources) // rebuild another pessimist because pessimist will be rebuilt after interruption
 
 	// CASE 5: start again with some previous shard DDL info and `done` operation for the owner.
 	c.Assert(p.Start(ctx, etcdTestCli), IsNil)
@@ -255,7 +257,8 @@ func (t *testPessimist) TestPessimist(c *C) {
 		return p.Locks()[ID2].IsDone(source2)
 	}), IsTrue)
 
-	p.Close() // close the Pessimist.
+	p.Close()                          // close the Pessimist.
+	p = NewPessimist(&logger, sources) // rebuild another pessimist because pessimist will be rebuilt after interruption
 
 	// CASE 6: start again with some previous shard DDL info and `done` operation for the owner and non-owner.
 	c.Assert(p.Start(ctx, etcdTestCli), IsNil)
@@ -279,7 +282,8 @@ func (t *testPessimist) TestPessimist(c *C) {
 	}), IsTrue)
 	c.Assert(p.Locks(), HasLen, 0)
 
-	p.Close() // close the Pessimist.
+	p.Close()                          // close the Pessimist.
+	p = NewPessimist(&logger, sources) // rebuild another pessimist because pessimist will be rebuilt after interruption
 
 	// CASE 7: start again after all shard DDL locks have been resolved.
 	c.Assert(p.Start(ctx, etcdTestCli), IsNil)
@@ -502,6 +506,7 @@ func (t *testPessimist) TestUnlockSourceMissBeforeSynced(c *C) {
 	defer cancel()
 
 	// 0. start the pessimist.
+	c.Assert(terror.ErrMasterPessimistNotStarted.Equal(p.UnlockLock(ctx, ID, "", false)), IsTrue)
 	c.Assert(p.Start(ctx, etcdTestCli), IsNil)
 	c.Assert(p.Locks(), HasLen, 0)
 	defer p.Close()

--- a/dm/master/shardddl/pessimist_test.go
+++ b/dm/master/shardddl/pessimist_test.go
@@ -35,6 +35,12 @@ var (
 	etcdTestCli *clientv3.Client
 )
 
+const (
+	noRestart          = iota // do nothing in rebuildPessimist, just keep testing
+	restartOnly               // restart without building new instance. mock leader role transfer
+	restartNewInstance        // restart with build a new instance. mock progress restore from failure
+)
+
 type testPessimist struct{}
 
 var _ = Suite(&testPessimist{})
@@ -59,6 +65,12 @@ func clearTestInfoOperation(c *C) {
 }
 
 func (t *testPessimist) TestPessimist(c *C) {
+	t.testPessimistProgress(c, noRestart)
+	t.testPessimistProgress(c, restartOnly)
+	t.testPessimistProgress(c, restartNewInstance)
+}
+
+func (t *testPessimist) testPessimistProgress(c *C, restart int) {
 	defer clearTestInfoOperation(c)
 
 	var (
@@ -91,6 +103,18 @@ func (t *testPessimist) TestPessimist(c *C) {
 		}
 		logger = log.L()
 		p      = NewPessimist(&logger, sources)
+
+		rebuildPessimist = func(ctx context.Context) {
+			switch restart {
+			case restartOnly:
+				p.Close()
+				c.Assert(p.Start(ctx, etcdTestCli), IsNil)
+			case restartNewInstance:
+				p.Close()
+				p = NewPessimist(&logger, sources)
+				c.Assert(p.Start(ctx, etcdTestCli), IsNil)
+			}
+		}
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -184,11 +208,8 @@ func (t *testPessimist) TestPessimist(c *C) {
 		return remain == 1
 	}), IsTrue)
 
-	p.Close()                          // close the Pessimist.
-	p = NewPessimist(&logger, sources) // rebuild another pessimist because pessimist will be rebuilt after interruption
-
 	// CASE 3: start again with some previous shard DDL info and the lock is un-synced.
-	c.Assert(p.Start(ctx, etcdTestCli), IsNil)
+	rebuildPessimist(ctx)
 	c.Assert(p.Locks(), HasLen, 1)
 	c.Assert(p.Locks(), HasKey, ID2)
 	synced, remain = p.Locks()[ID2].IsSynced()
@@ -216,10 +237,8 @@ func (t *testPessimist) TestPessimist(c *C) {
 	c.Assert(op21.Exec, IsTrue)
 	c.Assert(op21.Done, IsFalse)
 
-	p.Close() // close the Pessimist.
-
 	// CASE 4: start again with some previous shard DDL info and non-`done` operation.
-	c.Assert(p.Start(ctx, etcdTestCli), IsNil)
+	rebuildPessimist(ctx)
 	c.Assert(p.Locks(), HasLen, 1)
 	c.Assert(p.Locks(), HasKey, ID2)
 	synced, _ = p.Locks()[ID2].IsSynced()
@@ -236,11 +255,8 @@ func (t *testPessimist) TestPessimist(c *C) {
 		return p.Locks()[ID2].IsDone(source1)
 	}), IsTrue)
 
-	p.Close()                          // close the Pessimist.
-	p = NewPessimist(&logger, sources) // rebuild another pessimist because pessimist will be rebuilt after interruption
-
 	// CASE 5: start again with some previous shard DDL info and `done` operation for the owner.
-	c.Assert(p.Start(ctx, etcdTestCli), IsNil)
+	rebuildPessimist(ctx)
 	c.Assert(p.Locks(), HasLen, 1)
 	c.Assert(p.Locks(), HasKey, ID2)
 	synced, _ = p.Locks()[ID2].IsSynced()
@@ -257,11 +273,8 @@ func (t *testPessimist) TestPessimist(c *C) {
 		return p.Locks()[ID2].IsDone(source2)
 	}), IsTrue)
 
-	p.Close()                          // close the Pessimist.
-	p = NewPessimist(&logger, sources) // rebuild another pessimist because pessimist will be rebuilt after interruption
-
 	// CASE 6: start again with some previous shard DDL info and `done` operation for the owner and non-owner.
-	c.Assert(p.Start(ctx, etcdTestCli), IsNil)
+	rebuildPessimist(ctx)
 	c.Assert(p.Locks(), HasLen, 1)
 	c.Assert(p.Locks(), HasKey, ID2)
 	synced, _ = p.Locks()[ID2].IsSynced()
@@ -282,11 +295,8 @@ func (t *testPessimist) TestPessimist(c *C) {
 	}), IsTrue)
 	c.Assert(p.Locks(), HasLen, 0)
 
-	p.Close()                          // close the Pessimist.
-	p = NewPessimist(&logger, sources) // rebuild another pessimist because pessimist will be rebuilt after interruption
-
 	// CASE 7: start again after all shard DDL locks have been resolved.
-	c.Assert(p.Start(ctx, etcdTestCli), IsNil)
+	rebuildPessimist(ctx)
 	c.Assert(p.Locks(), HasLen, 0)
 	p.Close() // close the Pessimist.
 }

--- a/pkg/terror/error_list.go
+++ b/pkg/terror/error_list.go
@@ -409,6 +409,7 @@ const (
 	codeMasterRequestIsNotForwardToLeader
 	codeMasterIsNotAsyncRequest
 	codeMasterFailToGetExpectResult
+	codeMasterPessimistNotStarted
 )
 
 // DM-worker error code
@@ -913,6 +914,7 @@ var (
 	ErrMasterRequestIsNotForwardToLeader = New(codeMasterRequestIsNotForwardToLeader, ClassDMMaster, ScopeInternal, LevelHigh, "master is not leader, and can't forward request to leader")
 	ErrMasterIsNotAsyncRequest           = New(codeMasterIsNotAsyncRequest, ClassDMMaster, ScopeInternal, LevelMedium, "request %s is not an async one, needn't wait for ok")
 	ErrMasterFailToGetExpectResult       = New(codeMasterFailToGetExpectResult, ClassDMMaster, ScopeInternal, LevelMedium, "fail to get expected result")
+	ErrMasterPessimistNotStarted         = New(codeMasterPessimistNotStarted, ClassDMMaster, ScopeInternal, LevelMedium, "the shardddl pessimist has not started")
 
 	// DM-worker error
 	ErrWorkerParseFlagSet            = New(codeWorkerParseFlagSet, ClassDMWorker, ScopeInternal, LevelMedium, "parse dm-worker config flag set")


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/dm/issues/561

### What is changed and how it works?
1. set etcdClient to component at the beginning initialization
2. use `p.mu.Lock` for `Pessimist.UnlockLock` to avoid concurrency.
3. add stronger UT in scheduler and pessimist.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

