### PR TITLE
shardddl: add infoOpLock for pessmist shardddl

### DIFF
--- a/dm/master/shardddl/pessimist.go
+++ b/dm/master/shardddl/pessimist.go
@@ -471,9 +471,6 @@ func (p *Pessimist) handleInfoPut(ctx context.Context, infoCh <-chan pessimism.I
 			p.infoOpMu.Lock()
 			lockID, synced, remain, err := p.lk.TrySync(info, p.taskSources(info.Task))
 			if err != nil {
-				// if the lock become synced, and `done` for `exec`/`skip` operation received,
-				// but the `done` operations have not been deleted,
-				// then the DM-worker should not put any new DDL info until the old operation has been deleted.
 				p.logger.Error("fail to try sync shard DDL lock", zap.Stringer("info", info), log.ShortError(err))
 				// currently, only DDL mismatch will cause error
 				metrics.ReportDDLError(info.Task, metrics.InfoErrSyncLock)

--- a/tests/_utils/test_prepare
+++ b/tests/_utils/test_prepare
@@ -197,7 +197,7 @@ function check_log_contain_with_retry() {
         log2=$3
     fi
     rc=0
-    for ((k=1;k<11;k++)); do
+    for ((k=1;k<31;k++)); do
         if [[ ! -f $log1 ]]; then
             sleep 2
             echo "check log contain failed $k-th time (file not exist), retry later"


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #1253 

```
[2020-10-30T02:25:09.879Z] [2020/10/30 10:24:51.715 +08:00] [INFO] [pessimist.go:522] ["the lock for the shard DDL lock operation has been resolved"] [component="shard DDL pessimist"] [operation="{\"id\":\"test-`shardddl`.`tb`\",\"task\":\"test\",\"source\":\"mysql-replica-02\",\"ddls\":[\"ALTER TABLE `shardddl`.`tb` ADD UNIQUE `idx_a`(`a`)\"],\"exec\":false,\"done\":true}"]
[2020-10-30T02:25:09.879Z] [2020/10/30 10:24:51.818 +08:00] [INFO] [pessimist.go:466] ["receive a shard DDL info"] [component="shard DDL pessimist"] [info="{\"task\":\"test\",\"source\":\"mysql-replica-01\",\"schema\":\"shardddl\",\"table\":\"tb\",\"ddls\":[\"ALTER TABLE `shardddl`.`tb` ADD UNIQUE `idx_b`(`b`)\"]}"]
[2020-10-30T02:25:09.880Z] [2020/10/30 10:24:51.818 +08:00] [ERROR] [pessimist.go:472] ["fail to try sync shard DDL lock"] [component="shard DDL pessimist"] [info="{\"task\":\"test\",\"source\":\"mysql-replica-01\",\"schema\":\"shardddl\",\"table\":\"tb\",\"ddls\":[\"ALTER TABLE `shardddl`.`tb` ADD UNIQUE `idx_b`(`b`)\"]}"] [error="[code=38016:class=dm-master:scope=internal:level=high], Message: sharding ddls in ddl lock [ALTER TABLE `shardddl`.`tb` ADD UNIQUE `idx_a`(`a`)] is different with [ALTER TABLE `shardddl`.`tb` ADD UNIQUE `idx_b`(`b`)], Workaround: Please use show-ddl-locks command for more details."]
[2020-10-30T02:25:09.880Z] [2020/10/30 10:24:51.828 +08:00] [INFO] [pessimist.go:652] ["delete shard DDL lock operations"] [component="shard DDL pessimist"] [lock=test-`shardddl`.`tb`] [revision=114]
```
we have fixed put shard DDL info if the done operation exists in #725 , so the above log may because the done operations have been deleted but lock has not.

### What is changed and how it works?
add mutex in `handleInfoPut` and `handleOperationPut`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
