### PR TITLE
basedb: close db when fail ping

### DIFF
--- a/pkg/conn/basedb.go
+++ b/pkg/conn/basedb.go
@@ -98,6 +98,7 @@ func (d *DefaultDBProviderImpl) Apply(config config.DBConfig) (*BaseDB, error) {
 	}
 
 	if err = db.Ping(); err != nil {
+		db.Close()
 		return nil, terror.DBErrorAdapt(err, terror.ErrDBDriverError)
 	}
 

--- a/pkg/conn/basedb.go
+++ b/pkg/conn/basedb.go
@@ -99,6 +99,7 @@ func (d *DefaultDBProviderImpl) Apply(config config.DBConfig) (*BaseDB, error) {
 
 	if err = db.Ping(); err != nil {
 		db.Close()
+		doFuncInClose()
 		return nil, terror.DBErrorAdapt(err, terror.ErrDBDriverError)
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
DB connection leak when successful open DB but failed ping.

### What is changed and how it works?
close it manually. **alternative is we should return `db, error` to caller instead of `nil, error`, so caller's rollback function could handle closing DB**.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - unit test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
