### PR TITLE
syncer: remove KEY index in DML concurrency keys

### DIFF
--- a/syncer/dml.go
+++ b/syncer/dml.go
@@ -394,10 +394,15 @@ func genMultipleKeys(ti *model.TableInfo, value []interface{}, table string) []s
 	}
 
 	for _, indexCols := range ti.Indices {
+		// PK also has a true Unique
+		if !indexCols.Unique {
+			continue
+		}
 		cols, vals := getColumnData(ti.Columns, indexCols, value)
 		key := genKeyList(table, cols, vals)
 		if len(key) > 0 { // ignore `null` value.
 			multipleKeys = append(multipleKeys, key)
+			// TODO: break here? one unique index is enough?
 		} else {
 			log.L().Debug("ignore empty key", zap.String("table", table))
 		}

--- a/syncer/dml_test.go
+++ b/syncer/dml_test.go
@@ -150,13 +150,13 @@ func (s *testSyncerSuite) TestGenMultipleKeys(c *C) {
 			// one ordinary key
 			schema: `create table t4(a int, b double, key(b))`,
 			values: []interface{}{60, 70.5},
-			keys:   []string{"70.5table"},
+			keys:   []string{"table"},
 		},
 		{
 			// multiple keys
 			schema: `create table t5(a int, b text, c int, key(a), key(b(3)))`,
 			values: []interface{}{13, "abcdef", 15},
-			keys:   []string{"13table", "abcdeftable"},
+			keys:   []string{"table"},
 		},
 		{
 			// multiple keys with primary key
@@ -180,7 +180,7 @@ func (s *testSyncerSuite) TestGenMultipleKeys(c *C) {
 			// ordinary key of multiple columns
 			schema: `create table t75(a int, b int, c int, key(a, b), key(c, b))`,
 			values: []interface{}{48, 58, 68},
-			keys:   []string{"4858table", "6858table"},
+			keys:   []string{"table"},
 		},
 		{
 			// so many keys
@@ -194,7 +194,7 @@ func (s *testSyncerSuite) TestGenMultipleKeys(c *C) {
 				)
 			`,
 			values: []interface{}{27, 37, 47},
-			keys:   []string{"2737table", "3747table", "273747table", "4727table"},
+			keys:   []string{"2737table", "3747table", "4727table"},
 		},
 		{
 			// `null` for unique key


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists--> 
KEY index will be added in DML concurrency keys, which will slow the sync.

### What is changed and how it works?
remove it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects


Related changes

 - Need to cherry-pick to the release branch
