### PR TITLE
Fix auto resume

### DIFF
--- a/dm/worker/worker_test.go
+++ b/dm/worker/worker_test.go
@@ -118,12 +118,12 @@ func (t *testServer) TestTaskAutoResume(c *C) {
 
 	c.Assert(failpoint.Enable("github.com/pingcap/dm/dumpling/dumpUnitProcessForever", `return(true)`), IsNil)
 	defer failpoint.Disable("github.com/pingcap/dm/dumpling/dumpUnitProcessForever")
-	c.Assert(failpoint.Enable("github.com/pingcap/dm/dumpling/dumpUnitProcessWithError", `2*return("test auto resume inject error")`), IsNil)
-	defer failpoint.Disable("github.com/pingcap/dm/dumpling/dumpUnitProcessWithError")
 	c.Assert(failpoint.Enable("github.com/pingcap/dm/dm/worker/mockCreateUnitsDumpOnly", `return(true)`), IsNil)
 	defer failpoint.Disable("github.com/pingcap/dm/dm/worker/mockCreateUnitsDumpOnly")
 	c.Assert(failpoint.Enable("github.com/pingcap/dm/loader/ignoreLoadCheckpointErr", `return()`), IsNil)
 	defer failpoint.Disable("github.com/pingcap/dm/loader/ignoreLoadCheckpointErr")
+
+	c.Assert(failpoint.Enable("github.com/pingcap/dm/dumpling/dumpUnitProcessWithError", `return("test auto resume inject error")`), IsNil)
 
 	s := NewServer(cfg)
 
@@ -154,6 +154,7 @@ func (t *testServer) TestTaskAutoResume(c *C) {
 		}
 		return false
 	}), IsTrue)
+	failpoint.Disable("github.com/pingcap/dm/dumpling/dumpUnitProcessWithError")
 
 	rtsc, ok := s.getWorker(true).taskStatusChecker.(*realTaskStatusChecker)
 	c.Assert(ok, IsTrue)

--- a/dm/worker/worker_test.go
+++ b/dm/worker/worker_test.go
@@ -122,8 +122,8 @@ func (t *testServer) TestTaskAutoResume(c *C) {
 	defer failpoint.Disable("github.com/pingcap/dm/dm/worker/mockCreateUnitsDumpOnly")
 	c.Assert(failpoint.Enable("github.com/pingcap/dm/loader/ignoreLoadCheckpointErr", `return()`), IsNil)
 	defer failpoint.Disable("github.com/pingcap/dm/loader/ignoreLoadCheckpointErr")
-
 	c.Assert(failpoint.Enable("github.com/pingcap/dm/dumpling/dumpUnitProcessWithError", `return("test auto resume inject error")`), IsNil)
+	defer failpoint.Disable("github.com/pingcap/dm/dumpling/dumpUnitProcessWithError")
 
 	s := NewServer(cfg)
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
test fails because injected failpoint only fail for 2 times, when test runs slowly, that's not enough

### What is changed and how it works?
keep fails until we check, then disable it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes

 - Need to cherry-pick to the release branch

