### PR TITLE
task_checker: ignore more unrecoverable error

### DIFF
--- a/pkg/retry/errors.go
+++ b/pkg/retry/errors.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/errors"
 )
 
+// some error reference: https://docs.pingcap.com/tidb/stable/tidb-limitations#limitations-on-a-single-table
 var (
 	// UnsupportedDDLMsgs list the error messages of some unsupported DDL in TiDB
 	UnsupportedDDLMsgs = []string{
@@ -32,6 +33,9 @@ var (
 		"Unsupported collation",
 		"Invalid default value for",
 		"Unsupported drop primary key",
+		"Error 1059: Identifier name", // Limitations on identifier length
+		"Error 1117: Too many columns",
+		"Error 1069: Too many keys specified",
 	}
 
 	// UnsupportedDMLMsgs list the error messages of some un-recoverable DML, which is used in task auto recovery
@@ -39,6 +43,7 @@ var (
 		"Error 1062: Duplicate entry",
 		"Error 1406: Data too long for column",
 		"Error 1366",
+		"Error 8025: entry too large",
 	}
 
 	// ParseRelayLogErrMsgs list the error messages of some un-recoverable relay log parsing error, which is used in task auto recovery.


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
ignore more unrecoverable error from https://docs.pingcap.com/zh/tidb/stable/tidb-limitations. some errors are not generated in MySQL and TiDB (partition number limit) so omitted.

### What is changed and how it works?
add more error message

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
  get these message from latest TiDB

Code changes


Side effects


Related changes

 - Need to cherry-pick to the release branch
