### PR TITLE
bug-fix: fix currentLocation not increase in rows event

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -1549,6 +1549,14 @@ func (s *Syncer) handleRowsEvent(ev *replication.RowsEvent, ec eventContext) err
 	originSchema, originTable := string(ev.Table.Schema), string(ev.Table.Table)
 	schemaName, tableName := s.renameShardingSchema(originSchema, originTable)
 
+	*ec.currentLocation = binlog.InitLocation(
+		mysql.Position{
+			Name: ec.lastLocation.Position.Name,
+			Pos:  ec.header.LogPos,
+		},
+		ec.lastLocation.GetGTID(),
+	)
+
 	if ec.shardingReSync != nil {
 		ec.shardingReSync.currLocation = *ec.currentLocation
 		if binlog.CompareLocation(ec.shardingReSync.currLocation, ec.shardingReSync.latestLocation, s.cfg.EnableGTID) >= 0 {


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
row event's currentLocation not update due to #1303 
in #1303, we disable handle-error for rows event, but also skip [update currentLocation](https://github.com/pingcap/dm/blob/7e79861c53544a13c237fb680b8571af4f676fff/syncer/syncer.go#L1362) by mistake.
### What is changed and how it works?
update currentlocation in handleRowEvents

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 manually test

add more auto test for transaction later.