### PR TITLE
syncer: improve performance - part 2

### DIFF
--- a/dm/config/subtask.go
+++ b/dm/config/subtask.go
@@ -273,6 +273,13 @@ func (c *SubTaskConfig) Adjust(verifyDecryptPassword bool) error {
 		c.LoaderConfig.Dir += dirSuffix
 	}
 
+	if c.SyncerConfig.QueueSize == 0 {
+		c.SyncerConfig.QueueSize = defaultQueueSize
+	}
+	if c.SyncerConfig.CheckpointFlushInterval == 0 {
+		c.SyncerConfig.CheckpointFlushInterval = defaultCheckpointFlushInterval
+	}
+
 	c.From.Adjust()
 	c.To.Adjust()
 

--- a/dm/config/task.go
+++ b/dm/config/task.go
@@ -55,9 +55,10 @@ var (
 	defaultPoolSize = 16
 	defaultDir      = "./dumped_data"
 	// SyncerConfig
-	defaultWorkerCount = 16
-	defaultBatch       = 100
-	defaultQueueSize   = 5120
+	defaultWorkerCount             = 16
+	defaultBatch                   = 100
+	defaultQueueSize               = 5120
+	defaultCheckpointFlushInterval = 30 // in seconds
 )
 
 // Meta represents binlog's meta pos
@@ -195,6 +196,8 @@ type SyncerConfig struct {
 	WorkerCount int    `yaml:"worker-count" toml:"worker-count" json:"worker-count"`
 	Batch       int    `yaml:"batch" toml:"batch" json:"batch"`
 	QueueSize   int    `yaml:"queue-size" toml:"queue-size" json:"queue-size"`
+	// checkpoint flush interval in seconds.
+	CheckpointFlushInterval int `yaml:"checkpoint-flush-interval" toml:"checkpoint-flush-interval" json:"checkpoint-flush-interval"`
 
 	// deprecated
 	MaxRetry int `yaml:"max-retry" toml:"max-retry" json:"max-retry"`
@@ -209,9 +212,10 @@ type SyncerConfig struct {
 
 func defaultSyncerConfig() SyncerConfig {
 	return SyncerConfig{
-		WorkerCount: defaultWorkerCount,
-		Batch:       defaultBatch,
-		QueueSize:   defaultQueueSize,
+		WorkerCount:             defaultWorkerCount,
+		Batch:                   defaultBatch,
+		QueueSize:               defaultQueueSize,
+		CheckpointFlushInterval: defaultCheckpointFlushInterval,
 	}
 }
 

--- a/dm/config/task.go
+++ b/dm/config/task.go
@@ -57,8 +57,8 @@ var (
 	// SyncerConfig
 	defaultWorkerCount             = 16
 	defaultBatch                   = 100
-	defaultQueueSize               = 5120
-	defaultCheckpointFlushInterval = 30 // in seconds
+	defaultQueueSize               = 1024 // do not give too large default value to avoid OOM
+	defaultCheckpointFlushInterval = 30   // in seconds
 )
 
 // Meta represents binlog's meta pos

--- a/dm/dm-ansible/scripts/dm.json
+++ b/dm/dm-ansible/scripts/dm.json
@@ -2882,15 +2882,17 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "The number of binlog events received per unit of time that need to be skipped",
+          "description": "The number of binlog events received per unit of time that needs to be skipped",
           "fill": 1,
           "id": 35,
           "legend": {
+            "alignAsTable": true,
             "avg": false,
             "current": false,
             "max": false,
             "min": false,
-            "show": false,
+            "rightSide": true,
+            "show": true,
             "total": false,
             "values": false
           },
@@ -2909,10 +2911,18 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(dm_syncer_binlog_skipped_events_total{task=\"$task\", instance=\"$instance\"}[1m])",
+              "expr": "rate(dm_syncer_skip_binlog_duration_count{task=\"$task\", instance=\"$instance\", type=\"rows\"}[1m])",
               "format": "time_series",
               "intervalFactor": 2,
+              "legendFormat": "rows",
               "refId": "A"
+            },
+            {
+              "expr": "rate(dm_syncer_skip_binlog_duration_count{task=\"$task\", instance=\"$instance\", type=\"query\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "query",
+              "refId": "B"
             }
           ],
           "thresholds": [],
@@ -3691,7 +3701,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 4,
+          "span": 3,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -3792,7 +3802,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 4,
+          "span": 3,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -3886,7 +3896,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 4,
+          "span": 3,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -3916,6 +3926,100 @@
           "timeFrom": null,
           "timeShift": null,
           "title": "DML conflict detect duration",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 2,
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The time it takes binlog replication unit to skip a binlog event (in seconds)",
+          "fill": 1,
+          "id": 60,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.90, sum(rate(dm_syncer_skip_binlog_duration_bucket{task=\"$task\", instance=\"$instance\"}[1m])) by (le))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "90",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(dm_syncer_skip_binlog_duration_bucket{task=\"$task\", instance=\"$instance\"}[1m])) by (le))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(dm_syncer_skip_binlog_duration_bucket{task=\"$task\", instance=\"$instance\"}[1m])) by (le))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "99",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "skip event duration",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -4193,5 +4297,5 @@
   },
   "timezone": "",
   "title": "DM-task",
-  "version": 31
+  "version": 32
 }

--- a/syncer/checkpoint.go
+++ b/syncer/checkpoint.go
@@ -46,8 +46,6 @@ var (
 	globalCpTable        = "" // global checkpoint's cp_table
 	maxCheckPointTimeout = "1m"
 	minCheckpoint        = mysql.Position{Pos: 4}
-
-	maxCheckPointSaveTime = 30 * time.Second
 )
 
 // NOTE: now we sync from relay log, so not add GTID support yet
@@ -453,7 +451,7 @@ func (cp *RemoteCheckPoint) String() string {
 func (cp *RemoteCheckPoint) CheckGlobalPoint() bool {
 	cp.RLock()
 	defer cp.RUnlock()
-	return time.Since(cp.globalPointSaveTime) >= maxCheckPointSaveTime
+	return time.Since(cp.globalPointSaveTime) >= time.Duration(cp.cfg.CheckpointFlushInterval)*time.Second
 }
 
 // Rollback implements CheckPoint.Rollback

--- a/syncer/metrics.go
+++ b/syncer/metrics.go
@@ -84,12 +84,13 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(0.000005, 2, 25),
 		}, []string{"type", "task"})
 
-	binlogSkippedEventsTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
+	skipBinlogDurationHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Namespace: "dm",
 			Subsystem: "syncer",
-			Name:      "binlog_skipped_events_total",
-			Help:      "total number of skipped binlog events",
+			Name:      "skip_binlog_duration",
+			Help:      "bucketed histogram of skip a binlog event time (s)",
+			Buckets:   prometheus.ExponentialBuckets(0.0000005, 2, 25), // this should be very fast.
 		}, []string{"type", "task"})
 
 	addedJobsTotal = prometheus.NewCounterVec(
@@ -227,7 +228,7 @@ func RegisterMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(conflictDetectDurationHistogram)
 	registry.MustRegister(addJobDurationHistogram)
 	registry.MustRegister(dispatchBinlogDurationHistogram)
-	registry.MustRegister(binlogSkippedEventsTotal)
+	registry.MustRegister(skipBinlogDurationHistogram)
 	registry.MustRegister(addedJobsTotal)
 	registry.MustRegister(finishedJobsTotal)
 	registry.MustRegister(queueSizeGauge)

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -781,6 +781,7 @@ func (s *Syncer) addJob(job *job) error {
 		queueBucket = int(utils.GenHashKey(job.key)) % s.cfg.WorkerCount
 		s.addCount(false, s.queueBucketMapping[queueBucket], job.tp, 1)
 		startTime := time.Now()
+		s.tctx.L().Warn("queue for key", zap.Int("queue", queueBucket), zap.String("key", job.key))
 		s.jobs[queueBucket] <- job
 		addJobDurationHistogram.WithLabelValues(job.tp.String(), s.cfg.Name, s.queueBucketMapping[queueBucket]).Observe(time.Since(startTime).Seconds())
 	}
@@ -1957,6 +1958,7 @@ func (s *Syncer) commitJob(tp opType, sourceSchema, sourceTable, targetSchema, t
 	if err != nil {
 		return terror.ErrSyncerUnitResolveCasualityFail.Generate(err)
 	}
+	s.tctx.L().Warn("key for keys", zap.String("key", key), zap.Strings("keys", keys))
 	conflictDetectDurationHistogram.WithLabelValues(s.cfg.Name).Observe(time.Since(startTime).Seconds())
 
 	job := newJob(tp, sourceSchema, sourceTable, targetSchema, targetTable, sql, args, key, pos, cmdPos, gs, traceID)

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -781,6 +781,7 @@ func (s *Syncer) addJob(job *job) error {
 		queueBucket = int(utils.GenHashKey(job.key)) % s.cfg.WorkerCount
 		s.addCount(false, s.queueBucketMapping[queueBucket], job.tp, 1)
 		startTime := time.Now()
+		s.tctx.L().Debug("queue for key", zap.Int("queue", queueBucket), zap.String("key", job.key))
 		s.jobs[queueBucket] <- job
 		addJobDurationHistogram.WithLabelValues(job.tp.String(), s.cfg.Name, s.queueBucketMapping[queueBucket]).Observe(time.Since(startTime).Seconds())
 	}
@@ -1957,6 +1958,7 @@ func (s *Syncer) commitJob(tp opType, sourceSchema, sourceTable, targetSchema, t
 	if err != nil {
 		return terror.ErrSyncerUnitResolveCasualityFail.Generate(err)
 	}
+	s.tctx.L().Debug("key for keys", zap.String("key", key), zap.Strings("keys", keys))
 	conflictDetectDurationHistogram.WithLabelValues(s.cfg.Name).Observe(time.Since(startTime).Seconds())
 
 	job := newJob(tp, sourceSchema, sourceTable, targetSchema, targetTable, sql, args, key, pos, cmdPos, gs, traceID)

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -781,7 +781,6 @@ func (s *Syncer) addJob(job *job) error {
 		queueBucket = int(utils.GenHashKey(job.key)) % s.cfg.WorkerCount
 		s.addCount(false, s.queueBucketMapping[queueBucket], job.tp, 1)
 		startTime := time.Now()
-		s.tctx.L().Warn("queue for key", zap.Int("queue", queueBucket), zap.String("key", job.key))
 		s.jobs[queueBucket] <- job
 		addJobDurationHistogram.WithLabelValues(job.tp.String(), s.cfg.Name, s.queueBucketMapping[queueBucket]).Observe(time.Since(startTime).Seconds())
 	}
@@ -1958,7 +1957,6 @@ func (s *Syncer) commitJob(tp opType, sourceSchema, sourceTable, targetSchema, t
 	if err != nil {
 		return terror.ErrSyncerUnitResolveCasualityFail.Generate(err)
 	}
-	s.tctx.L().Warn("key for keys", zap.String("key", key), zap.Strings("keys", keys))
 	conflictDetectDurationHistogram.WithLabelValues(s.cfg.Name).Observe(time.Since(startTime).Seconds())
 
 	job := newJob(tp, sourceSchema, sourceTable, targetSchema, targetTable, sql, args, key, pos, cmdPos, gs, traceID)

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -1455,7 +1455,7 @@ func (s *Syncer) handleRowsEvent(ev *replication.RowsEvent, ec eventContext) err
 		return err
 	}
 	if ignore {
-		binlogSkippedEventsTotal.WithLabelValues("rows", s.cfg.Name).Inc()
+		skipBinlogDurationHistogram.WithLabelValues("rows", s.cfg.Name).Observe(time.Since(ec.startTime).Seconds())
 		// for RowsEvent, we should record lastPos rather than currentPos
 		return s.recordSkipSQLsPos(*ec.lastPos, nil)
 	}
@@ -1586,7 +1586,7 @@ func (s *Syncer) handleQueryEvent(ev *replication.QueryEvent, ec eventContext) e
 	}
 
 	if parseResult.ignore {
-		binlogSkippedEventsTotal.WithLabelValues("query", s.cfg.Name).Inc()
+		skipBinlogDurationHistogram.WithLabelValues("query", s.cfg.Name).Observe(time.Since(ec.startTime).Seconds())
 		s.tctx.L().Warn("skip event", zap.String("event", "query"), zap.String("statement", sql), zap.String("schema", usedSchema))
 		*ec.lastPos = *ec.currentPos // before record skip pos, update lastPos
 		return s.recordSkipSQLsPos(*ec.lastPos, nil)
@@ -1661,7 +1661,7 @@ func (s *Syncer) handleQueryEvent(ev *replication.QueryEvent, ec eventContext) e
 			return handleErr
 		}
 		if len(sqlDDL) == 0 {
-			binlogSkippedEventsTotal.WithLabelValues("query", s.cfg.Name).Inc()
+			skipBinlogDurationHistogram.WithLabelValues("query", s.cfg.Name).Observe(time.Since(ec.startTime).Seconds())
 			s.tctx.L().Warn("skip event", zap.String("event", "query"), zap.String("statement", sql), zap.String("schema", usedSchema))
 			continue
 		}

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -1190,6 +1190,7 @@ func (s *testSyncerSuite) TestSharding(c *C) {
 	// set batch to 1 is easy to mock
 	s.cfg.Batch = 1
 	s.cfg.WorkerCount = 1
+	s.cfg.CheckpointFlushInterval = 30
 
 	for i, _case := range testCases {
 		s.resetEventsGenerator(c)


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

improve binlog replication performance in some cases.

### What is changed and how it works?

- do not use `null` value as the concurrence dispatch key
- decrease  default value of `queue-size` from `5120` to `1024`
- add `checkpoint-flush-interval` config item
- update `binlogSkippedEventsTotal` to `skipBinlogDurationHistogram` to support observe duration and update the Grafana dashboard

![image](https://user-images.githubusercontent.com/3183039/79196769-3f795600-7e63-11ea-86ae-6a9032b69111.png)


![image](https://user-images.githubusercontent.com/3183039/79196443-b4985b80-7e62-11ea-9244-166ecc21d3e9.png)


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported variable/fields change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to update the documentation
 - Need to update the `dm/dm-ansible`
 - Need to be included in the release note
