### PR TITLE
check_task: cherrypick ping db when apply dbconfig

### DIFF
--- a/pkg/conn/basedb.go
+++ b/pkg/conn/basedb.go
@@ -69,6 +69,10 @@ func (d *defaultDBProvider) Apply(config config.DBConfig) (*BaseDB, error) {
 		return nil, terror.DBErrorAdapt(err, terror.ErrDBDriverError)
 	}
 
+	if err = db.Ping(); err != nil {
+		return nil, terror.DBErrorAdapt(err, terror.ErrDBDriverError)
+	}
+
 	db.SetMaxIdleConns(maxIdleConns)
 
 	return NewBaseDB(db), nil

--- a/tests/all_mode/run.sh
+++ b/tests/all_mode/run.sh
@@ -26,13 +26,9 @@ function test_session_config(){
 
     # error config
     sed -i 's/tidb_retry_limit: "10"/tidb_retry_limit: "fjs"/g'  $WORK_DIR/dm-task.yaml
-    dmctl_start_task "$WORK_DIR/dm-task.yaml"
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
-        "query-status test" \
-        "'tidb_retry_limit' can't be set to the value" 4
-    run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
-        "stop-task test" \
-        "\"result\": true" 3
+        "start-task $WORK_DIR/dm-task.yaml" \
+        "'tidb_retry_limit' can't be set to the value" 1
 
     # sql_mode=""
     sed -i 's/tidb_retry_limit: "fjs"/tidb_retry_limit: "10"/g'  $WORK_DIR/dm-task.yaml

--- a/tests/dmctl_basic/check_list/check_task.sh
+++ b/tests/dmctl_basic/check_list/check_task.sh
@@ -34,3 +34,10 @@ function check_task_not_pass() {
         "check-task $task_conf" \
         "\"result\": false" 1
 }
+
+function check_task_error_database_config() {
+    task_conf=$1
+    run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
+        "check-task $task_conf" \
+        "database driver error" 1
+}

--- a/tests/dmctl_basic/run.sh
+++ b/tests/dmctl_basic/run.sh
@@ -114,6 +114,10 @@ function run() {
     check_task_pass $TASK_CONF
     check_task_not_pass $cur/conf/dm-task2.yaml
 
+    cp $cur/conf/dm-task.yaml $WORK_DIR/dm-task-error-database-config.yaml
+    sed -i "s/password: \"\"/password: \"wrond password\"/g" $WORK_DIR/dm-task-error-database-config.yaml
+    check_task_error_database_config $WORK_DIR/dm-task-error-database-config.yaml
+
     dmctl_start_task
     check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
     update_task_not_paused $TASK_CONF


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
manually cherrypick #769 
### What problem does this PR solve? <!--add issue link with summary if exists-->
ping database when apply db config

Tests <!-- At least one of them must be included. -->

 - Integration test
