### PR TITLE
test: increase TTL to improve stability

### DIFF
--- a/dm/master/scheduler/scheduler_test.go
+++ b/dm/master/scheduler/scheduler_test.go
@@ -99,7 +99,7 @@ func (t *testScheduler) testSchedulerProgress(c *C, restart int) {
 		workerInfo2  = ha.NewWorkerInfo(workerName2, workerAddr2)
 		sourceCfg1   config.SourceConfig
 		subtaskCfg1  config.SubTaskConfig
-		keepAliveTTL = int64(1) // NOTE: this should be >= minLeaseTTL, in second.
+		keepAliveTTL = int64(2) // NOTE: this should be >= minLeaseTTL, in second.
 
 		rebuildScheduler = func(ctx context.Context) {
 			switch restart {
@@ -676,7 +676,7 @@ func (t *testScheduler) TestRestartScheduler(c *C) {
 		sourceBound1 = ha.NewSourceBound(sourceID1, workerName1)
 		sourceCfg1   config.SourceConfig
 		wg           sync.WaitGroup
-		keepAliveTTL = int64(1) // NOTE: this should be >= minLeaseTTL, in second.
+		keepAliveTTL = int64(2) // NOTE: this should be >= minLeaseTTL, in second.
 	)
 	c.Assert(sourceCfg1.LoadFromFile(sourceSampleFile), IsNil)
 	sourceCfg1.SourceID = sourceID1
@@ -788,7 +788,7 @@ func (t *testScheduler) TestWatchWorkerEventEtcdCompact(c *C) {
 		workerAddr3  = "127.0.0.1:18362"
 		workerAddr4  = "127.0.0.1:18462"
 		sourceCfg1   config.SourceConfig
-		keepAliveTTL = int64(1) // NOTE: this should be >= minLeaseTTL, in second.
+		keepAliveTTL = int64(2) // NOTE: this should be >= minLeaseTTL, in second.
 	)
 	c.Assert(sourceCfg1.LoadFromFile(sourceSampleFile), IsNil)
 	sourceCfg1.SourceID = sourceID1


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
reduce test fail for testScheduler.TestRestartScheduler: https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/dm_ghpr_test/detail/dm_ghpr_test/5753/pipeline

### What is changed and how it works?
etcd's check and keep alive interval is `retryConnWait = 500 * time.Millisecond`, see https://github.com/etcd-io/etcd/blob/b28a6272b73359591fe22bac5ac8cae8afdbe0cc/clientv3/lease.go#L580. I guess it accounts for our 1 second TTL timeout

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes
