### PR TITLE
Revert "dump: retrieve ANSI_QUOTES from upstream (#909) (#929)"

### DIFF
--- a/dm/config/task.go
+++ b/dm/config/task.go
@@ -557,6 +557,8 @@ func (c *TaskConfig) SubTaskConfigs(sources map[string]DBConfig) ([]*SubTaskConf
 
 		cfg.CleanDumpFile = c.CleanDumpFile
 
+		cfg.EnableANSIQuotes = c.EnableANSIQuotes
+
 		err := cfg.Adjust(true)
 		if err != nil {
 			return nil, terror.Annotatef(err, "source %s", inst.SourceID)


### PR DESCRIPTION

<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This reverts commit 3b16803e32c8ce9d6d1e43f4d273288dc2a8be25. Because isolated dump unit auto discover will save ANSI_QUOTES into subtask config, which cause sync unit can't work

### What is changed and how it works?
revert #929

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Code changes

Side effects

Related changes

