### PR TITLE
fix: accept comands with leading and trailing white spaces

### DIFF
--- a/cmd/dm-ctl/main.go
+++ b/cmd/dm-ctl/main.go
@@ -220,6 +220,8 @@ func loop() {
 			}
 			continue
 		}
+
+		line = strings.TrimSpace(line)
 		if line == "exit" {
 			os.Exit(0)
 		} else if line == "" {


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


`exit` with trailing white spaces

```
» exit
Error: unknown command "exit" for "dmctl"
Run 'dmctl --help' for usage.
fail to run: [exit]
```

`exit` with leading white spaces

```
»  exit
Error: unknown command "exit" for "dmctl"
Run 'dmctl --help' for usage.
fail to run: [exit]
```


### What is changed and how it works?

remove leading and trailing white spaces before handling it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    - re-run commands above

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
