### PR TITLE
sycner: automatically use upstream sql_mode

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -2351,23 +2351,25 @@ func (s *Syncer) createDBs(ctx context.Context) error {
 		return err
 	}
 
+	hasSQLMode := false
 	// get sql_mode from upstream db
 	if s.cfg.To.Session == nil {
 		s.cfg.To.Session = make(map[string]string)
-	}
-	hasSQLMode := false
-	for k := range s.cfg.To.Session {
-		if strings.ToLower(k) == "sql_mode" {
-			hasSQLMode = true
-			break
+	} else {
+		for k := range s.cfg.To.Session {
+			if strings.ToLower(k) == "sql_mode" {
+				hasSQLMode = true
+				break
+			}
 		}
 	}
 	if !hasSQLMode {
 		sqlMode, err2 := utils.GetGlobalVariable(ctx, s.fromDB.BaseDB.DB, "sql_mode")
 		if err2 != nil {
 			s.tctx.L().Warn("cannot get sql_mode from upstream database", log.ShortError(err2))
+		} else {
+			s.cfg.To.Session["sql_mode"] = sqlMode
 		}
-		s.cfg.To.Session["sql_mode"] = sqlMode
 	}
 
 	dbCfg = s.cfg.To

--- a/tests/all_mode/data/db2.increment.sql
+++ b/tests/all_mode/data/db2.increment.sql
@@ -1,2 +1,6 @@
 use all_mode;
 delete from t2 where name = 'Sansa';
+
+
+-- test sql_mode=NO_AUTO_VALUE_ON_ZERO
+insert into t2 (id, name) values (0,'haha')


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Inconsistent upstream and downstream sql_mode leads to inconsistent data

### What is changed and how it works?
get dsn scope sql_mode from upstream database if sql_mode is not specified in task config.

**Still can't use different session sql_mode base on different binlog event like mysql master-slave replication. One solution is get sql_mode from `begin` event and apply it for rows event in same txn, which is ineffective.**
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test