### PR TITLE
shardddl: add lock and version for optimistic info

### DIFF
--- a/pkg/binlog/reader/util.go
+++ b/pkg/binlog/reader/util.go
@@ -64,7 +64,7 @@ func GetGTIDsForPos(ctx context.Context, r Reader, endPos gmysql.Position) (gtid
 		case *replication.QueryEvent:
 			parser2, err2 := event.GetParserForStatusVars(ev.StatusVars)
 			if err2 != nil {
-				log.L().Warn("can't determine sql_mode from binlog status_vars, use default parser instead", zap.Error(err))
+				log.L().Warn("can't determine sql_mode from binlog status_vars, use default parser instead", zap.Error(err2))
 				parser2 = parser.New()
 			}
 
@@ -76,7 +76,7 @@ func GetGTIDsForPos(ctx context.Context, r Reader, endPos gmysql.Position) (gtid
 				}
 				err2 = latestGSet.Update(nextGTIDStr)
 				if err2 != nil {
-					return nil, terror.Annotatef(err, "update GTID set %v with GTID %s", latestGSet, nextGTIDStr)
+					return nil, terror.Annotatef(err2, "update GTID set %v with GTID %s", latestGSet, nextGTIDStr)
 				}
 				latestPos = e.Header.LogPos
 			}

--- a/pkg/binlog/reader/util.go
+++ b/pkg/binlog/reader/util.go
@@ -62,8 +62,8 @@ func GetGTIDsForPos(ctx context.Context, r Reader, endPos gmysql.Position) (gtid
 		// NOTE: only update endPos/GTIDs for DDL/XID to get an complete transaction.
 		switch ev := e.Event.(type) {
 		case *replication.QueryEvent:
-			parser2, err := event.GetParserForStatusVars(ev.StatusVars)
-			if err != nil {
+			parser2, err2 := event.GetParserForStatusVars(ev.StatusVars)
+			if err2 != nil {
 				log.L().Warn("can't determine sql_mode from binlog status_vars, use default parser instead", zap.Error(err))
 				parser2 = parser.New()
 			}
@@ -74,8 +74,8 @@ func GetGTIDsForPos(ctx context.Context, r Reader, endPos gmysql.Position) (gtid
 					// GTID not enabled, can't get GTIDs for the position.
 					return nil, errors.Errorf("should have a GTIDEvent before the DDL QueryEvent %+v", e.Header)
 				}
-				err = latestGSet.Update(nextGTIDStr)
-				if err != nil {
+				err2 = latestGSet.Update(nextGTIDStr)
+				if err2 != nil {
 					return nil, terror.Annotatef(err, "update GTID set %v with GTID %s", latestGSet, nextGTIDStr)
 				}
 				latestPos = e.Header.LogPos

--- a/pkg/conn/basedb.go
+++ b/pkg/conn/basedb.go
@@ -52,8 +52,8 @@ func init() {
 	DefaultDBProvider = &DefaultDBProviderImpl{}
 }
 
-// mock is used in unit test
-var mock sqlmock.Sqlmock
+// mockDB is used in unit test
+var mockDB sqlmock.Sqlmock
 
 // Apply will build BaseDB with DBConfig
 func (d *DefaultDBProviderImpl) Apply(config config.DBConfig) (*BaseDB, error) {
@@ -105,9 +105,9 @@ func (d *DefaultDBProviderImpl) Apply(config config.DBConfig) (*BaseDB, error) {
 	}
 	failpoint.Inject("failDBPing", func(_ failpoint.Value) {
 		db.Close()
-		db, mock, _ = sqlmock.New()
-		mock.ExpectPing()
-		mock.ExpectClose()
+		db, mockDB, _ = sqlmock.New()
+		mockDB.ExpectPing()
+		mockDB.ExpectClose()
 	})
 
 	err = db.Ping()

--- a/pkg/conn/basedb_test.go
+++ b/pkg/conn/basedb_test.go
@@ -72,6 +72,6 @@ func (t *testBaseDBSuite) TestFailDBPing(c *C) {
 	c.Assert(db, IsNil)
 	c.Assert(err, NotNil)
 
-	err = mock.ExpectationsWereMet()
+	err = mockDB.ExpectationsWereMet()
 	c.Assert(err, IsNil)
 }

--- a/pkg/shardddl/optimism/info_test.go
+++ b/pkg/shardddl/optimism/info_test.go
@@ -126,7 +126,9 @@ func (t *testForEtcd) TestInfoEtcd(c *C) {
 	c.Assert(ifm[task1], HasLen, 1)
 	c.Assert(ifm[task1][source1], HasLen, 1)
 	c.Assert(ifm[task1][source1][upSchema], HasLen, 1)
-	c.Assert(ifm[task1][source1][upSchema][upTable], DeepEquals, i11)
+	i11WithVer := i11
+	i11WithVer.Version = 2
+	c.Assert(ifm[task1][source1][upSchema][upTable], DeepEquals, i11WithVer)
 
 	// put another key and get again with 2 info.
 	rev4, err := PutInfo(etcdTestCli, i12)
@@ -136,8 +138,10 @@ func (t *testForEtcd) TestInfoEtcd(c *C) {
 	c.Assert(ifm, HasLen, 1)
 	c.Assert(ifm, HasKey, task1)
 	c.Assert(ifm[task1], HasLen, 2)
-	c.Assert(ifm[task1][source1][upSchema][upTable], DeepEquals, i11)
-	c.Assert(ifm[task1][source2][upSchema][upTable], DeepEquals, i12)
+	c.Assert(ifm[task1][source1][upSchema][upTable], DeepEquals, i11WithVer)
+	i12WithVer := i12
+	i12WithVer.Version = 1
+	c.Assert(ifm[task1][source2][upSchema][upTable], DeepEquals, i12WithVer)
 
 	// start the watcher.
 	wch := make(chan Info, 10)
@@ -149,23 +153,49 @@ func (t *testForEtcd) TestInfoEtcd(c *C) {
 		ctx, cancel := context.WithTimeout(context.Background(), watchTimeout)
 		defer cancel()
 		WatchInfo(ctx, etcdTestCli, rev4+1, wch, ech) // revision+1
-		close(wch)                                    // close the chan
-		close(ech)
 	}()
 
 	// put another key for a different task.
+	// version start from 1
 	_, err = PutInfo(etcdTestCli, i21)
 	c.Assert(err, IsNil)
-	wg.Wait()
-
-	// watch should only get i21.
-	c.Assert(len(wch), Equals, 1)
-	c.Assert(<-wch, DeepEquals, i21)
+	infoWithVer := <-wch
+	i21WithVer := i21
+	i21WithVer.Version = 1
+	c.Assert(infoWithVer, DeepEquals, i21WithVer)
 	c.Assert(len(ech), Equals, 0)
 
-	// delete i12.
-	deleteOp := deleteInfoOp(i12)
+	// put again
+	// version increase
+	_, err = PutInfo(etcdTestCli, i21)
+	c.Assert(err, IsNil)
+	infoWithVer = <-wch
+	i21WithVer.Version++
+	c.Assert(infoWithVer, DeepEquals, i21WithVer)
+	c.Assert(len(ech), Equals, 0)
+
+	// delete i21.
+	deleteOp := deleteInfoOp(i21)
 	resp, err := etcdTestCli.Txn(context.Background()).Then(deleteOp).Commit()
+	c.Assert(err, IsNil)
+	<-wch
+
+	// put again
+	// version reset to 1
+	_, err = PutInfo(etcdTestCli, i21)
+	c.Assert(err, IsNil)
+	infoWithVer = <-wch
+	i21WithVer.Version = 1
+	c.Assert(infoWithVer, DeepEquals, i21WithVer)
+	c.Assert(len(ech), Equals, 0)
+
+	close(wch) // close the chan
+	close(ech)
+	wg.Wait()
+
+	// delete i12.
+	deleteOp = deleteInfoOp(i12)
+	resp, err = etcdTestCli.Txn(context.Background()).Then(deleteOp).Commit()
 	c.Assert(err, IsNil)
 
 	// get again.
@@ -175,9 +205,9 @@ func (t *testForEtcd) TestInfoEtcd(c *C) {
 	c.Assert(ifm, HasKey, task1)
 	c.Assert(ifm, HasKey, task2)
 	c.Assert(ifm[task1], HasLen, 1)
-	c.Assert(ifm[task1][source1][upSchema][upTable], DeepEquals, i11)
+	c.Assert(ifm[task1][source1][upSchema][upTable], DeepEquals, i11WithVer)
 	c.Assert(ifm[task2], HasLen, 1)
-	c.Assert(ifm[task2][source1][upSchema][upTable], DeepEquals, i21)
+	c.Assert(ifm[task2][source1][upSchema][upTable], DeepEquals, i21WithVer)
 
 	// watch the deletion for i12.
 	wch = make(chan Info, 10)

--- a/pkg/shardddl/optimism/keeper.go
+++ b/pkg/shardddl/optimism/keeper.go
@@ -50,7 +50,7 @@ func (lk *LockKeeper) TrySync(info Info, tts []TargetTable) (string, []string, e
 		l = lk.locks[lockID]
 	}
 
-	newDDLs, err := l.TrySync(info.Source, info.UpSchema, info.UpTable, info.DDLs, info.TableInfoAfter, tts)
+	newDDLs, err := l.TrySync(info.Source, info.UpSchema, info.UpTable, info.DDLs, info.TableInfoAfter, tts, info.Version)
 	return lockID, newDDLs, err
 }
 

--- a/pkg/shardddl/optimism/lock.go
+++ b/pkg/shardddl/optimism/lock.go
@@ -53,7 +53,7 @@ type Lock struct {
 	done map[string]map[string]map[string]bool
 
 	// upstream source ID -> upstream schema name -> upstream table name -> info version.
-	Versions map[string]map[string]map[string]int64
+	versions map[string]map[string]map[string]int64
 }
 
 // NewLock creates a new Lock instance.
@@ -68,7 +68,7 @@ func NewLock(ID, task, downSchema, downTable string, ti *model.TableInfo, tts []
 		tables:     make(map[string]map[string]map[string]schemacmp.Table),
 		done:       make(map[string]map[string]map[string]bool),
 		synced:     true,
-		Versions:   make(map[string]map[string]map[string]int64),
+		versions:   make(map[string]map[string]map[string]int64),
 	}
 	l.addTables(tts)
 	metrics.ReportDDLPending(task, metrics.DDLPendingNone, metrics.DDLPendingSynced)
@@ -108,8 +108,8 @@ func (l *Lock) TrySync(callerSource, callerSchema, callerTable string,
 		map[string]map[string]struct{}{callerSchema: {callerTable: struct{}{}}}))
 	// add any new source tables.
 	l.addTables(tts)
-	if val, ok := l.Versions[callerSource][callerSchema][callerTable]; !ok || val < infoVersion {
-		l.Versions[callerSource][callerSchema][callerTable] = infoVersion
+	if val, ok := l.versions[callerSource][callerSchema][callerTable]; !ok || val < infoVersion {
+		l.versions[callerSource][callerSchema][callerTable] = infoVersion
 	}
 
 	var emptyDDLs = []string{}
@@ -257,7 +257,7 @@ func (l *Lock) TryRemoveTable(source, schema, table string) bool {
 	_, remain := l.syncStatus()
 	l.synced = remain == 0
 	delete(l.done[source][schema], table)
-	delete(l.Versions[source][schema], table)
+	delete(l.versions[source][schema], table)
 	log.L().Info("table removed from the lock", zap.String("lock", l.ID),
 		zap.String("source", source), zap.String("schema", schema), zap.String("table", table),
 		zap.Stringer("table info", ti))
@@ -405,20 +405,20 @@ func (l *Lock) addTables(tts []TargetTable) {
 		if _, ok := l.tables[tt.Source]; !ok {
 			l.tables[tt.Source] = make(map[string]map[string]schemacmp.Table)
 			l.done[tt.Source] = make(map[string]map[string]bool)
-			l.Versions[tt.Source] = make(map[string]map[string]int64)
+			l.versions[tt.Source] = make(map[string]map[string]int64)
 		}
 		for schema, tables := range tt.UpTables {
 			if _, ok := l.tables[tt.Source][schema]; !ok {
 				l.tables[tt.Source][schema] = make(map[string]schemacmp.Table)
 				l.done[tt.Source][schema] = make(map[string]bool)
-				l.Versions[tt.Source][schema] = make(map[string]int64)
+				l.versions[tt.Source][schema] = make(map[string]int64)
 			}
 			for table := range tables {
 				if _, ok := l.tables[tt.Source][schema][table]; !ok {
 					// NOTE: the newly added table uses the current table info.
 					l.tables[tt.Source][schema][table] = l.joined
 					l.done[tt.Source][schema][table] = false
-					l.Versions[tt.Source][schema][table] = 0
+					l.versions[tt.Source][schema][table] = 0
 					log.L().Info("table added to the lock", zap.String("lock", l.ID),
 						zap.String("source", tt.Source), zap.String("schema", schema), zap.String("table", table),
 						zap.Stringer("table info", l.joined))
@@ -426,4 +426,12 @@ func (l *Lock) addTables(tts []TargetTable) {
 			}
 		}
 	}
+}
+
+// GetVersion return version of info in lock.
+func (l *Lock) GetVersion(source string, schema string, table string) int64 {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	return l.versions[source][schema][table]
 }

--- a/pkg/shardddl/optimism/lock_test.go
+++ b/pkg/shardddl/optimism/lock_test.go
@@ -375,7 +375,7 @@ func (t *testLock) TestLockTrySyncIndex(c *C) {
 
 	// try sync for another table, also got `DROP INDEX` now.
 	vers[source][db][tbls[1]]++
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts, vers[source][db][tbls[0]])
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
 	c.Assert(l.versions, DeepEquals, vers)

--- a/pkg/shardddl/optimism/lock_test.go
+++ b/pkg/shardddl/optimism/lock_test.go
@@ -103,7 +103,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 				DDLs, err := l.TrySync(source, db, tbl, DDLs1, ti1, tts, vers[source][db][tbl])
 				c.Assert(err, IsNil)
 				c.Assert(DDLs, DeepEquals, DDLs1)
-				c.Assert(l.Versions, DeepEquals, vers)
+				c.Assert(l.versions, DeepEquals, vers)
 
 				syncedCount++
 				synced, remain := l.IsSynced()
@@ -122,7 +122,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	DDLs, err := l.TrySync(sources[0], dbs[0], tbls[0], DDLs1, ti1, tts, vers[sources[0]][dbs[0]][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	t.checkLockSynced(c, l)
 	t.checkLockNoDone(c, l)
 
@@ -132,7 +132,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs2, ti2, tts, vers[sources[0]][dbs[0]][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready := l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[0]], IsTrue)
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsFalse)
@@ -142,7 +142,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs2, ti2, tts, vers[sources[0]][dbs[0]][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[0]], IsTrue)
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsFalse)
@@ -152,7 +152,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[0:1], ti2_1, tts, vers[sources[0]][dbs[0]][tbls[1]]) // use ti2_1 info
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2[0:1])
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[0]], IsTrue)
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsFalse)
@@ -169,7 +169,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[0:1], ti2_1, tts, vers[sources[0]][dbs[0]][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{}) // NOTE: special case, joined has larger schema.
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsFalse)
 
@@ -178,7 +178,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[1:2], ti2, tts, vers[sources[0]][dbs[0]][tbls[1]]) // use ti2 info.
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2[1:2])
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsTrue) // ready now.
 	synced, remain = l.IsSynced()
@@ -194,7 +194,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[1:2], ti2, tts, vers[sources[0]][dbs[0]][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2[1:2])
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 
 	// try add columns for all tables to reach the same schema.
 	t.trySyncForAllTablesLarger(c, l, DDLs2, ti2, tts, vers)
@@ -222,7 +222,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 				vers[source][db][tbl]++
 				DDLs, err = l.TrySync(source, db, tbl, DDLs3, ti3, tts, vers[source][db][tbl])
 				c.Assert(err, IsNil)
-				c.Assert(l.Versions, DeepEquals, vers)
+				c.Assert(l.versions, DeepEquals, vers)
 				synced, remain = l.IsSynced()
 				c.Assert(synced, Equals, l.synced)
 				if syncedCount == tableCount {
@@ -246,7 +246,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs4, ti4, tts, vers[sources[0]][dbs[0]][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[0]], IsFalse)
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsTrue)
@@ -256,7 +256,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs4, ti4, tts, vers[sources[0]][dbs[0]][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[0]], IsFalse)
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsTrue)
@@ -266,7 +266,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[0:1], ti4_1, tts, vers[sources[0]][dbs[0]][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[0]], IsFalse)
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsFalse)
@@ -279,14 +279,14 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[0:1], ti4_1, tts, vers[sources[0]][dbs[0]][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 
 	// drop the second column for another table.
 	vers[sources[0]][dbs[0]][tbls[1]]++
 	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[1:2], ti4, tts, vers[sources[0]][dbs[0]][tbls[1]]) // use ti4 info.
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[0]], IsFalse)
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsFalse)
@@ -299,7 +299,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[1:2], ti4, tts, vers[sources[0]][dbs[0]][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 
 	// try drop columns for other tables to reach the same schema.
 	remain = tableCount - 2
@@ -309,7 +309,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 				if synced2 { // do not `TrySync` again for previous two (un-synced now).
 					DDLs, err = l.TrySync(source, schema, table, DDLs4, ti4, tts, vers[source][schema][table])
 					c.Assert(err, IsNil)
-					c.Assert(l.Versions, DeepEquals, vers)
+					c.Assert(l.versions, DeepEquals, vers)
 					remain--
 					if remain == 0 {
 						c.Assert(DDLs, DeepEquals, DDLs4)
@@ -367,7 +367,7 @@ func (t *testLock) TestLockTrySyncIndex(c *C) {
 	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	synced, remain := l.IsSynced()
 	c.Assert(synced, Equals, l.synced)
 	c.Assert(synced, IsFalse)
@@ -378,7 +378,7 @@ func (t *testLock) TestLockTrySyncIndex(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	t.checkLockSynced(c, l)
 
 	// try sync for one table, `ADD INDEX` not returned directly (to keep the schema more compatible).
@@ -387,7 +387,7 @@ func (t *testLock) TestLockTrySyncIndex(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[0], DDLs2, ti2, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{}) // no DDLs returned
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	synced, remain = l.IsSynced()
 	c.Assert(synced, Equals, l.synced)
 	c.Assert(synced, IsFalse)
@@ -398,7 +398,7 @@ func (t *testLock) TestLockTrySyncIndex(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	t.checkLockSynced(c, l)
 }
 
@@ -446,28 +446,28 @@ func (t *testLock) TestLockTrySyncNullNotNull(c *C) {
 		DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 		c.Assert(err, IsNil)
 		c.Assert(DDLs, DeepEquals, []string{})
-		c.Assert(l.Versions, DeepEquals, vers)
+		c.Assert(l.versions, DeepEquals, vers)
 
 		// try sync for another table, DDLs returned.
 		vers[source][db][tbls[1]]++
 		DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts, vers[source][db][tbls[1]])
 		c.Assert(err, IsNil)
 		c.Assert(DDLs, DeepEquals, DDLs1)
-		c.Assert(l.Versions, DeepEquals, vers)
+		c.Assert(l.versions, DeepEquals, vers)
 
 		// try sync for one table, from `NOT NULL` to `NULL`, DDLs returned.
 		vers[source][db][tbls[0]]++
 		DDLs, err = l.TrySync(source, db, tbls[0], DDLs2, ti2, tts, vers[source][db][tbls[0]])
 		c.Assert(err, IsNil)
 		c.Assert(DDLs, DeepEquals, DDLs2)
-		c.Assert(l.Versions, DeepEquals, vers)
+		c.Assert(l.versions, DeepEquals, vers)
 
 		// try sync for another table, from `NOT NULL` to `NULL`, DDLs, returned.
 		vers[source][db][tbls[1]]++
 		DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
 		c.Assert(err, IsNil)
 		c.Assert(DDLs, DeepEquals, DDLs2)
-		c.Assert(l.Versions, DeepEquals, vers)
+		c.Assert(l.versions, DeepEquals, vers)
 	}
 }
 
@@ -512,14 +512,14 @@ func (t *testLock) TestLockTrySyncIntBigint(c *C) {
 	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 
 	// try sync for another table, DDLs returned.
 	vers[source][db][tbls[1]]++
 	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 }
 
 func (t *testLock) TestLockTrySyncNoDiff(c *C) {
@@ -563,7 +563,7 @@ func (t *testLock) TestLockTrySyncNoDiff(c *C) {
 	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 }
 
 func (t *testLock) TestLockTrySyncNewTable(c *C) {
@@ -607,7 +607,7 @@ func (t *testLock) TestLockTrySyncNewTable(c *C) {
 	DDLs, err := l.TrySync(source2, db2, tbl2, DDLs1, ti1, tts, vers[source2][db2][tbl2])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 
 	ready := l.Ready()
 	c.Assert(ready, HasLen, 2)
@@ -631,7 +631,7 @@ func (t *testLock) TestLockTrySyncNewTable(c *C) {
 	DDLs, err = l.TrySync(source1, db1, tbl1, DDLs1, ti1, tts, vers[source1][db1][tbl1])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 
 	ready = l.Ready()
 	c.Assert(ready, HasLen, 2)
@@ -699,7 +699,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready := l.Ready()
 	c.Assert(ready[source][db][tbls[0]], IsTrue)
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
@@ -715,7 +715,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[0], DDLs2, ti2, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	t.checkLockSynced(c, l)
 	t.checkLockNoDone(c, l)
 
@@ -725,7 +725,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[0], DDLs3, ti3, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs3)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[0]], IsTrue)
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
@@ -741,7 +741,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[0], DDLs4, ti4, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs4)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
 	cmp, err = l.tables[source][db][tbls[0]].Compare(l.Joined())
@@ -756,7 +756,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[0], DDLs5, ti5, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs5)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	t.checkLockSynced(c, l)
 	t.checkLockNoDone(c, l)
 
@@ -766,7 +766,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[0], DDLs6, ti6, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs6)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
 	cmp, err = l.tables[source][db][tbls[0]].Compare(l.Joined())
@@ -781,7 +781,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[0], DDLs7, ti7, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs7)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
 	cmp, err = l.tables[source][db][tbls[0]].Compare(l.Joined())
@@ -796,7 +796,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[1], DDLs8, ti8, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs8)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	t.checkLockSynced(c, l)
 	t.checkLockNoDone(c, l)
 }
@@ -843,7 +843,7 @@ func (t *testLock) TestLockTrySyncConflictNonIntrusive(c *C) {
 	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready := l.Ready()
 	c.Assert(ready[source][db][tbls[0]], IsTrue)
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
@@ -859,7 +859,7 @@ func (t *testLock) TestLockTrySyncConflictNonIntrusive(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
 	c.Assert(err, ErrorMatches, ".*at tuple index.*")
 	c.Assert(cmp, Equals, 0)
@@ -871,7 +871,7 @@ func (t *testLock) TestLockTrySyncConflictNonIntrusive(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[0], DDLs3, ti3, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs3)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[0]], IsFalse)
 	c.Assert(ready[source][db][tbls[1]], IsTrue) // the second table become synced now.
@@ -887,7 +887,7 @@ func (t *testLock) TestLockTrySyncConflictNonIntrusive(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[0], DDLs4, ti4, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs4)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	t.checkLockSynced(c, l)
 	t.checkLockNoDone(c, l)
 }
@@ -945,7 +945,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready := l.Ready()
 	c.Assert(ready[source][db][tbls[0]], IsTrue)
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
@@ -961,7 +961,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
 	c.Assert(err, ErrorMatches, ".*at tuple index.*")
 	c.Assert(cmp, Equals, 0)
@@ -973,7 +973,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
 	c.Assert(err, ErrorMatches, ".*at tuple index.*")
 	c.Assert(cmp, Equals, 0)
@@ -983,7 +983,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[1], DDLs3, ti3, tts, vers[source][db][tbls[1]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
 	c.Assert(err, ErrorMatches, ".*at tuple index.*")
 	c.Assert(cmp, Equals, 0)
@@ -995,7 +995,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[1], DDLs4, ti4, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
 	c.Assert(err, IsNil)
 	c.Assert(cmp, Equals, -1)
@@ -1007,7 +1007,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
 	c.Assert(err, IsNil)
 	c.Assert(cmp, Equals, 0)
@@ -1020,7 +1020,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[0], DDLs5, ti5, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs5)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[0]], IsTrue)
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
@@ -1039,7 +1039,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
 	c.Assert(err, ErrorMatches, ".*at tuple index.*")
 	c.Assert(cmp, Equals, 0)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
 
@@ -1049,7 +1049,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[1], DDLs7, ti7, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs7) // special case: these DDLs should not be replicated to the downstream.
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[0]], IsFalse)
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
@@ -1121,7 +1121,7 @@ func (t *testLock) TestTryRemoveTable(c *C) {
 	DDLs, err := l.TrySync(source, db, tbl1, DDLs1, ti1, tts, vers[source][db][tbl1])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready := l.Ready()
 	c.Assert(ready, HasLen, 1)
 	c.Assert(ready[source], HasLen, 1)
@@ -1137,7 +1137,7 @@ func (t *testLock) TestTryRemoveTable(c *C) {
 	c.Assert(ready[source], HasLen, 1)
 	c.Assert(ready[source][db], HasLen, 1)
 	c.Assert(ready[source][db][tbl1], IsTrue)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 
 	// CASE: remove a table will not rebuild joined schema now.
 	// TrySync to add the second back.
@@ -1145,7 +1145,7 @@ func (t *testLock) TestTryRemoveTable(c *C) {
 	DDLs, err = l.TrySync(source, db, tbl2, DDLs2, ti2, tts, vers[source][db][tbl1])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready, HasLen, 1)
 	c.Assert(ready[source], HasLen, 1)
@@ -1161,7 +1161,7 @@ func (t *testLock) TestTryRemoveTable(c *C) {
 	c.Assert(ready[source], HasLen, 1)
 	c.Assert(ready[source][db], HasLen, 1)
 	c.Assert(ready[source][db][tbl1], IsFalse) // the joined schema is not rebuild.
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 
 	// CASE: try to remove for not-exists table.
 	c.Assert(l.TryRemoveTable(source, db, "not-exist"), IsFalse)
@@ -1210,7 +1210,7 @@ func (t *testLock) TestLockTryMarkDone(c *C) {
 	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 	t.checkLockNoDone(c, l)
 	c.Assert(l.IsResolved(), IsFalse)
 
@@ -1225,7 +1225,7 @@ func (t *testLock) TestLockTryMarkDone(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 
 	// the first table is still keep `done` (for the previous DDLs operation)
 	c.Assert(l.IsDone(source, db, tbls[0]), IsTrue)
@@ -1244,7 +1244,7 @@ func (t *testLock) TestLockTryMarkDone(c *C) {
 	DDLs, err = l.TrySync(source, db, tbls[0], DDLs3, ti3, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs3)
-	c.Assert(l.Versions, DeepEquals, vers)
+	c.Assert(l.versions, DeepEquals, vers)
 
 	// the first table become not-done, and the lock is un-resolved.
 	c.Assert(l.IsDone(source, db, tbls[0]), IsFalse)

--- a/pkg/shardddl/optimism/lock_test.go
+++ b/pkg/shardddl/optimism/lock_test.go
@@ -65,6 +65,17 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 		}
 
 		l = NewLock(ID, task, downSchema, downTable, ti0, tts)
+
+		vers = map[string]map[string]map[string]int64{
+			sources[0]: {
+				dbs[0]: {tbls[0]: 0, tbls[1]: 0},
+				dbs[1]: {tbls[0]: 0, tbls[1]: 0},
+			},
+			sources[1]: {
+				dbs[0]: {tbls[0]: 0, tbls[1]: 0},
+				dbs[1]: {tbls[0]: 0, tbls[1]: 0},
+			},
+		}
 	)
 
 	// the initial status is synced.
@@ -88,9 +99,11 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 
 		for _, db := range dbs {
 			for _, tbl := range tbls {
-				DDLs, err := l.TrySync(source, db, tbl, DDLs1, ti1, tts)
+				vers[source][db][tbl]++
+				DDLs, err := l.TrySync(source, db, tbl, DDLs1, ti1, tts, vers[source][db][tbl])
 				c.Assert(err, IsNil)
 				c.Assert(DDLs, DeepEquals, DDLs1)
+				c.Assert(l.Versions, DeepEquals, vers)
 
 				syncedCount++
 				synced, remain := l.IsSynced()
@@ -105,33 +118,41 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	t.checkLockNoDone(c, l)
 
 	// CASE: TrySync again after synced is idempotent.
-	DDLs, err := l.TrySync(sources[0], dbs[0], tbls[0], DDLs1, ti1, tts)
+	vers[sources[0]][dbs[0]][tbls[0]]++
+	DDLs, err := l.TrySync(sources[0], dbs[0], tbls[0], DDLs1, ti1, tts, vers[sources[0]][dbs[0]][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
+	c.Assert(l.Versions, DeepEquals, vers)
 	t.checkLockSynced(c, l)
 	t.checkLockNoDone(c, l)
 
 	// CASE: need to add more than one DDL to reach the desired schema (schema become larger).
 	// add two columns for one table.
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs2, ti2, tts)
+	vers[sources[0]][dbs[0]][tbls[0]]++
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs2, ti2, tts, vers[sources[0]][dbs[0]][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready := l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[0]], IsTrue)
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsFalse)
 
 	// TrySync again is idempotent (more than one DDL).
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs2, ti2, tts)
+	vers[sources[0]][dbs[0]][tbls[0]]++
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs2, ti2, tts, vers[sources[0]][dbs[0]][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[0]], IsTrue)
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsFalse)
 
 	// add only the first column for another table.
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[0:1], ti2_1, tts) // use ti2_1 info
+	vers[sources[0]][dbs[0]][tbls[1]]++
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[0:1], ti2_1, tts, vers[sources[0]][dbs[0]][tbls[1]]) // use ti2_1 info
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2[0:1])
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[0]], IsTrue)
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsFalse)
@@ -144,16 +165,20 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	c.Assert(cmp, Equals, 1)
 
 	// TrySync again (only the first DDL).
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[0:1], ti2_1, tts)
+	vers[sources[0]][dbs[0]][tbls[1]]++
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[0:1], ti2_1, tts, vers[sources[0]][dbs[0]][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{}) // NOTE: special case, joined has larger schema.
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsFalse)
 
 	// add the second column for another table.
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[1:2], ti2, tts) // use ti2 info.
+	vers[sources[0]][dbs[0]][tbls[1]]++
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[1:2], ti2, tts, vers[sources[0]][dbs[0]][tbls[1]]) // use ti2 info.
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2[1:2])
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsTrue) // ready now.
 	synced, remain = l.IsSynced()
@@ -165,12 +190,14 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	c.Assert(cmp, Equals, 0)
 
 	// Try again (for the second DDL).
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[1:2], ti2, tts)
+	vers[sources[0]][dbs[0]][tbls[1]]++
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[1:2], ti2, tts, vers[sources[0]][dbs[0]][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2[1:2])
+	c.Assert(l.Versions, DeepEquals, vers)
 
 	// try add columns for all tables to reach the same schema.
-	t.trySyncForAllTablesLarger(c, l, DDLs2, ti2, tts)
+	t.trySyncForAllTablesLarger(c, l, DDLs2, ti2, tts, vers)
 	t.checkLockSynced(c, l)
 	t.checkLockNoDone(c, l)
 
@@ -192,8 +219,10 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 		for _, db := range dbs {
 			for _, tbl := range tbls {
 				syncedCount++
-				DDLs, err = l.TrySync(source, db, tbl, DDLs3, ti3, tts)
+				vers[source][db][tbl]++
+				DDLs, err = l.TrySync(source, db, tbl, DDLs3, ti3, tts, vers[source][db][tbl])
 				c.Assert(err, IsNil)
+				c.Assert(l.Versions, DeepEquals, vers)
 				synced, remain = l.IsSynced()
 				c.Assert(synced, Equals, l.synced)
 				if syncedCount == tableCount {
@@ -213,25 +242,31 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 
 	// CASE: need to drop more than one DDL to reach the desired schema (schema become smaller).
 	// drop two columns for one table.
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs4, ti4, tts)
+	vers[sources[0]][dbs[0]][tbls[0]]++
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs4, ti4, tts, vers[sources[0]][dbs[0]][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[0]], IsFalse)
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsTrue)
 
 	// TrySync again is idempotent.
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs4, ti4, tts)
+	vers[sources[0]][dbs[0]][tbls[0]]++
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs4, ti4, tts, vers[sources[0]][dbs[0]][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[0]], IsFalse)
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsTrue)
 
 	// drop only the first column for another table.
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[0:1], ti4_1, tts)
+	vers[sources[0]][dbs[0]][tbls[1]]++
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[0:1], ti4_1, tts, vers[sources[0]][dbs[0]][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[0]], IsFalse)
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsFalse)
@@ -240,14 +275,18 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	c.Assert(cmp, Equals, -1)
 
 	// TrySync again (only the first DDL).
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[0:1], ti4_1, tts)
+	vers[sources[0]][dbs[0]][tbls[1]]++
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[0:1], ti4_1, tts, vers[sources[0]][dbs[0]][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
+	c.Assert(l.Versions, DeepEquals, vers)
 
 	// drop the second column for another table.
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[1:2], ti4, tts) // use ti4 info.
+	vers[sources[0]][dbs[0]][tbls[1]]++
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[1:2], ti4, tts, vers[sources[0]][dbs[0]][tbls[1]]) // use ti4 info.
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[0]], IsFalse)
 	c.Assert(ready[sources[0]][dbs[0]][tbls[1]], IsFalse)
@@ -256,9 +295,11 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	c.Assert(cmp, Equals, 0)
 
 	// TrySync again (for the second DDL).
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[1:2], ti4, tts)
+	vers[sources[0]][dbs[0]][tbls[1]]++
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[1:2], ti4, tts, vers[sources[0]][dbs[0]][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
+	c.Assert(l.Versions, DeepEquals, vers)
 
 	// try drop columns for other tables to reach the same schema.
 	remain = tableCount - 2
@@ -266,8 +307,9 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 		for schema, tables := range schemaTables {
 			for table, synced2 := range tables {
 				if synced2 { // do not `TrySync` again for previous two (un-synced now).
-					DDLs, err = l.TrySync(source, schema, table, DDLs4, ti4, tts)
+					DDLs, err = l.TrySync(source, schema, table, DDLs4, ti4, tts, vers[source][schema][table])
 					c.Assert(err, IsNil)
+					c.Assert(l.Versions, DeepEquals, vers)
 					remain--
 					if remain == 0 {
 						c.Assert(DDLs, DeepEquals, DDLs4)
@@ -307,6 +349,12 @@ func (t *testLock) TestLockTrySyncIndex(c *C) {
 		}
 
 		l = NewLock(ID, task, downSchema, downTable, ti0, tts)
+
+		vers = map[string]map[string]map[string]int64{
+			source: {
+				db: {tbls[0]: 0, tbls[1]: 0},
+			},
+		}
 	)
 
 	// the initial status is synced.
@@ -315,34 +363,42 @@ func (t *testLock) TestLockTrySyncIndex(c *C) {
 
 	// try sync for one table, `DROP INDEX` returned directly (to make schema become more compatible).
 	// `DROP INDEX` is handled like `ADD COLUMN`.
-	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
+	c.Assert(l.Versions, DeepEquals, vers)
 	synced, remain := l.IsSynced()
 	c.Assert(synced, Equals, l.synced)
 	c.Assert(synced, IsFalse)
 	c.Assert(remain, Equals, 1)
 
 	// try sync for another table, also got `DROP INDEX` now.
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts)
+	vers[source][db][tbls[1]]++
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
+	c.Assert(l.Versions, DeepEquals, vers)
 	t.checkLockSynced(c, l)
 
 	// try sync for one table, `ADD INDEX` not returned directly (to keep the schema more compatible).
 	// `ADD INDEX` is handled like `DROP COLUMN`.
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs2, ti2, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs2, ti2, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{}) // no DDLs returned
+	c.Assert(l.Versions, DeepEquals, vers)
 	synced, remain = l.IsSynced()
 	c.Assert(synced, Equals, l.synced)
 	c.Assert(synced, IsFalse)
 	c.Assert(remain, Equals, 1)
 
 	// try sync for another table, got `ADD INDEX` now.
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts)
+	vers[source][db][tbls[1]]++
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
+	c.Assert(l.Versions, DeepEquals, vers)
 	t.checkLockSynced(c, l)
 }
 
@@ -372,6 +428,12 @@ func (t *testLock) TestLockTrySyncNullNotNull(c *C) {
 		}
 
 		l = NewLock(ID, task, downSchema, downTable, ti0, tts)
+
+		vers = map[string]map[string]map[string]int64{
+			source: {
+				db: {tbls[0]: 0, tbls[1]: 0},
+			},
+		}
 	)
 
 	// the initial status is synced.
@@ -380,24 +442,32 @@ func (t *testLock) TestLockTrySyncNullNotNull(c *C) {
 
 	for i := 0; i < 2; i++ { // two round
 		// try sync for one table, from `NULL` to `NOT NULL`, no DDLs returned.
-		DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts)
+		vers[source][db][tbls[0]]++
+		DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 		c.Assert(err, IsNil)
 		c.Assert(DDLs, DeepEquals, []string{})
+		c.Assert(l.Versions, DeepEquals, vers)
 
 		// try sync for another table, DDLs returned.
-		DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts)
+		vers[source][db][tbls[1]]++
+		DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts, vers[source][db][tbls[1]])
 		c.Assert(err, IsNil)
 		c.Assert(DDLs, DeepEquals, DDLs1)
+		c.Assert(l.Versions, DeepEquals, vers)
 
 		// try sync for one table, from `NOT NULL` to `NULL`, DDLs returned.
-		DDLs, err = l.TrySync(source, db, tbls[0], DDLs2, ti2, tts)
+		vers[source][db][tbls[0]]++
+		DDLs, err = l.TrySync(source, db, tbls[0], DDLs2, ti2, tts, vers[source][db][tbls[0]])
 		c.Assert(err, IsNil)
 		c.Assert(DDLs, DeepEquals, DDLs2)
+		c.Assert(l.Versions, DeepEquals, vers)
 
 		// try sync for another table, from `NOT NULL` to `NULL`, DDLs, returned.
-		DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts)
+		vers[source][db][tbls[1]]++
+		DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
 		c.Assert(err, IsNil)
 		c.Assert(DDLs, DeepEquals, DDLs2)
+		c.Assert(l.Versions, DeepEquals, vers)
 	}
 }
 
@@ -425,6 +495,12 @@ func (t *testLock) TestLockTrySyncIntBigint(c *C) {
 		}
 
 		l = NewLock(ID, task, downSchema, downTable, ti0, tts)
+
+		vers = map[string]map[string]map[string]int64{
+			source: {
+				db: {tbls[0]: 0, tbls[1]: 0},
+			},
+		}
 	)
 
 	// the initial status is synced.
@@ -432,14 +508,18 @@ func (t *testLock) TestLockTrySyncIntBigint(c *C) {
 	t.checkLockNoDone(c, l)
 
 	// try sync for one table, from `INT` to `BIGINT`, DDLs returned.
-	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
+	c.Assert(l.Versions, DeepEquals, vers)
 
 	// try sync for another table, DDLs returned.
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts)
+	vers[source][db][tbls[1]]++
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
+	c.Assert(l.Versions, DeepEquals, vers)
 }
 
 func (t *testLock) TestLockTrySyncNoDiff(c *C) {
@@ -466,6 +546,12 @@ func (t *testLock) TestLockTrySyncNoDiff(c *C) {
 		}
 
 		l = NewLock(ID, task, downSchema, downTable, ti0, tts)
+
+		vers = map[string]map[string]map[string]int64{
+			source: {
+				db: {tbls[0]: 0, tbls[1]: 0},
+			},
+		}
 	)
 
 	// the initial status is synced.
@@ -473,9 +559,11 @@ func (t *testLock) TestLockTrySyncNoDiff(c *C) {
 	t.checkLockNoDone(c, l)
 
 	// try sync for one table.
-	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
+	c.Assert(l.Versions, DeepEquals, vers)
 }
 
 func (t *testLock) TestLockTrySyncNewTable(c *C) {
@@ -500,6 +588,14 @@ func (t *testLock) TestLockTrySyncNewTable(c *C) {
 		tables = map[string]map[string]struct{}{db1: {tbl1: struct{}{}}}
 		tts    = []TargetTable{newTargetTable(task, source1, downSchema, downTable, tables)}
 		l      = NewLock(ID, task, downSchema, downTable, ti0, tts)
+		vers   = map[string]map[string]map[string]int64{
+			source1: {
+				db1: {tbl1: 0},
+			},
+			source2: {
+				db2: {tbl2: 0},
+			},
+		}
 	)
 
 	// only one table exists before TrySync.
@@ -507,9 +603,11 @@ func (t *testLock) TestLockTrySyncNewTable(c *C) {
 	t.checkLockNoDone(c, l)
 
 	// TrySync for a new table as the caller.
-	DDLs, err := l.TrySync(source2, db2, tbl2, DDLs1, ti1, tts)
+	vers[source2][db2][tbl2]++
+	DDLs, err := l.TrySync(source2, db2, tbl2, DDLs1, ti1, tts, vers[source2][db2][tbl2])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
+	c.Assert(l.Versions, DeepEquals, vers)
 
 	ready := l.Ready()
 	c.Assert(ready, HasLen, 2)
@@ -526,9 +624,14 @@ func (t *testLock) TestLockTrySyncNewTable(c *C) {
 		newTargetTable(task, source1, downSchema, downTable, map[string]map[string]struct{}{db1: {tbl2: struct{}{}}}),
 		newTargetTable(task, source2, downTable, downTable, map[string]map[string]struct{}{db2: {tbl1: struct{}{}}}),
 	)
-	DDLs, err = l.TrySync(source1, db1, tbl1, DDLs1, ti1, tts)
+	vers[source1][db1][tbl2] = 0
+	vers[source2][db2][tbl1] = 0
+
+	vers[source1][db1][tbl1]++
+	DDLs, err = l.TrySync(source1, db1, tbl1, DDLs1, ti1, tts, vers[source1][db1][tbl1])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
+	c.Assert(l.Versions, DeepEquals, vers)
 
 	ready = l.Ready()
 	c.Assert(ready, HasLen, 2)
@@ -578,6 +681,12 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 		tables = map[string]map[string]struct{}{db: {tbls[0]: struct{}{}, tbls[1]: struct{}{}}}
 		tts    = []TargetTable{newTargetTable(task, source, downSchema, downTable, tables)}
 		l      = NewLock(ID, task, downSchema, downTable, ti0, tts)
+
+		vers = map[string]map[string]map[string]int64{
+			source: {
+				db: {tbls[0]: 0, tbls[1]: 0},
+			},
+		}
 	)
 
 	// the initial status is synced.
@@ -586,9 +695,11 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 
 	// CASE: revert for single DDL.
 	// TrySync for one table.
-	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready := l.Ready()
 	c.Assert(ready[source][db][tbls[0]], IsTrue)
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
@@ -600,17 +711,21 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	c.Assert(cmp, Equals, -1)
 
 	// revert for the table, become synced again.
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs2, ti2, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs2, ti2, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
+	c.Assert(l.Versions, DeepEquals, vers)
 	t.checkLockSynced(c, l)
 	t.checkLockNoDone(c, l)
 
 	// CASE: revert for multiple DDLs.
 	// TrySync for one table.
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs3, ti3, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs3, ti3, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs3)
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[0]], IsTrue)
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
@@ -622,9 +737,11 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	c.Assert(cmp, Equals, -1)
 
 	// revert part of the DDLs.
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs4, ti4, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs4, ti4, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs4)
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
 	cmp, err = l.tables[source][db][tbls[0]].Compare(l.Joined())
@@ -635,17 +752,21 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	c.Assert(cmp, Equals, -1)
 
 	// revert the reset part of the DDLs.
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs5, ti5, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs5, ti5, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs5)
+	c.Assert(l.Versions, DeepEquals, vers)
 	t.checkLockSynced(c, l)
 	t.checkLockNoDone(c, l)
 
 	// CASE: revert part of multiple DDLs.
 	// TrySync for one table.
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs6, ti6, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs6, ti6, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs6)
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
 	cmp, err = l.tables[source][db][tbls[0]].Compare(l.Joined())
@@ -656,9 +777,11 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	c.Assert(cmp, Equals, -1)
 
 	// revert part of the DDLs.
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs7, ti7, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs7, ti7, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs7)
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
 	cmp, err = l.tables[source][db][tbls[0]].Compare(l.Joined())
@@ -669,9 +792,11 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	c.Assert(cmp, Equals, -1)
 
 	// TrySync for another table.
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs8, ti8, tts)
+	vers[source][db][tbls[1]]++
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs8, ti8, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs8)
+	c.Assert(l.Versions, DeepEquals, vers)
 	t.checkLockSynced(c, l)
 	t.checkLockNoDone(c, l)
 }
@@ -701,6 +826,12 @@ func (t *testLock) TestLockTrySyncConflictNonIntrusive(c *C) {
 		tables = map[string]map[string]struct{}{db: {tbls[0]: struct{}{}, tbls[1]: struct{}{}}}
 		tts    = []TargetTable{newTargetTable(task, source, downSchema, downTable, tables)}
 		l      = NewLock(ID, task, downSchema, downTable, ti0, tts)
+
+		vers = map[string]map[string]map[string]int64{
+			source: {
+				db: {tbls[0]: 0, tbls[1]: 0},
+			},
+		}
 	)
 
 	// the initial status is synced.
@@ -708,9 +839,11 @@ func (t *testLock) TestLockTrySyncConflictNonIntrusive(c *C) {
 	t.checkLockNoDone(c, l)
 
 	// TrySync for the first table, construct the joined schema.
-	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready := l.Ready()
 	c.Assert(ready[source][db][tbls[0]], IsTrue)
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
@@ -722,9 +855,11 @@ func (t *testLock) TestLockTrySyncConflictNonIntrusive(c *C) {
 	c.Assert(cmp, Equals, -1)
 
 	// TrySync for the second table with another schema (add two columns, one of them will cause conflict).
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts)
+	vers[source][db][tbls[1]]++
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
+	c.Assert(l.Versions, DeepEquals, vers)
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
 	c.Assert(err, ErrorMatches, ".*at tuple index.*")
 	c.Assert(cmp, Equals, 0)
@@ -732,9 +867,11 @@ func (t *testLock) TestLockTrySyncConflictNonIntrusive(c *C) {
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
 
 	// TrySync for the first table to resolve the conflict.
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs3, ti3, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs3, ti3, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs3)
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[0]], IsFalse)
 	c.Assert(ready[source][db][tbls[1]], IsTrue) // the second table become synced now.
@@ -746,9 +883,11 @@ func (t *testLock) TestLockTrySyncConflictNonIntrusive(c *C) {
 	c.Assert(cmp, Equals, 0)
 
 	// TrySync for the first table.
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs4, ti4, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs4, ti4, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs4)
+	c.Assert(l.Versions, DeepEquals, vers)
 	t.checkLockSynced(c, l)
 	t.checkLockNoDone(c, l)
 }
@@ -788,6 +927,12 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 		tables = map[string]map[string]struct{}{db: {tbls[0]: struct{}{}, tbls[1]: struct{}{}}}
 		tts    = []TargetTable{newTargetTable(task, source, downSchema, downTable, tables)}
 		l      = NewLock(ID, task, downSchema, downTable, ti0, tts)
+
+		vers = map[string]map[string]map[string]int64{
+			source: {
+				db: {tbls[0]: 0, tbls[1]: 0},
+			},
+		}
 	)
 
 	// the initial status is synced.
@@ -796,9 +941,11 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 
 	// CASE: conflict happen, revert all changes to resolve the conflict.
 	// TrySync for the first table, construct the joined schema.
-	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready := l.Ready()
 	c.Assert(ready[source][db][tbls[0]], IsTrue)
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
@@ -810,9 +957,11 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	c.Assert(cmp, Equals, -1)
 
 	// TrySync for the second table with another schema (add two columns, one of them will cause conflict).
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts)
+	vers[source][db][tbls[1]]++
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
+	c.Assert(l.Versions, DeepEquals, vers)
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
 	c.Assert(err, ErrorMatches, ".*at tuple index.*")
 	c.Assert(cmp, Equals, 0)
@@ -820,17 +969,21 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
 
 	// TrySync again.
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts)
+	vers[source][db][tbls[1]]++
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
+	c.Assert(l.Versions, DeepEquals, vers)
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
 	c.Assert(err, ErrorMatches, ".*at tuple index.*")
 	c.Assert(cmp, Equals, 0)
 
 	// TrySync for the second table to drop the non-conflict column, the conflict should still exist.
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs3, ti3, tts)
+	vers[source][db][tbls[1]]++
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs3, ti3, tts, vers[source][db][tbls[1]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
+	c.Assert(l.Versions, DeepEquals, vers)
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
 	c.Assert(err, ErrorMatches, ".*at tuple index.*")
 	c.Assert(cmp, Equals, 0)
@@ -838,9 +991,11 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
 
 	// TrySync for the second table to drop the conflict column, the conflict should be resolved.
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs4, ti4, tts)
+	vers[source][db][tbls[1]]++
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs4, ti4, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
+	c.Assert(l.Versions, DeepEquals, vers)
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
 	c.Assert(err, IsNil)
 	c.Assert(cmp, Equals, -1)
@@ -848,9 +1003,11 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
 
 	// TrySync for the second table as we did for the first table, the lock should be synced.
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts)
+	vers[source][db][tbls[1]]++
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs)
+	c.Assert(l.Versions, DeepEquals, vers)
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
 	c.Assert(err, IsNil)
 	c.Assert(cmp, Equals, 0)
@@ -859,9 +1016,11 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 
 	// CASE: conflict happen, revert part of changes to resolve the conflict.
 	// TrySync for the first table, construct the joined schema.
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs5, ti5, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs5, ti5, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs5)
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[0]], IsTrue)
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
@@ -873,20 +1032,24 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	c.Assert(cmp, Equals, -1)
 
 	// TrySync for the second table with another schema (add two columns, one of them will cause conflict).
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs6, ti6, tts)
+	vers[source][db][tbls[1]]++
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs6, ti6, tts, vers[source][db][tbls[1]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
 	c.Assert(err, ErrorMatches, ".*at tuple index.*")
 	c.Assert(cmp, Equals, 0)
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
 
 	// TrySync for the second table to drop the conflict column, the conflict should be resolved.
 	// but both of tables are not synced now.
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs7, ti7, tts)
+	vers[source][db][tbls[1]]++
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs7, ti7, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs7) // special case: these DDLs should not be replicated to the downstream.
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[0]], IsFalse)
 	c.Assert(ready[source][db][tbls[1]], IsFalse)
@@ -898,14 +1061,16 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	c.Assert(cmp, Equals, -1)
 
 	// TrySync for the first table to become synced.
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs8_1, ti8, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs8_1, ti8, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs8_1)
 	ready = l.Ready()
 	c.Assert(ready[source][db][tbls[0]], IsTrue)
 
 	// TrySync for the second table to become synced.
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs8_2, ti8, tts)
+	vers[source][db][tbls[1]]++
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs8_2, ti8, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs8_2)
 	ready = l.Ready()
@@ -938,6 +1103,12 @@ func (t *testLock) TestTryRemoveTable(c *C) {
 		tables = map[string]map[string]struct{}{db: {tbl1: struct{}{}, tbl2: struct{}{}}}
 		tts    = []TargetTable{newTargetTable(task, source, downSchema, downTable, tables)}
 		l      = NewLock(ID, task, downSchema, downTable, ti0, tts)
+
+		vers = map[string]map[string]map[string]int64{
+			source: {
+				db: {tbl1: 0, tbl2: 0},
+			},
+		}
 	)
 
 	// only one table exists before TrySync.
@@ -946,9 +1117,11 @@ func (t *testLock) TestTryRemoveTable(c *C) {
 
 	// CASE: remove a table as normal.
 	// TrySync for the first table.
-	DDLs, err := l.TrySync(source, db, tbl1, DDLs1, ti1, tts)
+	vers[source][db][tbl1]++
+	DDLs, err := l.TrySync(source, db, tbl1, DDLs1, ti1, tts, vers[source][db][tbl1])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready := l.Ready()
 	c.Assert(ready, HasLen, 1)
 	c.Assert(ready[source], HasLen, 1)
@@ -958,17 +1131,21 @@ func (t *testLock) TestTryRemoveTable(c *C) {
 
 	// TryRemoveTable for the second table.
 	c.Assert(l.TryRemoveTable(source, db, tbl2), IsTrue)
+	delete(vers[source][db], tbl2)
 	ready = l.Ready()
 	c.Assert(ready, HasLen, 1)
 	c.Assert(ready[source], HasLen, 1)
 	c.Assert(ready[source][db], HasLen, 1)
 	c.Assert(ready[source][db][tbl1], IsTrue)
+	c.Assert(l.Versions, DeepEquals, vers)
 
 	// CASE: remove a table will not rebuild joined schema now.
 	// TrySync to add the second back.
-	DDLs, err = l.TrySync(source, db, tbl2, DDLs2, ti2, tts)
+	vers[source][db][tbl2] = 1
+	DDLs, err = l.TrySync(source, db, tbl2, DDLs2, ti2, tts, vers[source][db][tbl1])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
+	c.Assert(l.Versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready, HasLen, 1)
 	c.Assert(ready[source], HasLen, 1)
@@ -978,11 +1155,13 @@ func (t *testLock) TestTryRemoveTable(c *C) {
 
 	// TryRemoveTable for the second table.
 	c.Assert(l.TryRemoveTable(source, db, tbl2), IsTrue)
+	delete(vers[source][db], tbl2)
 	ready = l.Ready()
 	c.Assert(ready, HasLen, 1)
 	c.Assert(ready[source], HasLen, 1)
 	c.Assert(ready[source][db], HasLen, 1)
 	c.Assert(ready[source][db][tbl1], IsFalse) // the joined schema is not rebuild.
+	c.Assert(l.Versions, DeepEquals, vers)
 
 	// CASE: try to remove for not-exists table.
 	c.Assert(l.TryRemoveTable(source, db, "not-exist"), IsFalse)
@@ -1013,6 +1192,12 @@ func (t *testLock) TestLockTryMarkDone(c *C) {
 		tables = map[string]map[string]struct{}{db: {tbls[0]: struct{}{}, tbls[1]: struct{}{}}}
 		tts    = []TargetTable{newTargetTable(task, source, downSchema, downTable, tables)}
 		l      = NewLock(ID, task, downSchema, downTable, ti0, tts)
+
+		vers = map[string]map[string]map[string]int64{
+			source: {
+				db: {tbls[0]: 0, tbls[1]: 0},
+			},
+		}
 	)
 
 	// the initial status is synced but not resolved.
@@ -1021,9 +1206,11 @@ func (t *testLock) TestLockTryMarkDone(c *C) {
 	c.Assert(l.IsResolved(), IsFalse)
 
 	// TrySync for the first table, no table has done the DDLs operation.
-	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
+	c.Assert(l.Versions, DeepEquals, vers)
 	t.checkLockNoDone(c, l)
 	c.Assert(l.IsResolved(), IsFalse)
 
@@ -1034,9 +1221,11 @@ func (t *testLock) TestLockTryMarkDone(c *C) {
 	c.Assert(l.IsResolved(), IsFalse)
 
 	// TrySync for the second table, the joined schema become larger.
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts)
+	vers[source][db][tbls[1]]++
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
+	c.Assert(l.Versions, DeepEquals, vers)
 
 	// the first table is still keep `done` (for the previous DDLs operation)
 	c.Assert(l.IsDone(source, db, tbls[0]), IsTrue)
@@ -1051,9 +1240,11 @@ func (t *testLock) TestLockTryMarkDone(c *C) {
 	c.Assert(l.IsResolved(), IsFalse)
 
 	// TrySync for the first table, all tables become synced.
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs3, ti3, tts)
+	vers[source][db][tbls[0]]++
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs3, ti3, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs3)
+	c.Assert(l.Versions, DeepEquals, vers)
 
 	// the first table become not-done, and the lock is un-resolved.
 	c.Assert(l.IsDone(source, db, tbls[0]), IsFalse)
@@ -1080,11 +1271,11 @@ func (t *testLock) TestLockTryMarkDone(c *C) {
 }
 
 func (t *testLock) trySyncForAllTablesLarger(c *C, l *Lock,
-	DDLs []string, ti *model.TableInfo, tts []TargetTable) {
+	DDLs []string, ti *model.TableInfo, tts []TargetTable, vers map[string]map[string]map[string]int64) {
 	for source, schemaTables := range l.Ready() {
 		for schema, tables := range schemaTables {
 			for table := range tables {
-				DDLs2, err := l.TrySync(source, schema, table, DDLs, ti, tts)
+				DDLs2, err := l.TrySync(source, schema, table, DDLs, ti, tts, vers[source][schema][table])
 				c.Assert(err, IsNil)
 				c.Assert(DDLs2, DeepEquals, DDLs)
 			}

--- a/syncer/shardddl/optimist_test.go
+++ b/syncer/shardddl/optimist_test.go
@@ -144,7 +144,9 @@ func (t *testOptimist) TestOptimist(c *C) {
 	c.Assert(ifm[task], HasLen, 1)
 	c.Assert(ifm[task][source], HasLen, 1)
 	c.Assert(ifm[task][source][info1.UpSchema], HasLen, 1)
-	c.Assert(ifm[task][source][info1.UpSchema][info1.UpTable], DeepEquals, info1)
+	info1WithVer := info1
+	info1WithVer.Version = 1
+	c.Assert(ifm[task][source][info1.UpSchema][info1.UpTable], DeepEquals, info1WithVer)
 	opc := op1c
 	opc.Done = true
 	opm, _, err := optimism.GetAllOperations(etcdTestCli)
@@ -165,7 +167,9 @@ func (t *testOptimist) TestOptimist(c *C) {
 	c.Assert(rev3, Greater, rev2)
 	ifm, _, err = optimism.GetAllInfo(etcdTestCli)
 	c.Assert(err, IsNil)
-	c.Assert(ifm[task][source][infoCreate.UpSchema][infoCreate.UpTable], DeepEquals, infoCreate)
+	infoCreateWithVer := infoCreate
+	infoCreateWithVer.Version = 1
+	c.Assert(ifm[task][source][infoCreate.UpSchema][infoCreate.UpTable], DeepEquals, infoCreateWithVer)
 	c.Assert(o.tables.Tables[infoCreate.DownSchema][infoCreate.DownTable][infoCreate.UpSchema], HasKey, infoCreate.UpTable)
 
 	// handle `DROP TABLE`.


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- second ddl's lock may be deleted when first ddl resolved.
- new info putted to etcd may be deleted when previous ddl resolved

### What is changed and how it works?
- add lock in handleInfo and handleOperation to avoid concurrency conflict
- record the version of info, only delete info if all version of info are greater or equal then that in etcd.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test