### PR TITLE
utils: pretty print []byte

### DIFF
--- a/pkg/utils/string_test.go
+++ b/pkg/utils/string_test.go
@@ -58,6 +58,9 @@ func (t *testStringSuite) TestTruncateInterface(c *C) {
 		iis [][]interface{}
 	)
 	iis = append(iis, []interface{}{i1, i2}, []interface{}{i3, i4})
+	bytes0 := []byte{97, 98, 99}
+	bytes1 := []interface{}{i1, bytes0}
+	bytes2 := [][]interface{}{bytes1}
 
 	cases := []struct {
 		v      interface{}
@@ -80,6 +83,9 @@ func (t *testStringSuite) TestTruncateInterface(c *C) {
 		{v: iis, n: 3, expect: "[[{..."},
 		{v: iis, n: 9, expect: "[[{b:true..."},
 		{v: iis, n: 99, expect: "[[{b:true i:123 s:abc} {b:true i:456 s:def}] [{b:false i:321 s:cba} {b:false i:654 s:fed}]]"},
+		{v: bytes0, n: -1, expect: "abc"},
+		{v: bytes1, n: -1, expect: "[{b:true i:123 s:abc} abc]"},
+		{v: bytes2, n: -1, expect: "[[{b:true i:123 s:abc} abc]]"},
 	}
 
 	for _, cs := range cases {


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
DM didn't print `[]byte` well, for example
```
[argument="[mysql-replica-01 all_mode t1 mysql-bin.000001 5016 09bec856-ba95-11ea-850a-58f2b4af5188:1-8  0  [123 34 105 100 34 58 53 50 44 34 110 97 109 101 34 58 123 34 79 34 58 34 116 49 34 44 34 76 34 58 34 116 49 34 125 44 34 99 104 97 114 115 101 116 34 58 34 108 97 116 105 110 49 34 44 34 99 111 108 108 97 116 101 34 58 34 108 97 116 105 110 49 95 98 105 110 34 44 34 99 111 108 115 34 58 91 123 34 105 100 34 58 49 44 34 110 97 109 101 34 58 123 34 79 34 58 34 105 100 34 44 34 76 34 58 34 105 100 34 125 44 34 111 102 102 115 101 116 34 58 48 44 34 111 114 105 103 105 110 95 100 101 102 97 117 108 116 34 58 110 117 108 108 44 34 111 114 105 103 105 110 95 100 101 102 97 117 108 116 95 98 105 116 34 58 110 117 108 108 44 34 100 101 102 97 117 108 116 34 58 110 117 108 108 44 34 100 101 102 97 117 108 116 95 98 105 116 34 58 110 117 108 108 44 34 100 101 102 97 117 108 116 95 105 115 95 101 120 112 114 34 58 102 97 108 115 101 44 34 103 101 110 101 114 97 116 101 100 95 101 120 112 114 95 115 116 114 105 110 103 34 58..."]
```

### What is changed and how it works?
use `%s` to print `[]byte`, and find `[]byte` in up to 2 level nested `interface{}` slice.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
