### PR TITLE
fix: support "sql" prefix exists in table name

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -868,7 +868,7 @@ func (l *Loader) prepareDbFiles(files map[string]struct{}) error {
 			continue
 		}
 
-		idx := strings.Index(file, "-schema-create.sql")
+		idx := strings.LastIndex(file, "-schema-create.sql")
 		if idx > 0 {
 			schemaFileCount++
 			db := file[:idx]
@@ -900,7 +900,7 @@ func (l *Loader) prepareTableFiles(files map[string]struct{}) error {
 			continue
 		}
 
-		idx := strings.Index(file, "-schema.sql")
+		idx := strings.LastIndex(file, "-schema.sql")
 		name := file[:idx]
 		fields := strings.Split(name, ".")
 		if len(fields) != 2 {

--- a/loader/util.go
+++ b/loader/util.go
@@ -112,7 +112,7 @@ func escapeName(name string) string {
 
 // input filename is like `all_mode.t1.0.sql` or `all_mode.t1.sql`
 func getDBAndTableFromFilename(filename string) (string, string, error) {
-	idx := strings.Index(filename, ".sql")
+	idx := strings.LastIndex(filename, ".sql")
 	if idx < 0 {
 		return "", "", fmt.Errorf("%s doesn't have a `.sql` suffix", filename)
 	}

--- a/loader/util_test.go
+++ b/loader/util_test.go
@@ -92,3 +92,34 @@ func (t *testUtilSuite) TestGenerateSchemaCreateFile(c *C) {
 		c.Assert(string(data), Equals, testCase.createSQL)
 	}
 }
+
+func (t *testUtilSuite) TestGetDBAndTableFromFilename(c *C) {
+	cases := []struct {
+		filename string
+		schema   string
+		table    string
+		errMsg   string
+	}{
+		{"db.tbl.sql", "db", "tbl", ""},
+		{"db.tbl.0.sql", "db", "tbl", ""},
+		{"db.sqltbl.sql", "db", "sqltbl", ""},
+		{"db.sqltbl.0.sql", "db", "sqltbl", ""},
+		{"sqldb.tbl.sql", "sqldb", "tbl", ""},
+		{"sqldb.tbl.0.sql", "sqldb", "tbl", ""},
+		{"db.tbl.sql0.sql", "db", "tbl", ""},
+		{"db.tbl.0", "", "", ".*doesn't have a `.sql` suffix.*"},
+		{"db.sql", "", "", ".*doesn't have correct `.` seperator.*"},
+		{"db.0.sql", "db", "0", ""}, // treat `0` as the table name.
+	}
+
+	for _, cs := range cases {
+		schema, table, err := getDBAndTableFromFilename(cs.filename)
+		if cs.errMsg != "" {
+			c.Assert(err, ErrorMatches, cs.errMsg)
+		} else {
+			c.Assert(err, IsNil)
+			c.Assert(schema, Equals, cs.schema)
+			c.Assert(table, Equals, cs.table)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix #1255 

### What is changed and how it works?

use `LastIndex` rather than `Index` to find the index of `.sql` suffix.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
