### PR TITLE
dm-worker: move cpu metrics to worker server level

### DIFF
--- a/dm/worker/worker.go
+++ b/dm/worker/worker.go
@@ -144,6 +144,12 @@ func (w *Worker) Start(startRelay bool) {
 
 	w.l.Info("start running")
 
+	w.wg.Add(1)
+	go func() {
+		w.runBackgroundJob(w.ctx)
+		w.wg.Done()
+	}()
+
 	ticker := time.NewTicker(5 * time.Second)
 	w.closed.Set(closedFalse)
 	defer ticker.Stop()

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -512,12 +512,6 @@ func (s *Syncer) Process(ctx context.Context, pr chan pb.ProcessResult) {
 		<-newCtx.Done() // ctx or newCtx
 	}()
 
-	wg.Add(1)
-	go func() {
-		s.runBackgroundJob(newCtx)
-		wg.Done()
-	}()
-
 	err := s.Run(newCtx)
 	if err != nil {
 		// returned error rather than sent to runFatalChan


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Data race at collecting metrics. #672 

### What is changed and how it works?
 move cpu usage metrics to worker server level

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test