### PR TITLE
task_checker: don't auto-resume for wrong datetime value

### DIFF
--- a/pkg/retry/errors.go
+++ b/pkg/retry/errors.go
@@ -37,7 +37,7 @@ var (
 	UnsupportedDMLMsgs = []string{
 		"Error 1062: Duplicate entry",
 		"Error 1406: Data too long for column",
-		"Error 1366: Incorrect datetime value",
+		"Error 1366",
 	}
 
 	// ParseRelayLogErrMsgs list the error messages of some un-recoverable relay log parsing error, which is used in task auto recovery.

--- a/pkg/retry/errors.go
+++ b/pkg/retry/errors.go
@@ -37,6 +37,7 @@ var (
 	UnsupportedDMLMsgs = []string{
 		"Error 1062: Duplicate entry",
 		"Error 1406: Data too long for column",
+		"Error 1366: Incorrect datetime value",
 	}
 
 	// ParseRelayLogErrMsgs list the error messages of some un-recoverable relay log parsing error, which is used in task auto recovery.


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #921

### What is changed and how it works?
add this type of error to `UnsupportedDMLMsgs` (can't verify this is the right place)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - hard to find a MariaDB 10.0, can't imitate using newer MariaDB and mysql56_temporal_format = OFF

Code changes

Side effects


Related changes

 - Need to cherry-pick to the release branch

