### PR TITLE
loader: don't print ERROR log, clean dump file when all finished (#1027)

### DIFF
--- a/loader/checkpoint.go
+++ b/loader/checkpoint.go
@@ -44,6 +44,9 @@ type CheckPoint interface {
 	// GetAllRestoringFileInfo return all restoring files position
 	GetAllRestoringFileInfo() map[string][]int64
 
+	// IsTableCreated checks if db / table was created. set `table` to "" when check db
+	IsTableCreated(db, table string) bool
+
 	// IsTableFinished query if table has finished
 	IsTableFinished(db, table string) bool
 
@@ -67,6 +70,13 @@ type CheckPoint interface {
 
 	// GenSQL generates sql to update checkpoint to DB
 	GenSQL(filename string, offset int64) string
+
+	// UpdateOffset keeps `cp.restoringFiles` in memory same with checkpoint in DB,
+	// should be called after update checkpoint in DB
+	UpdateOffset(filename string, offset int64)
+
+	// AllFinished returns `true` when all restoring job are finished
+	AllFinished() bool
 }
 
 // RemoteCheckPoint implements CheckPoint by saving status in remote database system, mostly in TiDB.
@@ -80,8 +90,8 @@ type RemoteCheckPoint struct {
 	conn           *DBConn
 	id             string
 	schema         string
-	tableName      string // tableName contains schema name
-	restoringFiles map[string]map[string]FilePosSet
+	tableName      string                           // tableName contains schema name
+	restoringFiles map[string]map[string]FilePosSet // schema -> table -> FilePosSet(filename -> [cur, end])
 	finishedTables map[string]struct{}
 	logCtx         *tcontext.Context
 }
@@ -219,6 +229,19 @@ func (cp *RemoteCheckPoint) GetAllRestoringFileInfo() map[string][]int64 {
 	return results
 }
 
+// IsTableCreated implements CheckPoint.IsTableCreated
+func (cp *RemoteCheckPoint) IsTableCreated(db, table string) bool {
+	tables, ok := cp.restoringFiles[db]
+	if !ok {
+		return false
+	}
+	if table == "" {
+		return true
+	}
+	_, ok = tables[table]
+	return ok
+}
+
 // IsTableFinished implements CheckPoint.IsTableFinished
 func (cp *RemoteCheckPoint) IsTableFinished(db, table string) bool {
 	key := strings.Join([]string{db, table}, ".")
@@ -258,7 +281,7 @@ func (cp *RemoteCheckPoint) CalcProgress(allFiles map[string]Tables2DataFiles) e
 		}
 	}
 
-	cp.logCtx.L().Info("calculate checkpoint finished.", zap.Reflect("finished tables", cp.finishedTables))
+	cp.logCtx.L().Info("calculate checkpoint finished.", zap.Any("finished tables", cp.finishedTables))
 	return nil
 }
 
@@ -270,6 +293,18 @@ func (cp *RemoteCheckPoint) allFilesFinished(files map[string][]int64) bool {
 		}
 		if pos[0] != pos[1] {
 			return false
+		}
+	}
+	return true
+}
+
+// AllFinished implements CheckPoint.AllFinished
+func (cp *RemoteCheckPoint) AllFinished() bool {
+	for _, tables := range cp.restoringFiles {
+		for _, restoringFiles := range tables {
+			if !cp.allFilesFinished(restoringFiles) {
+				return false
+			}
 		}
 	}
 	return true
@@ -304,7 +339,7 @@ func (cp *RemoteCheckPoint) Init(tctx *tcontext.Context, filename string, endPos
 	cp.connMutex.Unlock()
 	if err != nil {
 		if isErrDupEntry(err) {
-			cp.logCtx.L().Info("checkpoint record already exists, skip it.", zap.String("id", cp.id), zap.String("filename", filename))
+			cp.logCtx.L().Error("checkpoint record already exists, skip it.", zap.String("id", cp.id), zap.String("filename", filename))
 			return nil
 		}
 		return terror.WithScope(terror.Annotate(err, "initialize checkpoint"), terror.ScopeDownstream)
@@ -344,6 +379,16 @@ func (cp *RemoteCheckPoint) GenSQL(filename string, offset int64) string {
 	sql := fmt.Sprintf("UPDATE %s SET `offset`=%d WHERE `id` ='%s' AND `filename`='%s';",
 		cp.tableName, offset, cp.id, filename)
 	return sql
+}
+
+// UpdateOffset implements CheckPoint.UpdateOffset
+func (cp *RemoteCheckPoint) UpdateOffset(filename string, offset int64) {
+	fields := strings.Split(filename, ".")
+	if len(fields) != 2 && len(fields) != 3 {
+		cp.logCtx.L().Error("can't get db and table from filename in checkpoint UpdateOffset", zap.String("filename", filename))
+	}
+	db, table := fields[0], fields[1]
+	cp.restoringFiles[db][table][filename][0] = offset
 }
 
 // Clear implements CheckPoint.Clear

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -921,15 +921,11 @@ func (l *Loader) prepareDataFiles(files map[string]struct{}) error {
 			continue
 		}
 
-		idx := strings.Index(file, ".sql")
-		name := file[:idx]
-		fields := strings.Split(name, ".")
-		if len(fields) != 2 && len(fields) != 3 {
-			l.logCtx.L().Warn("invalid db table sql file", zap.String("file", file))
+		db, table, err := getDBAndTableFromFilename(file)
+		if err != nil {
+			l.logCtx.L().Warn("invalid db table sql file", zap.String("file", file), zap.Error(err))
 			continue
 		}
-
-		db, table := fields[0], fields[1]
 		if l.skipSchemaAndTable(&filter.Table{Schema: db, Name: table}) {
 			l.logCtx.L().Warn("ignore data file", zap.String("data file", file))
 			continue
@@ -1286,7 +1282,7 @@ func (l *Loader) cleanDumpFiles() {
 		var lastErr error
 		for f := range files {
 			if strings.HasSuffix(f, ".sql") {
-				lastErr = os.Remove(f)
+				lastErr = os.Remove(filepath.Join(l.cfg.Dir, f))
 			}
 		}
 		if lastErr != nil {

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -49,7 +49,8 @@ import (
 )
 
 const (
-	jobCount = 1000
+	jobCount            = 1000
+	uninitializedOffset = -1
 )
 
 // FilePosSet represents a set in mathematics.
@@ -185,21 +186,8 @@ func (w *Worker) run(ctx context.Context, fileJobQueue chan *fileJob, runFatalCh
 					}
 					return
 				}
+				w.loader.checkPoint.UpdateOffset(job.file, job.offset)
 				w.loader.finishedDataSize.Add(job.offset - job.lastOffset)
-
-				if w.cfg.CleanDumpFile {
-					fileInfos := w.checkPoint.GetRestoringFileInfo(job.schema, job.table)
-					if pos, ok := fileInfos[job.file]; ok {
-						if job.offset == pos[1] {
-							w.tctx.L().Info("try to remove loaded dump file", zap.String("data file", job.file))
-							if err := os.Remove(job.absPath); err != nil {
-								w.tctx.L().Warn("error when remove loaded dump file", zap.String("data file", job.file), zap.Error(err))
-							}
-						}
-					} else {
-						w.tctx.L().Warn("file not recorded in checkpoint", zap.String("data file", job.file))
-					}
-				}
 			}
 		}
 	}
@@ -262,22 +250,28 @@ func (w *Worker) dispatchSQL(ctx context.Context, file string, offset int64, tab
 		cur int64
 	)
 
+	baseFile := filepath.Base(file)
+
 	f, err = os.Open(file)
 	if err != nil {
 		return terror.ErrLoadUnitDispatchSQLFromFile.Delegate(err)
 	}
 	defer f.Close()
 
-	finfo, err := f.Stat()
-	if err != nil {
-		return terror.ErrLoadUnitDispatchSQLFromFile.Delegate(err)
-	}
+	// file was not found in checkpoint
+	if offset == uninitializedOffset {
+		offset = 0
 
-	baseFile := filepath.Base(file)
-	err = w.checkPoint.Init(w.tctx.WithContext(ctx), baseFile, finfo.Size())
-	if err != nil {
-		w.tctx.L().Error("fail to initial checkpoint", zap.String("data file", file), zap.Int64("offset", offset), log.ShortError(err))
-		return err
+		finfo, err2 := f.Stat()
+		if err2 != nil {
+			return terror.ErrLoadUnitDispatchSQLFromFile.Delegate(err2)
+		}
+
+		err2 = w.checkPoint.Init(w.tctx.WithContext(ctx), baseFile, finfo.Size())
+		if err2 != nil {
+			w.tctx.L().Error("fail to initial checkpoint", zap.String("data file", file), zap.Int64("offset", offset), log.ShortError(err2))
+			return err2
+		}
 	}
 
 	cur, err = f.Seek(offset, io.SeekStart)
@@ -647,25 +641,6 @@ func (l *Loader) Restore(ctx context.Context) error {
 
 	if err == nil {
 		l.logCtx.L().Info("all data files have been finished", zap.Duration("cost time", time.Since(begin)))
-		if l.cfg.CleanDumpFile {
-			files := CollectDirFiles(l.cfg.Dir)
-			hasDatafile := false
-			for file := range files {
-				if strings.HasSuffix(file, ".sql") &&
-					!strings.HasSuffix(file, "-schema.sql") &&
-					!strings.HasSuffix(file, "-schema-create.sql") &&
-					!strings.Contains(file, "-schema-view.sql") &&
-					!strings.Contains(file, "-schema-triggers.sql") &&
-					!strings.Contains(file, "-schema-post.sql") {
-					hasDatafile = true
-				}
-			}
-
-			if !hasDatafile {
-				l.logCtx.L().Info("clean dump files after importing all files")
-				l.cleanDumpFiles()
-			}
-		}
 	} else if errors.Cause(err) != context.Canceled {
 		return err
 	}
@@ -693,6 +668,9 @@ func (l *Loader) Close() {
 	err := l.toDB.Close()
 	if err != nil {
 		l.logCtx.L().Error("close downstream DB error", log.ShortError(err))
+	}
+	if l.cfg.CleanDumpFile && l.checkPoint.AllFinished() {
+		l.cleanDumpFiles()
 	}
 	l.checkPoint.Close()
 	l.removeLabelValuesWithTaskInMetrics(l.cfg.Name)
@@ -1034,6 +1012,10 @@ func (l *Loader) prepare() error {
 
 // restoreSchema creates schema
 func (l *Loader) restoreSchema(ctx context.Context, conn *DBConn, sqlFile, schema string) error {
+	if l.checkPoint.IsTableCreated(schema, "") {
+		l.logCtx.L().Info("database already exists in checkpoint, skip creating it", zap.String("schema", schema), zap.String("db schema file", sqlFile))
+		return nil
+	}
 	err := l.restoreStructure(ctx, conn, sqlFile, schema, "")
 	if err != nil {
 		if isErrDBExists(err) {
@@ -1047,6 +1029,10 @@ func (l *Loader) restoreSchema(ctx context.Context, conn *DBConn, sqlFile, schem
 
 // restoreTable creates table
 func (l *Loader) restoreTable(ctx context.Context, conn *DBConn, sqlFile, schema, table string) error {
+	if l.checkPoint.IsTableCreated(schema, table) {
+		l.logCtx.L().Info("table already exists in checkpoint, skip creating it", zap.String("schema", schema), zap.String("table", table), zap.String("db schema file", sqlFile))
+		return nil
+	}
 	err := l.restoreStructure(ctx, conn, sqlFile, schema, table)
 	if err != nil {
 		if isErrTableExists(err) {
@@ -1107,7 +1093,6 @@ func (l *Loader) restoreStructure(ctx context.Context, conn *DBConn, sqlFile str
 				return terror.WithScope(err, terror.ScopeDownstream)
 			}
 		}
-
 	}
 
 	return nil
@@ -1225,7 +1210,7 @@ func (l *Loader) restoreData(ctx context.Context) error {
 
 				l.logCtx.L().Debug("dispatch data file", zap.String("schema", db), zap.String("table", table), zap.String("data file", file))
 
-				var offset int64
+				offset := int64(uninitializedOffset)
 				posSet, ok := restoringFiles[file]
 				if ok {
 					offset = posSet[0]
@@ -1289,24 +1274,23 @@ func (l *Loader) getMydumpMetadata() error {
 
 // cleanDumpFiles is called when finish restoring data, to clean useless files
 func (l *Loader) cleanDumpFiles() {
+	l.logCtx.L().Info("clean dump files")
 	if l.cfg.Mode == config.ModeFull {
 		// in full-mode all files won't be need in the future
 		if err := os.RemoveAll(l.cfg.Dir); err != nil {
 			l.logCtx.L().Warn("error when remove loaded dump folder", zap.String("data folder", l.cfg.Dir), zap.Error(err))
 		}
 	} else {
-		// leave metadata file, only delete structure files
-		for db, tables := range l.db2Tables {
-			dbFile := fmt.Sprintf("%s/%s-schema-create.sql", l.cfg.Dir, db)
-			if err := os.Remove(dbFile); err != nil {
-				l.logCtx.L().Warn("error when remove loaded dump file", zap.String("data file", dbFile), zap.Error(err))
+		// leave metadata file, only delete sql files
+		files := CollectDirFiles(l.cfg.Dir)
+		var lastErr error
+		for f := range files {
+			if strings.HasSuffix(f, ".sql") {
+				lastErr = os.Remove(f)
 			}
-			for table := range tables {
-				tableFile := fmt.Sprintf("%s/%s.%s-schema.sql", l.cfg.Dir, db, table)
-				if err := os.Remove(tableFile); err != nil {
-					l.logCtx.L().Warn("error when remove loaded dump file", zap.String("data file", tableFile), zap.Error(err))
-				}
-			}
+		}
+		if lastErr != nil {
+			l.logCtx.L().Warn("show last error when remove loaded dump sql files", zap.String("data folder", l.cfg.Dir), zap.Error(lastErr))
 		}
 	}
 }

--- a/loader/util.go
+++ b/loader/util.go
@@ -91,3 +91,16 @@ func generateSchemaCreateFile(dir string, schema string) error {
 func escapeName(name string) string {
 	return strings.Replace(name, "`", "``", -1)
 }
+
+// input filename is like `all_mode.t1.0.sql` or `all_mode.t1.sql`
+func getDBAndTableFromFilename(filename string) (string, string, error) {
+	idx := strings.Index(filename, ".sql")
+	if idx < 0 {
+		return "", "", fmt.Errorf("%s doesn't have a `.sql` suffix", filename)
+	}
+	fields := strings.Split(filename[:idx], ".")
+	if len(fields) != 2 && len(fields) != 3 {
+		return "", "", fmt.Errorf("%s doesn't have correct `.` seperator", filename)
+	}
+	return fields[0], fields[1], nil
+}

--- a/tests/all_mode/run.sh
+++ b/tests/all_mode/run.sh
@@ -148,8 +148,8 @@ function run() {
     check_contains "all_mode"
 
     echo "check dump files have been cleaned"
-    ls $WORK_DIR/worker1/dumped_data.test && exit 1 || echo "worker1 auto removed dump files"
-    ls $WORK_DIR/worker2/dumped_data.test && exit 1 || echo "worker2 auto removed dump files"
+    ls $WORK_DIR/worker1/dumped_data.$ILLEGAL_CHAR_NAME && exit 1 || echo "worker1 auto removed dump files"
+    ls $WORK_DIR/worker2/dumped_data.$ILLEGAL_CHAR_NAME && exit 1 || echo "worker2 auto removed dump files"
 
     echo "check no password in log"
     check_log_not_contains $WORK_DIR/master/log/dm-master.log "/Q7B9DizNLLTTfiZHv9WoEAKamfpIUs="

--- a/tests/import_goroutine_leak/run.sh
+++ b/tests/import_goroutine_leak/run.sh
@@ -26,7 +26,6 @@ function run() {
     run_sql_file $WORK_DIR/db1.prepare.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
     run_sql_file $WORK_DIR/db2.prepare.sql $MYSQL_HOST2 $MYSQL_PORT2 $MYSQL_PASSWORD2
 
-
     echo "dm-worker panic, doJob of import unit workers don't exit"
     # check doJobs of import unit worker exit
     inject_points=("github.com/pingcap/dm/loader/dispatchError=return(1)"
@@ -70,6 +69,7 @@ function run() {
     inject_points=("github.com/pingcap/dm/loader/dontWaitWorkerExit=return(1)"
                    "github.com/pingcap/dm/loader/LoadDataSlowDown=sleep(1000)"
                    "github.com/pingcap/dm/loader/executeSQLError=return(1)"
+                   "github.com/pingcap/dm/loader/dispatchError=return(1)"
                    )
     export GO_FAILPOINTS="$(join_string \; ${inject_points[@]})"
     run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml


### PR DESCRIPTION
manually cherry-pick #1027 and #1042

---

<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #1006

### What is changed and how it works?
- **keep checkpoint in memory updated with DB**
- don't execute structure SQL when found db/table in checkpoint
- don't repeatly initiate checkpoint record
- only clean dump SQL files when all finished, to keep progress when resuming

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manually check log contains "skip creating it"

Code changes

 - Has exported function/method change
 - Has interface methods change

Side effects

Related changes

 - Need to cherry-pick to the release branch
