### PR TITLE
dumpling: properly enable EscapeBackslash with upstream SQL mode

### DIFF
--- a/dumpling/dumpling.go
+++ b/dumpling/dumpling.go
@@ -59,6 +59,7 @@ func (m *Dumpling) Init(ctx context.Context) error {
 	var err error
 	m.dumpConfig, err = m.constructArgs()
 	m.detectSQLMode()
+	m.logger.Info("create dumpling", zap.Stringer("config", m.dumpConfig))
 	return err
 }
 
@@ -211,7 +212,6 @@ func (m *Dumpling) constructArgs() (*export.Config, error) {
 		return nil, err
 	}
 	dumpConfig.TableFilter = tableFilter
-	dumpConfig.EscapeBackslash = true
 	dumpConfig.CompleteInsert = true // always keep column name in `INSERT INTO` statements.
 	dumpConfig.Logger = m.logger.Logger
 
@@ -254,8 +254,6 @@ func (m *Dumpling) constructArgs() (*export.Config, error) {
 		dumpConfig.PosAfterConnect = true
 	}
 
-	m.logger.Info("create dumpling", zap.Stringer("config", dumpConfig))
-
 	if !cfg.CaseSensitive {
 		dumpConfig.TableFilter = filter.CaseInsensitive(dumpConfig.TableFilter)
 	}
@@ -263,7 +261,8 @@ func (m *Dumpling) constructArgs() (*export.Config, error) {
 	return dumpConfig, nil
 }
 
-// detectSQLMode tries to detect SQL mode from upstream. If success, write it to LoaderConfig
+// detectSQLMode tries to detect SQL mode from upstream. If success, write it to LoaderConfig.
+// Because loader will use this SQL mode, we need to treat disable `EscapeBackslash` when NO_BACKSLASH_ESCAPES
 func (m *Dumpling) detectSQLMode() {
 	db, err := sql.Open("mysql", m.dumpConfig.GetDSN(""))
 	if err != nil {
@@ -277,4 +276,9 @@ func (m *Dumpling) detectSQLMode() {
 	}
 	m.logger.Info("found upstream SQL mode", zap.String("SQL mode", sqlMode))
 	m.cfg.LoaderConfig.SQLMode = sqlMode
+	if strings.Contains(sqlMode, "NO_BACKSLASH_ESCAPES") {
+		m.dumpConfig.EscapeBackslash = false
+	} else {
+		m.dumpConfig.EscapeBackslash = true
+	}
 }

--- a/tests/full_mode/data/db1.prepare.sql
+++ b/tests/full_mode/data/db1.prepare.sql
@@ -3,9 +3,10 @@ create database `full_mode`;
 use `full_mode`;
 create table t1 (id int, name varchar(20), primary key(`id`));
 insert into t1 (id, name) values (1, 'arya'), (2, 'catelyn');
-insert into t1 (id, name) values (3, 'Eddard Stark');
-update t1 set name = 'Arya Stark' where id = 1;
-update t1 set name = 'Catelyn Stark' where name = 'catelyn';
+insert into t1 (id, name) values (3, 'Eddard
+Stark');
+update t1 set name = 'Arya S\\\\tark' where id = 1;
+update t1 set name = 'Catelyn S\"\n\ttark' where name = 'catelyn';
 
 -- test multi column index with generated column
 alter table t1 add column info json;

--- a/tests/full_mode/run.sh
+++ b/tests/full_mode/run.sh
@@ -111,6 +111,8 @@ function run() {
     fail_acquire_global_lock
     escape_schema
 
+    run_sql_both_source "SET @@GLOBAL.SQL_MODE='NO_BACKSLASH_ESCAPES'"
+
     run_sql_file $cur/data/db1.prepare.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
     check_contains 'Query OK, 2 rows affected'
     run_sql_file $cur/data/db2.prepare.sql $MYSQL_HOST2 $MYSQL_PORT2 $MYSQL_PASSWORD2
@@ -149,6 +151,7 @@ function run() {
     echo "check dump files have been cleaned"
     ls $WORK_DIR/worker1/dumped_data.test && exit 1 || echo "worker1 auto removed dump files"
     ls $WORK_DIR/worker2/dumped_data.test && exit 1 || echo "worker2 auto removed dump files"
+    run_sql_both_source "SET @@GLOBAL.SQL_MODE='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'"
 }
 
 cleanup_data full_mode


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
part of #1130

### What is changed and how it works?
because loader will use upstream's SQL mode, if upstream has `NO_BACKSLASH_ESCAPES`, we should not escape `\` in dump files.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

Side effects


Related changes

 - Need to cherry-pick to the release branch
