### PR TITLE
worker/: fix subtask config pointer usage

### DIFF
--- a/dm/worker/server.go
+++ b/dm/worker/server.go
@@ -721,8 +721,8 @@ func (s *Server) startWorker(cfg *config.SourceConfig) error {
 	for _, subTaskCfg := range subTaskCfgm {
 		subTaskCfg.LogLevel = s.cfg.LogLevel
 		subTaskCfg.LogFile = s.cfg.LogFile
-
-		subTaskCfgs = append(subTaskCfgs, &subTaskCfg)
+		subTaskCfgClone := subTaskCfg
+		subTaskCfgs = append(subTaskCfgs, &subTaskCfgClone)
 	}
 
 	if cfg.EnableRelay {


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
We append pointer of loop variables, which can't represent the actual value.

### What is changed and how it works?
Append pointers of subtask config's copy.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
