### PR TITLE
fix: TLS support for dumpling and syncer in v2.0

### DIFF
--- a/dumpling/dumpling.go
+++ b/dumpling/dumpling.go
@@ -239,6 +239,12 @@ func (m *Dumpling) constructArgs() (*export.Config, error) {
 		ret = append(ret, "--skip-tz-utc")
 	}
 
+	if db.Security != nil {
+		dumpConfig.Security.CAPath = db.Security.SSLCA
+		dumpConfig.Security.CertPath = db.Security.SSLCert
+		dumpConfig.Security.KeyPath = db.Security.SSLKey
+	}
+
 	extraArgs := strings.Fields(cfg.ExtraArgs)
 	if len(extraArgs) > 0 {
 		err := parseExtraArgs(&m.logger, dumpConfig, ParseArgLikeBash(extraArgs))

--- a/dumpling/util.go
+++ b/dumpling/util.go
@@ -72,6 +72,9 @@ func parseExtraArgs(logger *log.Logger, dumpCfg *export.Config, args []string) e
 	dumplingFlagSet.StringVar(&dumpCfg.Where, "where", dumpCfg.Where, "Dump only selected records")
 	dumplingFlagSet.BoolVar(&dumpCfg.EscapeBackslash, "escape-backslash", dumpCfg.EscapeBackslash, "Use backslash to escape quotation marks")
 	dumplingFlagSet.StringArrayVarP(&filters, "filter", "f", []string{"*.*"}, "Filter to select which tables to dump")
+	dumplingFlagSet.StringVar(&dumpCfg.Security.CAPath, "ca", dumpCfg.Security.CAPath, "The path name to the certificate authority file for TLS connection")
+	dumplingFlagSet.StringVar(&dumpCfg.Security.CertPath, "cert", dumpCfg.Security.CertPath, "The path name to the client certificate file for TLS connection")
+	dumplingFlagSet.StringVar(&dumpCfg.Security.KeyPath, "key", dumpCfg.Security.KeyPath, "The path name to the client private key file for TLS connection")
 
 	err := dumplingFlagSet.Parse(args)
 	if err != nil {

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -15,6 +15,7 @@ package syncer
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"os"
 	"path"
@@ -60,6 +61,7 @@ import (
 	operator "github.com/pingcap/dm/syncer/err-operator"
 	sm "github.com/pingcap/dm/syncer/safe-mode"
 	"github.com/pingcap/dm/syncer/shardddl"
+	toolutils "github.com/pingcap/tidb-tools/pkg/utils"
 )
 
 var (
@@ -2597,7 +2599,11 @@ func (s *Syncer) UpdateFromConfig(cfg *config.SubTaskConfig) error {
 		return err
 	}
 
-	s.setSyncCfg()
+	err = s.setSyncCfg()
+	if err != nil {
+		return err
+	}
+
 	if s.streamerController != nil {
 		s.streamerController.UpdateSyncCfg(s.syncCfg, s.fromDB)
 	}
@@ -2632,7 +2638,19 @@ func (s *Syncer) setTimezone() {
 	s.timezone = loc
 }
 
-func (s *Syncer) setSyncCfg() {
+func (s *Syncer) setSyncCfg() error {
+	var tlsConfig *tls.Config
+	var err error
+	if s.cfg.From.Security != nil {
+		tlsConfig, err = toolutils.ToTLSConfig(s.cfg.From.Security.SSLCA, s.cfg.From.Security.SSLCert, s.cfg.From.Security.SSLKey)
+		if err != nil {
+			return terror.ErrConnInvalidTLSConfig.Delegate(err)
+		}
+		if tlsConfig != nil {
+			tlsConfig.InsecureSkipVerify = true
+		}
+	}
+
 	syncCfg := replication.BinlogSyncerConfig{
 		ServerID:                uint32(s.cfg.ServerID),
 		Flavor:                  s.cfg.Flavor,
@@ -2641,12 +2659,14 @@ func (s *Syncer) setSyncCfg() {
 		User:                    s.cfg.From.User,
 		Password:                s.cfg.From.Password,
 		TimestampStringLocation: s.timezone,
+		TLSConfig:               tlsConfig,
 	}
 	// when retry count > 1, go-mysql will retry sync from the previous GTID set in GTID mode,
 	// which may get duplicate binlog event after retry success. so just set retry count = 1, and task
 	// will exit when meet error, and then auto resume by DM itself.
 	common.SetDefaultReplicationCfg(&syncCfg, 1)
 	s.syncCfg = syncCfg
+	return nil
 }
 
 // ShardDDLInfo returns the current pending to handle shard DDL info.


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #880 

### What is changed and how it works?
- set tls for dumpling
- set tls for streamController

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)
    start a mysql server with tls config, run an all mode task