### PR TITLE
fix: handle `null` table_info after importing from v1.0.x

### DIFF
--- a/tests/import_v10x/data/v106_syncer_checkpoint.sql
+++ b/tests/import_v10x/data/v106_syncer_checkpoint.sql
@@ -12,4 +12,6 @@ CREATE TABLE IF NOT EXISTS `dm_meta`.`test_syncer_checkpoint` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 INSERT INTO `dm_meta`.`test_syncer_checkpoint` VALUES
 ('mysql-replica-01','','','BINLOG_NAME1',BINLOG_POS1,1,'2020-07-31 18:10:40','2020-07-31 18:11:40'),
-('mysql-replica-02','','','BINLOG_NAME2',BINLOG_POS2,1,'2020-07-31 18:10:40','2020-07-31 18:11:40');
+('mysql-replica-01','import_v10x','t1','BINLOG_NAME1',BINLOG_POS1,0,'2020-07-31 18:10:40','2020-07-31 18:11:40'),
+('mysql-replica-02','','','BINLOG_NAME2',BINLOG_POS2,1,'2020-07-31 18:10:40','2020-07-31 18:11:40'),
+('mysql-replica-02','import_v10x','t2','BINLOG_NAME2',BINLOG_POS2,0,'2020-07-31 18:10:40','2020-07-31 18:11:40');


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

    `gen delete sqls failed, schema: import_v10x, table: t2: Column count doesn't match value count: 0 (columns) vs 2 (values)` reported after importing from v1.0.6.

### What is changed and how it works?

   do not create an empty table if `table_info` column is `null`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
