### PR TITLE
fix: reset the start part of GTID sets when recovering from relay log or upgrading v1.0.x checkpoint

### DIFF
--- a/pkg/gtid/gtid.go
+++ b/pkg/gtid/gtid.go
@@ -237,6 +237,29 @@ func (g *MySQLGTIDSet) Truncate(end Set) error {
 	return nil
 }
 
+// ResetStart resets the start part of GTID sets,
+// like `00c04543-f584-11e9-a765-0242ac120002:40-60` will be reset to `00c04543-f584-11e9-a765-0242ac120002:1-60`.
+// return `true` if reset real happen.
+// NOTE: for MariaDB GTID, no this function exists because its format is `domainID-serverID-SeqNum`.
+func (g *MySQLGTIDSet) ResetStart() bool {
+	if g == nil || g.set == nil {
+		return false
+	}
+
+	reset := false
+	for _, set := range g.set.Sets {
+		for i, inter := range set.Intervals {
+			if inter.Start > 1 {
+				inter.Start = 1
+				set.Intervals[i] = inter // re-assign
+				reset = true
+			}
+		}
+	}
+
+	return reset
+}
+
 func (g *MySQLGTIDSet) String() string {
 	if g.set == nil {
 		return ""

--- a/pkg/gtid/gtid_test.go
+++ b/pkg/gtid/gtid_test.go
@@ -383,3 +383,36 @@ func (s *testGTIDSuite) TestMariaDBGTIDTruncate(c *C) {
 		}
 	}
 }
+
+func (s *testGTIDSuite) TestMySQLGTIDResetStart(c *C) {
+	var (
+		flavor    = "mysql"
+		gNil      *MySQLGTIDSet
+		gEmpty, _ = ParserGTID(flavor, "")
+		g1, _     = ParserGTID(flavor, "00c04543-f584-11e9-a765-0242ac120002:1-100")
+		g2, _     = ParserGTID(flavor, "00c04543-f584-11e9-a765-0242ac120002:100")
+		g3, _     = ParserGTID(flavor, "00c04543-f584-11e9-a765-0242ac120002:50-100")
+		g4, _     = ParserGTID(flavor, "00c04543-f584-11e9-a765-0242ac120002:1-100,03fc0263-28c7-11e7-a653-6c0b84d59f30:1-100")
+		g5, _     = ParserGTID(flavor, "00c04543-f584-11e9-a765-0242ac120002:1-100,03fc0263-28c7-11e7-a653-6c0b84d59f30:50-100")
+		g6, _     = ParserGTID(flavor, "00c04543-f584-11e9-a765-0242ac120002:40-100,03fc0263-28c7-11e7-a653-6c0b84d59f30:50-100")
+	)
+
+	c.Assert(gNil.ResetStart(), IsFalse)
+	c.Assert(gEmpty.(*MySQLGTIDSet).ResetStart(), IsFalse)
+
+	c.Assert(g1.(*MySQLGTIDSet).ResetStart(), IsFalse)
+
+	c.Assert(g2.(*MySQLGTIDSet).ResetStart(), IsTrue)
+	c.Assert(g2.Equal(g1), IsTrue)
+
+	c.Assert(g3.(*MySQLGTIDSet).ResetStart(), IsTrue)
+	c.Assert(g3.Equal(g1), IsTrue)
+
+	c.Assert(g4.(*MySQLGTIDSet).ResetStart(), IsFalse)
+
+	c.Assert(g5.(*MySQLGTIDSet).ResetStart(), IsTrue)
+	c.Assert(g5.Equal(g4), IsTrue)
+
+	c.Assert(g6.(*MySQLGTIDSet).ResetStart(), IsTrue)
+	c.Assert(g6.Equal(g4), IsTrue)
+}

--- a/pkg/v1dbschema/schema.go
+++ b/pkg/v1dbschema/schema.go
@@ -176,21 +176,39 @@ func getGlobalPos(tctx *tcontext.Context, dbConn *conn.BaseConn, tableName, sour
 }
 
 // getGTIDsForPos gets the GTID sets for the position.
-func getGTIDsForPos(tctx *tcontext.Context, pos gmysql.Position, tcpReader reader.Reader, parser2 *parser.Parser) (gtid.Set, error) {
+func getGTIDsForPos(tctx *tcontext.Context, pos gmysql.Position, tcpReader reader.Reader, parser2 *parser.Parser) (gs gtid.Set, err error) {
+	// in MySQL, we expect `PreviousGTIDsEvent` contains ALL previous GTID sets, but in fact it may lack a part of them sometimes,
+	// e.g we expect `00c04543-f584-11e9-a765-0242ac120002:1-100,03fc0263-28c7-11e7-a653-6c0b84d59f30:1-100`,
+	// but may be `00c04543-f584-11e9-a765-0242ac120002:50-100,03fc0263-28c7-11e7-a653-6c0b84d59f30:60-100`.
+	// and when DM requesting MySQL to send binlog events with this EXCLUDED GTID sets, some errors like
+	// `ERROR 1236 (HY000): The slave is connecting using CHANGE MASTER TO MASTER_AUTO_POSITION = 1, but the master has purged binary logs containing GTIDs that the slave requires.`
+	// may occur, so we force to reset the START part of any GTID set.
+	defer func() {
+		if err == nil && gs != nil {
+			oldGs := gs.Clone()
+			if mysqlGs, ok := gs.(*gtid.MySQLGTIDSet); ok {
+				if mysqlGs.ResetStart() {
+					tctx.L().Warn("force to reset the start part of GTID sets", zap.Stringer("from GTID set", oldGs), zap.Stringer("to GTID set", mysqlGs))
+				}
+			}
+		}
+	}()
+
 	// NOTE: because we have multiple unit test cases updating/clearing binlog in the upstream,
 	// we may encounter errors when reading binlog event but cleared by another test case.
 	failpoint.Inject("MockGetGTIDsForPos", func(val failpoint.Value) {
 		str := val.(string)
-		gs, _ := gtid.ParserGTID(gmysql.MySQLFlavor, str)
+		gs, _ = gtid.ParserGTID(gmysql.MySQLFlavor, str)
 		tctx.L().Info("set gs for position", zap.String("failpoint", "MockGetGTIDsForPos"), zap.Stringer("pos", pos))
 		failpoint.Return(gs, nil)
 	})
 
-	realPos, err := binlog.RealMySQLPos(pos)
+	var realPos gmysql.Position
+	realPos, err = binlog.RealMySQLPos(pos)
 	if err != nil {
 		return nil, err
 	}
-	gs, err := reader.GetGTIDsForPos(tctx.Ctx, tcpReader, realPos, parser2)
+	gs, err = reader.GetGTIDsForPos(tctx.Ctx, tcpReader, realPos, parser2)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/v1dbschema/schema_test.go
+++ b/pkg/v1dbschema/schema_test.go
@@ -113,7 +113,7 @@ func (t *testSchema) TestSchemaV106ToV20x(c *C) {
 		endGS, _ = gtid.ParserGTID(gmysql.MySQLFlavor, "ccb992ad-a557-11ea-ba6a-0242ac140002:1-16")
 	)
 
-	c.Assert(failpoint.Enable("github.com/pingcap/dm/pkg/v1dbschema/MockGetGTIDsForPos", `return("ccb992ad-a557-11ea-ba6a-0242ac140002:1-16")`), IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/dm/pkg/v1dbschema/MockGetGTIDsForPos", `return("ccb992ad-a557-11ea-ba6a-0242ac140002:10-16")`), IsNil) // need `ResetStart`.
 	defer failpoint.Disable("github.com/pingcap/dm/pkg/v1dbschema/MockGetGTIDsForPos")
 
 	dbConn, err := t.db.GetBaseConn(tctx.Ctx)


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

in MySQL, we expect `PreviousGTIDsEvent` contains ALL previous GTID sets, but in fact it may lack a part of them sometimes.

 e.g we expect `00c04543-f584-11e9-a765-0242ac120002:1-100,03fc0263-28c7-11e7-a653-6c0b84d59f30:1-100`, but may be `00c04543-f584-11e9-a765-0242ac120002:50-100,03fc0263-28c7-11e7-a653-6c0b84d59f30:60-100`.

and when DM requesting MySQL to send binlog events with this EXCLUDED GTID sets, some errors like `ERROR 1236 (HY000): The slave is connecting using CHANGE MASTER TO MASTER_AUTO_POSITION = 1, but the master has purged binary logs containing GTIDs that the slave requires.` may occur

### What is changed and how it works?

reset the start part of GTID sets when recovering from relay log or upgrading v1.0.x checkpoint

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has persistent data change

Related changes

 - Need to cherry-pick to the release branch
