### PR TITLE
sync unit: disable retry for binlog syncer

### DIFF
--- a/pkg/binlog/common/replication.go
+++ b/pkg/binlog/common/replication.go
@@ -20,22 +20,18 @@ import (
 )
 
 var (
-	// max reconnection times for binlog syncer in go-mysql
-	maxBinlogSyncerReconnect = 60
+	// MaxBinlogSyncerReconnect is the max reconnection times for binlog syncer in go-mysql
+	MaxBinlogSyncerReconnect = 60
 	// SlaveReadTimeout is slave read binlog data timeout, ref: https://dev.mysql.com/doc/refman/8.0/en/replication-options-slave.html#sysvar_slave_net_timeout
 	SlaveReadTimeout      = 1 * time.Minute
 	masterHeartbeatPeriod = 30 * time.Second // master server send heartbeat period: ref: `MASTER_HEARTBEAT_PERIOD` in https://dev.mysql.com/doc/refman/8.0/en/change-master-to.html
 )
 
 // SetDefaultReplicationCfg sets some default value for BinlogSyncerConfig
-func SetDefaultReplicationCfg(cfg *replication.BinlogSyncerConfig, reConnect bool) {
+func SetDefaultReplicationCfg(cfg *replication.BinlogSyncerConfig, retryCount int) {
 	cfg.UseDecimal = true // must set true. ref: https://github.com/pingcap/tidb-enterprise-tools/pull/272
 	cfg.VerifyChecksum = true
-	if reConnect {
-		cfg.MaxReconnectAttempts = maxBinlogSyncerReconnect
-	} else {
-		cfg.MaxReconnectAttempts = 1
-	}
+	cfg.MaxReconnectAttempts = retryCount
 	cfg.ReadTimeout = SlaveReadTimeout
 	cfg.HeartbeatPeriod = masterHeartbeatPeriod
 }

--- a/pkg/binlog/common/replication.go
+++ b/pkg/binlog/common/replication.go
@@ -28,10 +28,14 @@ var (
 )
 
 // SetDefaultReplicationCfg sets some default value for BinlogSyncerConfig
-func SetDefaultReplicationCfg(cfg *replication.BinlogSyncerConfig) {
+func SetDefaultReplicationCfg(cfg *replication.BinlogSyncerConfig, reConnect bool) {
 	cfg.UseDecimal = true // must set true. ref: https://github.com/pingcap/tidb-enterprise-tools/pull/272
 	cfg.VerifyChecksum = true
-	cfg.MaxReconnectAttempts = maxBinlogSyncerReconnect
+	if reConnect {
+		cfg.MaxReconnectAttempts = maxBinlogSyncerReconnect
+	} else {
+		cfg.MaxReconnectAttempts = 1
+	}
 	cfg.ReadTimeout = SlaveReadTimeout
 	cfg.HeartbeatPeriod = masterHeartbeatPeriod
 }

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -125,7 +125,7 @@ func NewRealRelay(cfg *Config) Process {
 		Password: cfg.From.Password,
 		Charset:  cfg.Charset,
 	}
-	common.SetDefaultReplicationCfg(&syncerCfg)
+	common.SetDefaultReplicationCfg(&syncerCfg, true)
 
 	if !cfg.EnableGTID {
 		// for rawMode(true), we only parse FormatDescriptionEvent and RotateEvent
@@ -803,7 +803,7 @@ func (r *Relay) Reload(newCfg *Config) error {
 		Password: newCfg.From.Password,
 		Charset:  newCfg.Charset,
 	}
-	common.SetDefaultReplicationCfg(&syncerCfg)
+	common.SetDefaultReplicationCfg(&syncerCfg, true)
 
 	if !newCfg.EnableGTID {
 		// for rawMode(true), we only parse FormatDescriptionEvent and RotateEvent

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -125,7 +125,7 @@ func NewRealRelay(cfg *Config) Process {
 		Password: cfg.From.Password,
 		Charset:  cfg.Charset,
 	}
-	common.SetDefaultReplicationCfg(&syncerCfg, true)
+	common.SetDefaultReplicationCfg(&syncerCfg, common.MaxBinlogSyncerReconnect)
 
 	if !cfg.EnableGTID {
 		// for rawMode(true), we only parse FormatDescriptionEvent and RotateEvent
@@ -803,7 +803,7 @@ func (r *Relay) Reload(newCfg *Config) error {
 		Password: newCfg.From.Password,
 		Charset:  newCfg.Charset,
 	}
-	common.SetDefaultReplicationCfg(&syncerCfg, true)
+	common.SetDefaultReplicationCfg(&syncerCfg, common.MaxBinlogSyncerReconnect)
 
 	if !newCfg.EnableGTID {
 		// for rawMode(true), we only parse FormatDescriptionEvent and RotateEvent

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -2530,10 +2530,10 @@ func (s *Syncer) setSyncCfg() {
 		Password:                s.cfg.From.Password,
 		TimestampStringLocation: s.timezone,
 	}
-	// when enable reConnect, go-mysql will retry sync from the previous GTID set in GTID mode,
-	// which may get duplicate binlog event after retry success. so just disable reConnect, and task
-	// will exit with error, and then auto resume by DM itself.
-	common.SetDefaultReplicationCfg(&syncCfg, false)
+	// when retry count > 1, go-mysql will retry sync from the previous GTID set in GTID mode,
+	// which may get duplicate binlog event after retry success. so just set retry count = 1, and task
+	// will exit when meet error, and then auto resume by DM itself.
+	common.SetDefaultReplicationCfg(&syncCfg, 1)
 	s.syncCfg = syncCfg
 }
 

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -2530,7 +2530,10 @@ func (s *Syncer) setSyncCfg() {
 		Password:                s.cfg.From.Password,
 		TimestampStringLocation: s.timezone,
 	}
-	common.SetDefaultReplicationCfg(&syncCfg)
+	// when enable reConnect, go-mysql will retry sync from the previous GTID set in GTID mode,
+	// which may get duplicate binlog event after retry success. so just disable reConnect, and task
+	// will exit with error, and then auto resume by DM itself.
+	common.SetDefaultReplicationCfg(&syncCfg, false)
 	s.syncCfg = syncCfg
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

when enabling retry, go-mysql will [retry sync](https://github.com/siddontang/go-mysql/blob/3731d5147201d61e212e7fbd0c83ea14cb6ef0b9/replication/binlogsyncer.go#L577) from the previous GTID set in GTID mode, 
which may get duplicate binlog event after retry success. 

### What is changed and how it works?

so just disable retry, and the task will exit with error, then auto-resume by DM itself.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test
