### PR TITLE
feat: support to dump data with column name

### DIFF
--- a/dumpling/dumpling.go
+++ b/dumpling/dumpling.go
@@ -212,6 +212,7 @@ func (m *Dumpling) constructArgs() (*export.Config, error) {
 	}
 	dumpConfig.TableFilter = tableFilter
 	dumpConfig.EscapeBackslash = true
+	dumpConfig.CompleteInsert = true // always keep column name in `INSERT INTO` statements.
 	dumpConfig.Logger = m.logger.Logger
 
 	if cfg.Threads > 0 {

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
-	github.com/pingcap/dumpling v0.0.0-20200813063618-45df63f5539f
+	github.com/pingcap/dumpling v0.0.0-20200819021059-26975af91c7b
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20200729012136-4e113ddee29e
 	github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce

--- a/go.sum
+++ b/go.sum
@@ -501,8 +501,8 @@ github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12 h1:rfD9v3+ppLPzoQBgZ
 github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=
 github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712 h1:R8gStypOBmpnHEx1qi//SaqxJVI4inOqljg/Aj5/390=
 github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=
-github.com/pingcap/dumpling v0.0.0-20200813063618-45df63f5539f h1:DbxdcSQnYlQmKVDw1uZQNofPW3Uh7DPiLOuSmQSpBnY=
-github.com/pingcap/dumpling v0.0.0-20200813063618-45df63f5539f/go.mod h1:YdHhmydPKos+hqzn6kjMSGDu5VBUet5+C0HlZlv+hMM=
+github.com/pingcap/dumpling v0.0.0-20200819021059-26975af91c7b h1:RqxrVPu3e+nvwwwqhHedawNWkI/BQF4MgJRC+gcgnfk=
+github.com/pingcap/dumpling v0.0.0-20200819021059-26975af91c7b/go.mod h1:W1F7jfA4o29S7Mn8Gh9U81wvxdmEl72y5SQOqH0eDDg=
 github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9/go.mod h1:4b2X8xSqxIroj/IZ9MX/VGZhAwc11wB9wRIzHvz6SeM=
 github.com/pingcap/errcode v0.3.0 h1:IF6LC/4+b1KNwrMlr2rBTUrojFPMexXBcDWZSpNwxjg=
 github.com/pingcap/errcode v0.3.0/go.mod h1:4b2X8xSqxIroj/IZ9MX/VGZhAwc11wB9wRIzHvz6SeM=
@@ -594,8 +594,7 @@ github.com/pingcap/tidb-tools v4.0.0-rc.1.0.20200421113014-507d2bb3a15e+incompat
 github.com/pingcap/tidb-tools v4.0.0-rc.1.0.20200514040632-f76b3e428e19+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tidb-tools v4.0.0+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tidb-tools v4.0.1+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
-github.com/pingcap/tidb-tools v4.0.5-0.20200805025317-02a16e0521cb+incompatible h1:obFDQU7XvnCj8CiaXFP+bWaiQDp15Ueynk8cC0s5Utk=
-github.com/pingcap/tidb-tools v4.0.5-0.20200805025317-02a16e0521cb+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
+github.com/pingcap/tidb-tools v4.0.5-0.20200817064459-ba61a7376547+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tidb-tools v4.0.5-0.20200819060105-3ac93f6b99d4+incompatible h1:YWvktFiwn8oAwhlMwfM0/ohO/lREdFB6ZQHsthMgTzI=
 github.com/pingcap/tidb-tools v4.0.5-0.20200819060105-3ac93f6b99d4+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330 h1:rRMLMjIMFulCX9sGKZ1hoov/iROMsKyC8Snc02nSukw=

--- a/tests/print_status/run.sh
+++ b/tests/print_status/run.sh
@@ -60,7 +60,7 @@ function check_print_status() {
     echo "checking print status"
     # check load unit print status
     status_file=$WORK_DIR/worker1/log/loader_status.log
-    grep -oP "\[unit=load\] \[finished_bytes=[0-9]+\] \[total_bytes=58128\] \[total_file_count=3\] \[progress=.*\]" $WORK_DIR/worker1/log/dm-worker.log > $status_file
+    grep -oP "\[unit=load\] \[finished_bytes=[0-9]+\] \[total_bytes=59506\] \[total_file_count=3\] \[progress=.*\]" $WORK_DIR/worker1/log/dm-worker.log > $status_file
     #grep -oP "loader.*\Kfinished_bytes = [0-9]+, total_bytes = [0-9]+, total_file_count = [0-9]+, progress = .*" $WORK_DIR/worker1/log/dm-worker.log > $status_file
     status_count=$(wc -l $status_file|awk '{print $1}')
     [ $status_count -ge 2 ]


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

dump date with column name, so we can support the case:
- more columns exist in downstream than upstream
- different column order between downstream and upstream

### What is changed and how it works?

- update dumpling
- set `CompleteInsert` to `true`

data dumped before

```sql
INSERT INTO VALUES
(1,1),
(2,2),
(3,3);
```

data dumped now

```sql
INSERT INTO `t1` (`c1`,`c2`) VALUES
(1,1),
(2,2),
(3,3),
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    - dump & load data with more columns exist in downstream

Code changes

 - Has persistent data change

Related changes

 - Need to update the documentation
