### PR TITLE
syncer/checkpoint: ignore cancel for update/delete

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -872,9 +872,7 @@ func (s *Syncer) flushCheckPoints() error {
 		s.tctx.L().Info("prepare flush sqls", zap.Strings("shard meta sqls", shardMetaSQLs), zap.Reflect("shard meta arguments", shardMetaArgs))
 	}
 
-	tctx, cancel := s.tctx.WithContext(context.Background()).WithTimeout(maxDMLConnectionDuration)
-	defer cancel()
-	err := s.checkpoint.FlushPointsExcept(tctx, exceptTables, shardMetaSQLs, shardMetaArgs)
+	err := s.checkpoint.FlushPointsExcept(s.tctx, exceptTables, shardMetaSQLs, shardMetaArgs)
 	if err != nil {
 		return terror.Annotatef(err, "flush checkpoint %s", s.checkpoint)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #1172

### What is changed and how it works?
for lease change, when update/delete checkpoint in DB, use a new context with 5-minute timeout, to avoid syncer's `cancel()` did not let SQL commit. 

create checkpoint is only called at syncer's `Init`, seems OK to be canceled

read checkpoint doesn't have a side effect, OK to be canceled

those methods are called from `Run -> handleQueryEvent`, which may block when pause/stop. Maybe we need https://github.com/pingcap/dm/pull/605

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Pass original test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch