### PR TITLE
fix wrong usage of failpoint in #695

### DIFF
--- a/dm/master/election.go
+++ b/dm/master/election.go
@@ -60,12 +60,14 @@ func (s *Server) electionNotify(ctx context.Context) {
 					if strings.Contains(masterStrings, s.cfg.Name) {
 						log.L().Info("fail to start leader", zap.String("failpoint", "FailToStartLeader"))
 						s.retireLeader()
+						s.election.Resign()
 						failpoint.Continue()
 					}
 				})
 
 				if !ok {
 					s.retireLeader()
+					s.election.Resign()
 					continue
 				}
 

--- a/dm/master/election_test.go
+++ b/dm/master/election_test.go
@@ -33,7 +33,7 @@ type testElectionSuite struct {
 }
 
 func (t *testMaster) TestFailToStartLeader(c *check.C) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
 	// create a new cluster

--- a/dm/master/election_test.go
+++ b/dm/master/election_test.go
@@ -33,7 +33,7 @@ type testElectionSuite struct {
 }
 
 func (t *testMaster) TestFailToStartLeader(c *check.C) {
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	// create a new cluster


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix wrong usage of failpoint in #695, which will cause unit test fail.

### What is changed and how it works?
failpoint generate `ok` variable and overide outer `ok`
```
ok:=true
failpoint.Inject("", func(val failpoint.Value) {
     ok=false
})
fmt.Println(ok) // ok still true
```
this pr rewrite the logic of failpoint in #695 
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test