### PR TITLE
loader: fix bug that SQL Mode didn't take effect

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -460,7 +460,20 @@ func (l *Loader) Init(ctx context.Context) (err error) {
 	dbCfg.RawDBCfg = config.DefaultRawDBConfig().
 		SetMaxIdleConns(l.cfg.PoolSize)
 
-	l.toDB, l.toDBConns, err = createConns(tctx, l.cfg, l.cfg.PoolSize)
+	// used to change loader's specified DB settings, currently SQL Mode
+	lcfg, err := l.cfg.Clone()
+	if err != nil {
+		return err
+	}
+	lowerM := map[string]struct{}{}
+	for k := range l.cfg.To.Session {
+		lowerM[strings.ToLower(k)] = struct{}{}
+	}
+	if _, ok := lowerM["sql_mode"]; !ok {
+		lcfg.To.Session["sql_mode"] = l.cfg.LoaderConfig.SQLMode
+	}
+
+	l.toDB, l.toDBConns, err = createConns(tctx, lcfg, l.cfg.PoolSize)
 	if err != nil {
 		return err
 	}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -465,11 +465,14 @@ func (l *Loader) Init(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	lowerM := map[string]struct{}{}
+	hasSQLMode := false
 	for k := range l.cfg.To.Session {
-		lowerM[strings.ToLower(k)] = struct{}{}
+		if strings.ToLower(k) == "sql_mode" {
+			hasSQLMode = true
+			break
+		}
 	}
-	if _, ok := lowerM["sql_mode"]; !ok {
+	if !hasSQLMode {
 		lcfg.To.Session["sql_mode"] = l.cfg.LoaderConfig.SQLMode
 	}
 

--- a/tests/all_mode/conf/dm-task.yaml
+++ b/tests/all_mode/conf/dm-task.yaml
@@ -7,7 +7,6 @@ meta-schema: "dm_meta"
 heartbeat-update-interval: 1
 heartbeat-report-interval: 1
 timezone: "Asia/Shanghai"
-ansi-quotes: false
 
 target-database:
   host: "127.0.0.1"
@@ -15,7 +14,6 @@ target-database:
   user: "root"
   password: ""
   session:
-    sql_mode: "NO_AUTO_VALUE_ON_ZERO,ANSI_QUOTES"
     tidb_skip_utf8_check: 1
     tidb_disable_txn_auto_retry: off
     tidb_retry_limit: "10"

--- a/tests/all_mode/data/db1.prepare.sql
+++ b/tests/all_mode/data/db1.prepare.sql
@@ -2,7 +2,8 @@ drop database if exists `all_mode`;
 create database `all_mode`;
 use `all_mode`;
 create table t1 (id int NOT NULL AUTO_INCREMENT, name varchar(20), PRIMARY KEY (id));
-insert into t1 (id, name) values (1, 'arya'), (2, 'catelyn');
+-- test ANSI_QUOTES works with quote in string
+insert into t1 (id, name) values (1, 'ar"ya'), (2, 'catelyn');
 
 -- test sql_mode=NO_AUTO_VALUE_ON_ZERO
 insert into t1 (id, name) values (0, 'lalala');

--- a/tests/all_mode/run.sh
+++ b/tests/all_mode/run.sh
@@ -32,21 +32,16 @@ function test_session_config(){
     cp $cur/conf/dm-task.yaml $WORK_DIR/dm-task.yaml
     sed -i "s/name: test/name: $ILLEGAL_CHAR_NAME/g" $WORK_DIR/dm-task.yaml
 
-    # enable ansi-quotes
-    sed -i 's/ansi-quotes: false/ansi-quotes: true/g'  $WORK_DIR/dm-task.yaml
     # error config
     sed -i 's/tidb_retry_limit: "10"/tidb_retry_limit: "fjs"/g'  $WORK_DIR/dm-task.yaml
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
         "start-task $WORK_DIR/dm-task.yaml --remove-meta" \
         "'tidb_retry_limit' can't be set to the value" 1
 
-    # sql_mode="ANSI_QUOTES"
     sed -i 's/tidb_retry_limit: "fjs"/tidb_retry_limit: "10"/g'  $WORK_DIR/dm-task.yaml
-    sed -i 's/sql_mode: ".*"/sql_mode: "ANSI_QUOTES"/g'  $WORK_DIR/dm-task.yaml
     dmctl_start_task "$WORK_DIR/dm-task.yaml" "--remove-meta"
 
-    # fail because insert 0 will auto generates the next serial number
-    check_sync_diff $WORK_DIR $cur/conf/diff_config.toml 10 'fail'
+    check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
             "stop-task $ILLEGAL_CHAR_NAME"\
             "\"result\": true" 3
@@ -85,8 +80,6 @@ function run() {
     # start DM task only
     cp $cur/conf/dm-task.yaml $WORK_DIR/dm-task.yaml
     sed -i "s/name: test/name: $ILLEGAL_CHAR_NAME/g" $WORK_DIR/dm-task.yaml
-    # test deprecated config
-    sed -i 's/enable-ansi-quotes: false/enable-ansi-quotes: true/g'  $WORK_DIR/dm-task.yaml
     dmctl_start_task "$WORK_DIR/dm-task.yaml" "--remove-meta"
 
     # use sync_diff_inspector to check full dump loader


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix bug that loader didn't use SQL Mode when create database connections, this bug is not revealed because `all_mode` has manually set SQL Mode related config

### What is changed and how it works?
if `to` database doesn't have a `sql_mode` item, we use SQL Mode discovered by dumpling's `Init`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
