### PR TITLE
syncer: do not ignore fake rotate event to the next file

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -1499,7 +1499,7 @@ type eventContext struct {
 func (s *Syncer) handleRotateEvent(ev *replication.RotateEvent, ec eventContext) error {
 	if ec.header.Timestamp == 0 || ec.header.LogPos == 0 { // fake rotate event
 		if string(ev.NextLogName) <= ec.lastLocation.Position.Name {
-			return nil // not rotate to the next binlgo file, ignore it
+			return nil // not rotate to the next binlog file, ignore it
 		}
 	}
 

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -1497,9 +1497,10 @@ type eventContext struct {
 // TODO: Further split into smaller functions and group common arguments into
 // a context struct.
 func (s *Syncer) handleRotateEvent(ev *replication.RotateEvent, ec eventContext) error {
-	if ec.header.Timestamp == 0 || ec.header.LogPos == 0 {
-		// it is fake rotate event, ignore it
-		return nil
+	if ec.header.Timestamp == 0 || ec.header.LogPos == 0 { // fake rotate event
+		if string(ev.NextLogName) <= ec.lastLocation.Position.Name {
+			return nil // not rotate to the next binlgo file, ignore it
+		}
 	}
 
 	*ec.currentLocation = binlog.Location{


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix #1038

### What is changed and how it works?

only skip the fake rotate event if it's not to the next binlog file.

NOTE:
- MySQL server will write a RotateEvent before rotate to the next binlog file normally.
- MySQL server will send a _fake_ RotateEvent to the slave before sending other real binlog events.
- MySQL server will write a StopEvent at the end of a binlog file when stoping itself but without RotateEvent
- MySQL server will write from a new binlog file after started itself

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
     - trigger the error reported in #1038 with an older version of DM
     - replace DM-worker with a newer version in this PR
     - observe the task resumed

Code changes

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
