### PR TITLE
refine dm-worker query-status

### DIFF
--- a/dm/worker/status.go
+++ b/dm/worker/status.go
@@ -112,6 +112,11 @@ func (w *Worker) Status(stName string) []*pb.SubTaskStatus {
 				case pb.UnitType_Sync:
 					stStatus.Status = &pb.SubTaskStatus_Sync{Sync: us.(*pb.SyncStatus)}
 				}
+			} else if result := st.Result(); result != nil {
+				processErrorMsg := utils.JoinProcessErrors(result.Errors)
+				if len(processErrorMsg) > 0 {
+					stStatus.Status = &pb.SubTaskStatus_Msg{Msg: processErrorMsg}
+				}
 			}
 		}
 		status = append(status, &stStatus)


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Refine dm-worker query-status prompt when failing from initialize task #657 

### What is changed and how it works?
Use result.Errors as status message when currUnit is nil.

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
