### PR TITLE
fix: fix wrong shorthand for `statement-size`

### DIFF
--- a/dumpling/util.go
+++ b/dumpling/util.go
@@ -65,7 +65,7 @@ func parseExtraArgs(logger *log.Logger, dumpCfg *export.Config, args []string) e
 	dumplingFlagSet.StringSliceVarP(&tablesList, "tables-list", "T", nil, "Comma delimited table list to dump; must be qualified table names")
 	dumplingFlagSet.IntVarP(&dumpCfg.Threads, "threads", "t", dumpCfg.Threads, "Number of goroutines to use, default 4")
 	dumplingFlagSet.StringVarP(&fileSizeStr, "filesize", "F", "", "The approximate size of output file")
-	dumplingFlagSet.Uint64VarP(&dumpCfg.StatementSize, "statement-size", "S", dumpCfg.StatementSize, "Attempted size of INSERT statement in bytes")
+	dumplingFlagSet.Uint64VarP(&dumpCfg.StatementSize, "statement-size", "s", dumpCfg.StatementSize, "Attempted size of INSERT statement in bytes")
 	dumplingFlagSet.StringVar(&dumpCfg.Consistency, "consistency", dumpCfg.Consistency, "Consistency level during dumping: {auto|none|flush|lock|snapshot}")
 	dumplingFlagSet.StringVar(&dumpCfg.Snapshot, "snapshot", dumpCfg.Snapshot, "Snapshot position. Valid only when consistency=snapshot")
 	dumplingFlagSet.BoolVarP(&dumpCfg.NoViews, "no-views", "W", dumpCfg.NoViews, "Do not dump views")

--- a/dumpling/util_test.go
+++ b/dumpling/util_test.go
@@ -98,12 +98,13 @@ func (m *testDumplingSuite) TestParseArgsWontOverwrite(c *C) {
 	}
 	cfg.BAList = rules
 	// make sure we enter `parseExtraArgs`
-	cfg.ExtraArgs = "--statement-size=4000 --consistency lock"
+	cfg.ExtraArgs = "-s=4000 --consistency lock"
 
 	d := NewDumpling(cfg)
 	exportCfg, err := d.constructArgs()
 	c.Assert(err, IsNil)
 
+	c.Assert(exportCfg.StatementSize, Equals, uint64(4000))
 	c.Assert(exportCfg.FileSize, Equals, uint64(1*units.MiB))
 
 	f, err2 := tfilter.ParseMySQLReplicationRules(rules)


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

in dumpling, we use `-s` as the shorthand for `--statement-size` (https://github.com/pingcap/dumpling/blob/270170441a02b0a31ea927ae3ffb13c4acb8dc23/cmd/dumpling/main.go#L102), but we use `-S` in DM.

### What is changed and how it works?

change `S` to `s`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported variable/fields change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
