### PR TITLE
tls: add config to skip verify server cert

### DIFF
--- a/dm/config/security.go
+++ b/dm/config/security.go
@@ -21,6 +21,7 @@ type Security struct {
 	SSLCert       string   `toml:"ssl-cert" json:"ssl-cert" yaml:"ssl-cert"`
 	SSLKey        string   `toml:"ssl-key" json:"ssl-key" yaml:"ssl-key"`
 	CertAllowedCN strArray `toml:"cert-allowed-cn" json:"cert-allowed-cn" yaml:"cert-allowed-cn"`
+	VerifyServer  bool     `toml:"verify-server" json:"verify-server" yaml:"verify-server"`
 }
 
 // used for parse string slice in flag

--- a/tests/tls/conf/dm-master1.toml
+++ b/tests/tls/conf/dm-master1.toml
@@ -9,3 +9,4 @@ ssl-ca = "dir-placeholer/ca.pem"
 ssl-cert = "dir-placeholer/dm.pem"
 ssl-key = "dir-placeholer/dm.key"
 cert-allowed-cn = ["dm"]
+verify-server = true

--- a/tests/tls/conf/dm-master2.toml
+++ b/tests/tls/conf/dm-master2.toml
@@ -9,3 +9,4 @@ ssl-ca = "dir-placeholer/ca.pem"
 ssl-cert = "dir-placeholer/dm.pem"
 ssl-key = "dir-placeholer/dm.key"
 cert-allowed-cn = ["dm"]
+verify-server = true

--- a/tests/tls/conf/dm-master3.toml
+++ b/tests/tls/conf/dm-master3.toml
@@ -9,3 +9,4 @@ ssl-ca = "dir-placeholer/ca.pem"
 ssl-cert = "dir-placeholer/dm.pem"
 ssl-key = "dir-placeholer/dm.key"
 cert-allowed-cn = ["dm"]
+verify-server = true

--- a/tests/tls/conf/dm-task.yaml
+++ b/tests/tls/conf/dm-task.yaml
@@ -15,6 +15,7 @@ target-database:
     ssl-ca: "dir-placeholer/ca.pem"
     ssl-cert: "dir-placeholer/dm.pem"
     ssl-key: "dir-placeholer/dm.key"
+    verify-server: true
 
 mysql-instances:
   - source-id: "mysql-replica-01"

--- a/tests/tls/conf/dm-worker1.toml
+++ b/tests/tls/conf/dm-worker1.toml
@@ -5,3 +5,4 @@ ssl-ca = "dir-placeholer/ca.pem"
 ssl-cert = "dir-placeholer/dm.pem"
 ssl-key = "dir-placeholer/dm.key"
 cert-allowed-cn = ["dm"]
+verify-server = true


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
when upstream MySQL uses a certificate which has not written its hostname into SAN or CN, it will fail certificate check. now we could set `verify-server` to skip this check. But for [`go-sql-driver`'s settings](https://github.com/go-sql-driver/mysql#tls), this also eliminate usage of provided certificate.

### What is changed and how it works?
add `verify-server` and change `dsn`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - pass origin test
 - Manual test (test MySQL with wrong TLS)

Code changes

 - Has interface methods change

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
