### PR TITLE
update dm-portal default name

### DIFF
--- a/dm/portal/frontend/src/components/NamingStep.tsx
+++ b/dm/portal/frontend/src/components/NamingStep.tsx
@@ -76,7 +76,7 @@ function NamingStep({ onNext, onPrev, onData, taskInfo }: Props) {
           help={taskName.errMsg}
         >
           <Input
-            placeholder="test-task"
+            placeholder="test"
             value={taskName.value}
             onChange={(e: any) =>
               setTaskName(handleTaskNameChange(e.target.value))


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
dm-portal default name `test-task` will be judged as invalid name.

### What is changed and how it works?
Change `test-task` to `test`

