### PR TITLE
master: fix panic when etcd member not started

### DIFF
--- a/dm/master/server.go
+++ b/dm/master/server.go
@@ -1864,9 +1864,13 @@ func (s *Server) listMemberMaster(ctx context.Context, names []string) (*pb.Memb
 		}
 
 		alive := true
-		_, err := client.Get(etcdMember.ClientURLs[0] + "/health")
-		if err != nil {
+		if len(etcdMember.ClientURLs) == 0 {
 			alive = false
+		} else {
+			_, err := client.Get(etcdMember.ClientURLs[0] + "/health")
+			if err != nil {
+				alive = false
+			}
 		}
 
 		masters = append(masters, &pb.MasterInfo{


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```
panic: runtime error: index out of range [0] with length 0

goroutine 758 [running]:
github.com/pingcap/dm/dm/master.(*Server).listMemberMaster(0xc0002fe3c0, 0x24dcde0, 0xc001af5a70, 0x0, 0x0, 0x0, 0x0, 0x1, 0xc001af5cb0)
        /home/jenkins/agent/workspace/build_dm_multi_branch_master/go/src/github.com/pingcap/dm/dm/master/server.go:1870 +0x6aa
github.com/pingcap/dm/dm/master.(*Server).ListMember(0xc0002fe3c0, 0x24dcde0, 0xc001af5a70, 0xc001ae2cc0, 0xc0002fe3c0, 0x24f6200, 0xc00093d080)
        /home/jenkins/agent/workspace/build_dm_multi_branch_master/go/src/github.com/pingcap/dm/dm/master/server.go:1989 +0x568
github.com/pingcap/dm/dm/pb._Master_ListMember_Handler.func1(0x24dcde0, 0xc001af5a70, 0x1fe7c20, 0xc001ae2cc0, 0x15, 0xc001aed7c0, 0xc002728701, 0x21b6250)
        /home/jenkins/agent/workspace/build_dm_multi_branch_master/go/src/github.com/pingcap/dm/dm/pb/dmmaster.pb.go:4057 +0x86
github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1(0x24dcde0, 0xc001af5a70, 0x1fe7c20, 0xc001ae2cc0, 0xc001ae2ce0, 0xc001ae2d00, 0xc001b409a0, 0x3c420d0, 0x1ed52c0, 0xc001af5980)
        /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107 +0xad
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1(0x24dcde0, 0xc001af5a70, 0x1fe7c20, 0xc001ae2cc0, 0x3c438c0, 0x1, 0x0, 0x11)
        /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 +0x63
go.etcd.io/etcd/etcdserver/api/v3rpc.newUnaryInterceptor.func1(0x24dcde0, 0xc001af5a70, 0x1fe7c20, 0xc001ae2cc0, 0xc001ae2ce0, 0xc001ae2d20, 0x4870e6, 0x5f4dbb2f, 0x1b8723f8, 0x9bf4b8b520b)
        /go/pkg/mod/go.etcd.io/etcd@v0.5.0-alpha.5.0.20191023171146-3cf2f69b5738/etcdserver/api/v3rpc/interceptor.go:64 +0x108
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1(0x24dcde0, 0xc001af5a70, 0x1fe7c20, 0xc001ae2cc0, 0x8, 0x2, 0x0, 0x203000)
        /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 +0x63
go.etcd.io/etcd/etcdserver/api/v3rpc.newLogUnaryInterceptor.func1(0x24dcde0, 0xc001af5a70, 0x1fe7c20, 0xc001ae2cc0, 0xc001ae2ce0, 0xc001ae2d40, 0x0, 0x0, 0x0, 0x0)
        /go/pkg/mod/go.etcd.io/etcd@v0.5.0-alpha.5.0.20191023171146-3cf2f69b5738/etcdserver/api/v3rpc/interceptor.go:71 +0xba
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1(0x24dcde0, 0xc001af5a70, 0x1fe7c20, 0xc001ae2cc0, 0xc001b64500, 0x0, 0xc0016caac0, 0x40cad8)
        /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 +0x63
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1(0x24dcde0, 0xc001af5a70, 0x1fe7c20, 0xc001ae2cc0, 0xc001ae2ce0, 0xc001ae2d00, 0xc0016cab30, 0x4907a8, 0x1f2b4e0, 0xc001af5a70)
        /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:34 +0xd5
github.com/pingcap/dm/dm/pb._Master_ListMember_Handler(0x20c42e0, 0xc0002fe3c0, 0x24dcde0, 0xc001af5a70, 0xc00093cf60, 0xc0024e68a0, 0x24dcde0, 0xc001af5a70, 0xc0008c73f0, 0x2)
        /home/jenkins/agent/workspace/build_dm_multi_branch_master/go/src/github.com/pingcap/dm/dm/pb/dmmaster.pb.go:4059 +0x14b
google.golang.org/grpc.(*Server).processUnaryRPC(0xc002490600, 0x25015a0, 0xc001abd800, 0xc001b64500, 0xc002562750, 0x3bca8f0, 0x0, 0x0, 0x0)
        /go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:1024 +0x4f4
google.golang.org/grpc.(*Server).handleStream(0xc002490600, 0x25015a0, 0xc001abd800, 0xc001b64500, 0x0)
        /go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:1313 +0xd97
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0008c6cf0, 0xc002490600, 0x25015a0, 0xc001abd800, 0xc001b64500)
        /go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:722 +0xbb
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:720 +0xa1
```

### What is changed and how it works?
when etcd member not started, its ClientURLs will be empty. check length to avoid panic 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Seems corrent and hard to test

Code changes


Side effects


Related changes

 - Need to cherry-pick to the release branch
 - Need update release note:
  修复了新启动的 DM-master 导致 `list-member` panic 的问题