### PR TITLE
dump: retrieve ANSI_QUOTES from upstream (#909)

### DIFF
--- a/dm/config/task.go
+++ b/dm/config/task.go
@@ -557,8 +557,6 @@ func (c *TaskConfig) SubTaskConfigs(sources map[string]DBConfig) ([]*SubTaskConf
 
 		cfg.CleanDumpFile = c.CleanDumpFile
 
-		cfg.EnableANSIQuotes = c.EnableANSIQuotes
-
 		err := cfg.Adjust(true)
 		if err != nil {
 			return nil, terror.Annotatef(err, "source %s", inst.SourceID)

--- a/mydumper/mydumper.go
+++ b/mydumper/mydumper.go
@@ -17,6 +17,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"database/sql"
+	"fmt"
 	"os"
 	"os/exec"
 	"regexp"
@@ -60,6 +62,7 @@ func NewMydumper(cfg *config.SubTaskConfig) *Mydumper {
 func (m *Mydumper) Init(ctx context.Context) error {
 	var err error
 	m.args, err = m.constructArgs()
+	m.detectAnsiQuotes()
 	return err
 }
 
@@ -315,4 +318,25 @@ func (m *Mydumper) logArgs(cfg *config.SubTaskConfig) []string {
 		args = append(args, "--verbose", "3")
 	}
 	return args
+}
+
+// detectAnsiQuotes tries to detect ANSI_QUOTES from upstream. If success, change EnableANSIQuotes in subtask config
+func (m *Mydumper) detectAnsiQuotes() {
+	dbCfg := m.cfg.From
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/", dbCfg.User, dbCfg.Password, dbCfg.Host, dbCfg.Port)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return
+	}
+	defer db.Close()
+	enable, err := utils.HasAnsiQuotesMode(db)
+	if err != nil {
+		return
+	}
+	if enable != m.cfg.EnableANSIQuotes {
+		m.logger.Warn("found mismatched ANSI_QUOTES setting, going to overwrite it to DB specified",
+			zap.Bool("DB specified", enable),
+			zap.Bool("config file specified", m.cfg.EnableANSIQuotes))
+	}
+	m.cfg.EnableANSIQuotes = enable
 }


### PR DESCRIPTION
cherry-pick #909 

---

<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
part of https://github.com/pingcap/dm/issues/907

### What is changed and how it works?
retrieve ANSI_QUOTES from upstream, and change subtask config.

disable manually config EnableANSIQuotes of subtask

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes


Side effects

Related changes

 - Need to cherry-pick to the release branch
