### PR TITLE
log: set log level for embed etcd and ddl tracker

### DIFF
--- a/cmd/dm-worker/main.go
+++ b/cmd/dm-worker/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/dm/dm/worker"
 	"github.com/pingcap/dm/pkg/log"
 	"github.com/pingcap/dm/pkg/utils"
+	globalLog "github.com/pingcap/log"
 
 	"github.com/pingcap/errors"
 	"go.uber.org/zap"
@@ -49,6 +50,13 @@ func main() {
 		fmt.Printf("init logger error %v", errors.ErrorStack(err))
 		os.Exit(2)
 	}
+
+	// currently only schema tracker use global logger(std logger), simply replace it with `error` level
+	// may be we should support config logger in mock tidb later
+	conf := &globalLog.Config{Level: "error", File: globalLog.FileLogConfig{}}
+	lg, r, _ := globalLog.InitLogger(conf)
+	lg = lg.With(zap.String("component", "ddl tracker"))
+	globalLog.ReplaceGlobals(lg, r)
 
 	utils.PrintInfo("dm-worker", func() {
 		log.L().Info("", zap.Stringer("dm-worker config", cfg))

--- a/dm/master/config.go
+++ b/dm/master/config.go
@@ -393,8 +393,9 @@ func genEmbedEtcdConfigWithLogger() *embed.Config {
 	// NOTE: `genEmbedEtcdConfig` can only be called after logger initialized.
 	// NOTE: if using zap logger for etcd, must build it before any concurrent gRPC calls,
 	// otherwise, DATA RACE occur in NewZapCoreLoggerBuilder and gRPC.
-	logger := log.L().WithFields(zap.String("component", "embed etcd"))
-	cfg.ZapLoggerBuilder = embed.NewZapCoreLoggerBuilder(logger.Logger, logger.Core(), log.Props().Syncer) // use global app props.
+	// NOTE: we can only increase the log level for the clone logger but not decrease.
+	logger := log.L().WithFields(zap.String("component", "embed etcd")).WithOptions(zap.IncreaseLevel(zap.ErrorLevel))
+	cfg.ZapLoggerBuilder = embed.NewZapCoreLoggerBuilder(logger, logger.Core(), log.Props().Syncer) // use global app props.
 	cfg.Logger = "zap"
 
 	// TODO: we run ZapLoggerBuilder to set SetLoggerV2 before we do some etcd operations


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read MD's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #495 

### What is changed and how it works?
- set error log level for embed etcd
- set error log level for global logger which currently only use by schemaTracker

Tests <!-- At least one of them must be included. -->

 - Manually check the log
