### PR TITLE
syncer/: add async flush checkpoint

### DIFF
--- a/syncer/checkpoint.go
+++ b/syncer/checkpoint.go
@@ -357,7 +357,6 @@ func (cp *RemoteCheckPoint) SaveGlobalPoint(pos mysql.Position) {
 // FlushPointsExcept implements CheckPoint.FlushPointsExcept
 func (cp *RemoteCheckPoint) FlushPointsExcept(tctx *tcontext.Context, exceptTables [][]string, extraSQLs []string, extraArgs [][]interface{}) error {
 	cp.RLock()
-	defer cp.RUnlock()
 
 	// convert slice to map
 	excepts := make(map[string]map[string]struct{})
@@ -406,16 +405,18 @@ func (cp *RemoteCheckPoint) FlushPointsExcept(tctx *tcontext.Context, exceptTabl
 	}
 
 	_, err := cp.dbConn.executeSQL(tctx, sqls, args...)
+	cp.RUnlock()
 	if err != nil {
 		return err
 	}
 
+	cp.Lock()
 	cp.globalPoint.flush()
 	for _, point := range points {
 		point.flush()
 	}
-
 	cp.globalPointSaveTime = time.Now()
+	cp.Unlock()
 	return nil
 }
 

--- a/syncer/job.go
+++ b/syncer/job.go
@@ -33,6 +33,7 @@ const (
 	flush
 	skip // used by Syncer.recordSkipSQLsPos to record global pos, but not execute SQL
 	rotate
+	fake // used to flush worker's checkpoint
 )
 
 func (t opType) String() string {
@@ -53,6 +54,8 @@ func (t opType) String() string {
 		return "skip"
 	case rotate:
 		return "rotate"
+	case fake:
+		return "fake"
 	}
 
 	return ""
@@ -150,6 +153,13 @@ func newXIDJob(pos, cmdPos mysql.Position, currentGtidSet gtid.Set, traceID stri
 func newFlushJob() *job {
 	return &job{
 		tp: flush,
+	}
+}
+
+func newFakeJob(pos mysql.Position) *job {
+	return &job{
+		tp:  fake,
+		pos: pos,
 	}
 }
 

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -769,7 +769,11 @@ func (s *Syncer) checkWait(job *job) bool {
 func (s *Syncer) addJob(job *job) error {
 	defer func() {
 		if job.tp == insert || job.tp == update || job.tp == del {
-			s.lastAddedJobPos.save(s.sgk.AdjustGlobalPoint(job.pos))
+			pos := job.pos
+			if s.cfg.IsSharding {
+				pos = s.sgk.AdjustGlobalPoint(pos)
+			}
+			s.lastAddedJobPos.save(pos)
 		}
 	}()
 	var (

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -769,7 +769,7 @@ func (s *Syncer) checkWait(job *job) bool {
 func (s *Syncer) addJob(job *job) error {
 	defer func() {
 		if job.tp == insert || job.tp == update || job.tp == del {
-			s.lastAddedJobPos.save(job.pos)
+			s.lastAddedJobPos.save(s.sgk.AdjustGlobalPoint(job.pos))
 		}
 	}()
 	var (

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -88,7 +88,11 @@ type FlushType uint8
 
 // flush checkpoint type
 const (
+	// For ddl job the global checkpoint will be updated in addJobFunc, so we needn't update and flush directly
 	NoNeedUpdate FlushType = iota + 1
+	// If global checkpoint hasn't been updated for more than 30s, or receive a flush job,
+	// we send a NeedUpdate request to async flush checkpoint go routine.
+	// It will update global checkpoint to minPos of workers and then flush checkpoint
 	NeedUpdate
 )
 

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -83,8 +83,10 @@ const (
 	LocalBinlog
 )
 
+// FlushType represents flush checkpoint type
 type FlushType uint8
 
+// flush checkpoint type
 const (
 	NoNeedUpdate FlushType = iota + 1
 	NeedUpdate

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -327,6 +327,7 @@ func (s *Syncer) Init(ctx context.Context) (err error) {
 		return err
 	}
 	rollbackHolder.Add(fr.FuncRollback{Name: "close-DBs", Fn: s.closeDBs})
+	s.workerCheckpoints = makeWorkerCheckpointArray(s.cfg.WorkerCount)
 
 	s.bwList, err = filter.New(s.cfg.CaseSensitive, s.cfg.BWList)
 	if err != nil {
@@ -2585,4 +2586,12 @@ func (s *Syncer) setTimezone() {
 	}
 	s.tctx.L().Info("use timezone", log.WrapStringerField("location", loc))
 	s.timezone = loc
+}
+
+func makeWorkerCheckpointArray(workerCount int) []*binlogPoint {
+	workerCheckpoints := make([]*binlogPoint, 0, workerCount)
+	for i := 0; i < workerCount; i++ {
+		workerCheckpoints = append(workerCheckpoints, newBinlogPoint(minCheckpoint, minCheckpoint))
+	}
+	return workerCheckpoints
 }

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -1036,6 +1036,8 @@ func (s *testSyncerSuite) TestCasuality(c *C) {
 	s.cfg.WorkerCount = 1
 	syncer := NewSyncer(s.cfg)
 	syncer.jobs = []chan *job{make(chan *job, 1)}
+	syncer.workerCheckpoints = makeWorkerCheckpointArray(1)
+	syncer.flushCheckpointChan = make(chan FlushType, 16)
 	syncer.queueBucketMapping = []string{"queue_0", adminQueueName}
 
 	wg.Add(1)

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -1035,6 +1035,7 @@ func (s *testSyncerSuite) TestCasuality(c *C) {
 	var wg sync.WaitGroup
 	s.cfg.WorkerCount = 1
 	syncer := NewSyncer(s.cfg)
+	syncer.lastAddedJobPos = newBinlogPoint(minCheckpoint, minCheckpoint)
 	syncer.jobs = []chan *job{make(chan *job, 1)}
 	syncer.workerCheckpoints = makeWorkerCheckpointArray(1)
 	syncer.flushCheckpointChan = make(chan FlushType, 16)

--- a/tests/retry_cancel/run.sh
+++ b/tests/retry_cancel/run.sh
@@ -92,7 +92,10 @@ function run() {
 
     # use sync_diff_inspector to check full dump loader
     check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
-
+    # execute ddl to make sure sync checkpoint is flushed
+	run_sql "ALTER TABLE \`retry_cancel\`.\`t1\` ADD COLUMN info VARCHAR(10);" $MYSQL_PORT1 $MYSQL_PASSWORD1
+    run_sql "ALTER TABLE \`retry_cancel\`.\`t2\` ADD COLUMN info VARCHAR(10);" $MYSQL_PORT2 $MYSQL_PASSWORD2
+    sleep 3
     # ---------- test for incremental replication ----------
     # stop DM-worker, then enable failponits
     kill_dm_worker

--- a/tests/retry_cancel/run.sh
+++ b/tests/retry_cancel/run.sh
@@ -93,7 +93,7 @@ function run() {
     # use sync_diff_inspector to check full dump loader
     check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
     # execute ddl to make sure sync checkpoint is flushed
-	run_sql "ALTER TABLE \`retry_cancel\`.\`t1\` ADD COLUMN info VARCHAR(10);" $MYSQL_PORT1 $MYSQL_PASSWORD1
+    run_sql "ALTER TABLE \`retry_cancel\`.\`t1\` ADD COLUMN info VARCHAR(10);" $MYSQL_PORT1 $MYSQL_PASSWORD1
     run_sql "ALTER TABLE \`retry_cancel\`.\`t2\` ADD COLUMN info VARCHAR(10);" $MYSQL_PORT2 $MYSQL_PASSWORD2
     sleep 3
     # ---------- test for incremental replication ----------


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Async flush checkpoint to improve effeciency.

### What is changed and how it works?
worker goroutine: concurrent worker count
1. The worker successfully executes a batch of jobs
2. The worker updates his checkpoint to his latest successful job pos
(The checkpoint saved by the worker goroutine is only global checkpoint, and the table checkpoint is refreshed by ddl job)

flush goroutine:
for loop
     1. Get flush type from channel. Check whether we need to update global checkpoint this time. If so, update global checkpoint with min worker pos.
     2. Flush checkpoint.

add job:
No longer scheduled wait dml job execution is complete
     a. The ddl job is executed, the wait job is completed, the checkpoint is updated, and submitted to the flush goroutine
     b. If there is no flush checkpoint for more than 30s, submit a request to the flush goroutine

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported variable/fields change
