### PR TITLE
dm-master: fix wrong clientURL

### DIFF
--- a/dm/master/config.go
+++ b/dm/master/config.go
@@ -330,12 +330,15 @@ func (c *Config) genEmbedEtcdConfig(cfg *embed.Config) (*embed.Config, error) {
 	cfg.Dir = c.DataDir
 
 	// reuse the previous master-addr as the client listening URL.
-	cURL, err := parseURLs(c.MasterAddr)
+	var err error
+	cfg.LCUrls, err = parseURLs(c.MasterAddr)
 	if err != nil {
 		return nil, terror.ErrMasterGenEmbedEtcdConfigFail.Delegate(err, "invalid master-addr")
 	}
-	cfg.LCUrls = cURL
-	cfg.ACUrls = cURL
+	cfg.ACUrls, err = parseURLs(c.AdvertiseAddr)
+	if err != nil {
+		return nil, terror.ErrMasterGenEmbedEtcdConfigFail.Delegate(err, "advertise-addr")
+	}
 
 	cfg.LPUrls, err = parseURLs(c.PeerUrls)
 	if err != nil {

--- a/dm/master/config.go
+++ b/dm/master/config.go
@@ -337,7 +337,7 @@ func (c *Config) genEmbedEtcdConfig(cfg *embed.Config) (*embed.Config, error) {
 	}
 	cfg.ACUrls, err = parseURLs(c.AdvertiseAddr)
 	if err != nil {
-		return nil, terror.ErrMasterGenEmbedEtcdConfigFail.Delegate(err, "advertise-addr")
+		return nil, terror.ErrMasterGenEmbedEtcdConfigFail.Delegate(err, "invalid advertise-addr")
 	}
 
 	cfg.LPUrls, err = parseURLs(c.PeerUrls)

--- a/dm/master/config_test.go
+++ b/dm/master/config_test.go
@@ -249,7 +249,7 @@ func (t *testConfigSuite) TestGenEmbedEtcdConfig(c *check.C) {
 	c.Assert(etcdCfg.Name, check.Equals, fmt.Sprintf("dm-master-%s", hostname))
 	c.Assert(etcdCfg.Dir, check.Equals, fmt.Sprintf("default.%s", etcdCfg.Name))
 	c.Assert(etcdCfg.LCUrls, check.DeepEquals, []url.URL{{Scheme: "http", Host: "0.0.0.0:8261"}})
-	c.Assert(etcdCfg.ACUrls, check.DeepEquals, []url.URL{{Scheme: "http", Host: "0.0.0.0:8261"}})
+	c.Assert(etcdCfg.ACUrls, check.DeepEquals, []url.URL{{Scheme: "http", Host: "127.0.0.1:8261"}})
 	c.Assert(etcdCfg.LPUrls, check.DeepEquals, []url.URL{{Scheme: "http", Host: "127.0.0.1:8291"}})
 	c.Assert(etcdCfg.APUrls, check.DeepEquals, []url.URL{{Scheme: "http", Host: "127.0.0.1:8291"}})
 	c.Assert(etcdCfg.InitialCluster, check.DeepEquals, fmt.Sprintf("dm-master-%s=http://127.0.0.1:8291", hostname))


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix #819 

### What is changed and how it works?

set `ACUrls` to `advertise-addr`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
     - run DM-master with `master-addr="0.0.0.0:8261` and `advertise-addr=127.0.0.1:8261`
     - `list-member` and check `clientURLs` should be `http://127.0.0.1:8261`

