### PR TITLE
*: add metrics for optimistic shard DDL lock

### DIFF
--- a/dm/master/metrics/metrics.go
+++ b/dm/master/metrics/metrics.go
@@ -116,18 +116,18 @@ func GetMetricsHandler() http.Handler {
 	return promhttp.Handler()
 }
 
-// ReportWorkerStageToMetrics is a setter for workerState, this name is easy to understand to caller
-func ReportWorkerStageToMetrics(name string, state float64) {
+// ReportWorkerStage is a setter for workerState
+func ReportWorkerStage(name string, state float64) {
 	workerState.WithLabelValues(name).Set(state)
 }
 
-// RemoveWorkerStateInMetrics cleans state of deleted worker
-func RemoveWorkerStateInMetrics(name string) {
+// RemoveWorkerState cleans state of deleted worker
+func RemoveWorkerState(name string) {
 	workerState.DeleteAllAboutLabels(prometheus.Labels{"worker": name})
 }
 
-// ReportDDLPendingToMetrics inc/dec by 1 to ddlPendingCounter
-func ReportDDLPendingToMetrics(task, old, new string) {
+// ReportDDLPending inc/dec by 1 to ddlPendingCounter
+func ReportDDLPending(task, old, new string) {
 	if old != DDLPendingNone {
 		ddlPendingCounter.WithLabelValues(task, old).Dec()
 	}
@@ -136,8 +136,8 @@ func ReportDDLPendingToMetrics(task, old, new string) {
 	}
 }
 
-// ReportDDLErrorToMetrics is a setter for ddlErrCounter
-func ReportDDLErrorToMetrics(task, errType string) {
+// ReportDDLError is a setter for ddlErrCounter
+func ReportDDLError(task, errType string) {
 	ddlErrCounter.WithLabelValues(task, errType).Inc()
 }
 

--- a/dm/master/scheduler/scheduler.go
+++ b/dm/master/scheduler/scheduler.go
@@ -1389,7 +1389,7 @@ func (s *Scheduler) deleteWorker(name string) {
 	}
 	w.Close()
 	delete(s.workers, name)
-	metrics.RemoveWorkerStateInMetrics(w.baseInfo.Name)
+	metrics.RemoveWorkerState(w.baseInfo.Name)
 }
 
 // updateStatusForBound updates the in-memory status for bound, including:

--- a/dm/master/scheduler/worker.go
+++ b/dm/master/scheduler/worker.go
@@ -153,5 +153,5 @@ func (w *Worker) reportMetrics() {
 	if n, ok := workerStage2Num[w.stage]; ok {
 		s = n
 	}
-	metrics.ReportWorkerStageToMetrics(w.baseInfo.Name, s)
+	metrics.ReportWorkerStage(w.baseInfo.Name, s)
 }

--- a/dm/master/shardddl/optimist.go
+++ b/dm/master/shardddl/optimist.go
@@ -423,7 +423,7 @@ func (o *Optimist) handleInfo(ctx context.Context, infoCh <-chan optimism.Info) 
 			err := o.handleLock(info, tts, false)
 			if err != nil {
 				o.logger.Error("fail to handle the shard DDL lock", zap.Stringer("info", info), log.ShortError(err))
-				metrics.ReportDDLErrorToMetrics(info.Task, metrics.InfoErrHandleLock)
+				metrics.ReportDDLError(info.Task, metrics.InfoErrHandleLock)
 				continue
 			}
 		}
@@ -467,7 +467,7 @@ func (o *Optimist) handleOperationPut(ctx context.Context, opCh <-chan optimism.
 			err := o.removeLock(lock)
 			if err != nil {
 				o.logger.Error("fail to delete the shard DDL infos and lock operations", zap.String("lock", lock.ID), log.ShortError(err))
-				metrics.ReportDDLErrorToMetrics(op.Task, metrics.OpErrRemoveLock)
+				metrics.ReportDDLError(op.Task, metrics.OpErrRemoveLock)
 			}
 			o.logger.Info("the shard DDL infos and lock operations have been cleared", zap.Stringer("operation", op))
 		}
@@ -533,6 +533,7 @@ func (o *Optimist) removeLock(lock *optimism.Lock) error {
 		return err
 	}
 	o.lk.RemoveLock(lock.ID)
+	metrics.ReportDDLPending(lock.Task, metrics.DDLPendingSynced, metrics.DDLPendingNone)
 	return nil
 }
 

--- a/pkg/shardddl/pessimism/lock.go
+++ b/pkg/shardddl/pessimism/lock.go
@@ -56,7 +56,7 @@ func NewLock(ID, task, owner string, DDLs, sources []string) *Lock {
 		l.ready[s] = false
 		l.done[s] = false
 	}
-	metrics.ReportDDLPendingToMetrics(task, metrics.DDLPendingNone, metrics.DDLPendingUnSynced)
+	metrics.ReportDDLPending(task, metrics.DDLPendingNone, metrics.DDLPendingUnSynced)
 
 	return l
 }
@@ -87,7 +87,7 @@ func (l *Lock) TrySync(caller string, DDLs, sources []string) (bool, int, error)
 		l.remain--
 		l.ready[caller] = true
 		if l.remain == 0 {
-			metrics.ReportDDLPendingToMetrics(l.Task, metrics.DDLPendingUnSynced, metrics.DDLPendingSynced)
+			metrics.ReportDDLPending(l.Task, metrics.DDLPendingUnSynced, metrics.DDLPendingSynced)
 		}
 	}
 
@@ -100,7 +100,7 @@ func (l *Lock) ForceSynced() {
 	defer l.mu.Unlock()
 
 	if l.remain > 0 {
-		metrics.ReportDDLPendingToMetrics(l.Task, metrics.DDLPendingUnSynced, metrics.DDLPendingSynced)
+		metrics.ReportDDLPending(l.Task, metrics.DDLPendingUnSynced, metrics.DDLPendingSynced)
 	}
 	for source := range l.ready {
 		l.ready[source] = true
@@ -114,7 +114,7 @@ func (l *Lock) RevertSynced(sources []string) {
 	defer l.mu.Unlock()
 
 	if l.remain == 0 && len(sources) > 0 {
-		metrics.ReportDDLPendingToMetrics(l.Task, metrics.DDLPendingSynced, metrics.DDLPendingUnSynced)
+		metrics.ReportDDLPending(l.Task, metrics.DDLPendingSynced, metrics.DDLPendingUnSynced)
 	}
 	for _, source := range sources {
 		if synced, ok := l.ready[source]; ok && synced {


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
part of #543

### What is changed and how it works?
add metrics for optimistic shard DDL lock, and some renames because we call `metrics.ReportDDLPending` so don't repeat `...ToMetric`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (pause sequence_sharding_optimistic and check grafana)

Code changes

 - Has exported function/method change

Side effects

Related changes
