### PR TITLE
master: replace wrong usage of utils.Decrypt

### DIFF
--- a/dm/master/server.go
+++ b/dm/master/server.go
@@ -1569,11 +1569,7 @@ func (s *Server) removeMetaData(ctx context.Context, cfg *config.TaskConfig) err
 	toDB := *cfg.TargetDB
 	toDB.Adjust()
 	if len(toDB.Password) > 0 {
-		pswdTo, err := utils.Decrypt(toDB.Password)
-		if err != nil {
-			return err
-		}
-		toDB.Password = pswdTo
+		toDB.Password = utils.DecryptOrPlaintext(toDB.Password)
 	}
 
 	// clear shard meta data for pessimistic/optimist


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
`start-task --remove-meta` routine will call `utils.Decrypt` which is not suitable for plain password

### What is changed and how it works?
replace to `utils.DecryptOrPlaintext`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (I guess no problem, will test **after** merge in Aurora migration)

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
