### PR TITLE
dumpling: fix default values changed when specified extra-args

### DIFF
--- a/dumpling/util.go
+++ b/dumpling/util.go
@@ -94,7 +94,12 @@ func parseExtraArgs(logger *log.Logger, dumpCfg *export.Config, args []string) e
 		}
 	}
 
-	dumpCfg.FileSize, err = parseFileSize(fileSizeStr)
+	if fileSizeStr != "" {
+		dumpCfg.FileSize, err = parseFileSize(fileSizeStr)
+		if err != nil {
+			return err
+		}
+	}
 
 	if len(tablesList) > 0 || (len(filters) != 1 || filters[0] != "*.*") {
 		ff, err2 := parseTableFilter(tablesList, filters)
@@ -105,7 +110,7 @@ func parseExtraArgs(logger *log.Logger, dumpCfg *export.Config, args []string) e
 		logger.Warn("overwrite `block-allow-list` by `tables-list` or `filter`")
 	}
 
-	return err
+	return nil
 }
 
 func parseFileSize(fileSizeStr string) (uint64, error) {

--- a/dumpling/util_test.go
+++ b/dumpling/util_test.go
@@ -16,10 +16,13 @@ package dumpling
 import (
 	"strings"
 
+	"github.com/docker/go-units"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb-tools/pkg/filter"
+	tfilter "github.com/pingcap/tidb-tools/pkg/table-filter"
+
 	"github.com/pingcap/dm/dm/config"
 	"github.com/pingcap/dm/pkg/log"
-
-	. "github.com/pingcap/check"
 )
 
 func (m *testDumplingSuite) TestParseArgs(c *C) {
@@ -85,4 +88,27 @@ func (m *testDumplingSuite) TestParseArgs(c *C) {
 	extraArgs = `--no-locks --consistency lock`
 	err = parseExtraArgs(&logger, exportCfg, strings.Fields(extraArgs))
 	c.Assert(err.Error(), Equals, "cannot both specify `--no-locks` and `--consistency` other than `none`")
+}
+
+func (m *testDumplingSuite) TestParseArgsWontOverwrite(c *C) {
+	cfg := &config.SubTaskConfig{}
+	cfg.ChunkFilesize = "1"
+	rules := &filter.Rules{
+		DoDBs: []string{"unit_test"},
+	}
+	cfg.BAList = rules
+	// make sure we enter `parseExtraArgs`
+	cfg.ExtraArgs = "--statement-size=4000 --consistency lock"
+
+	d := NewDumpling(cfg)
+	exportCfg, err := d.constructArgs()
+	c.Assert(err, IsNil)
+
+	c.Assert(exportCfg.FileSize, Equals, uint64(1*units.MiB))
+
+	f, err2 := tfilter.ParseMySQLReplicationRules(rules)
+	c.Assert(err2, IsNil)
+	c.Assert(exportCfg.TableFilter, DeepEquals, tfilter.CaseInsensitive(f))
+
+	c.Assert(exportCfg.Consistency, Equals, "lock")
 }


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
when specifed `extra-args`, `parseExtraArgs` will overwrite `FileSize` set in other place

### What is changed and how it works?
check in `parseExtraArgs`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
