### PR TITLE
*: change `dm_version` to `nightly`

### DIFF
--- a/dm/dm-ansible/inventory.ini
+++ b/dm/dm-ansible/inventory.ini
@@ -26,7 +26,7 @@ cluster_name = test-cluster
 
 ansible_user = tidb
 
-dm_version = latest
+dm_version = nightly
 
 deploy_dir = /home/tidb/deploy
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

now, we build **master** branch nightly as `nightly` version, but let `latest` as the latest **release** version (now, it's `v1.0.6`).

if a user downloads DM-Ansible `nightly`, and then deploy DM directly, they expect the `nightly` version of DM deployed (and not v1.0.6).

### What is changed and how it works?

change `dm_version` in `inventory.ini` to `nightly`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

