### PR TITLE
ansible: release v1.0.5

### DIFF
--- a/dm/dm-ansible/inventory.ini
+++ b/dm/dm-ansible/inventory.ini
@@ -26,7 +26,7 @@ cluster_name = test-cluster
 
 ansible_user = tidb
 
-dm_version = v1.0.4-hotfix
+dm_version = v1.0.5
 
 deploy_dir = /home/tidb/deploy
 


### PR DESCRIPTION
### What is changed and how it works?

update `dm_version` in DM-ansible's inventory.ini from `v1.0.4` to `v1.0.5`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code