### PR TITLE
chaos: fix diffIncrData has no effect

### DIFF
--- a/chaos/cases/config.go
+++ b/chaos/cases/config.go
@@ -80,9 +80,11 @@ func (c *config) parse(args []string) error {
 
 func (c *config) adjust() {
 	// `go-sqlsmith` may generate ZERO time data, so we simply clear `sql_mode` now.
-	c.Source1.Session = map[string]string{"sql_mode": ""}
-	c.Source2.Session = map[string]string{"sql_mode": ""}
-	c.Target.Session = map[string]string{"sql_mode": ""}
+	// mysql:5.7 `explicit_defaults_for_timestamp`: OFF
+	// tidb `explicit_defaults_for_timestamp`: ON
+	// `ALTER TABLE .* ADD COLUMN (.* TIMESTAMP)` will have different default value
+	c.Source1.Session = map[string]string{"sql_mode": "", "explicit_defaults_for_timestamp": "on"}
+	c.Source2.Session = map[string]string{"sql_mode": "", "explicit_defaults_for_timestamp": "on"}
 
 	c.Source1.Adjust()
 	c.Source2.Adjust()

--- a/chaos/cases/diff.go
+++ b/chaos/cases/diff.go
@@ -38,6 +38,7 @@ func diffDataLoop(ctx context.Context, count int, interval time.Duration, schema
 			if err == nil {
 				return nil
 			}
+			log.L().Warn("diff data error", zap.Int("count", i+1), log.ShortError(err))
 		}
 	}
 	return err

--- a/chaos/cases/task.go
+++ b/chaos/cases/task.go
@@ -37,7 +37,7 @@ import (
 const (
 	tableCount      = 10               // tables count in schema.
 	fullInsertCount = 100              // `INSERT INTO` count (not rows count) for each table in full stage.
-	diffCount       = 10               // diff data check count
+	diffCount       = 20               // diff data check count
 	diffInterval    = 10 * time.Second // diff data check interval
 	incrRoundTime   = 20 * time.Second // time to generate incremental data in one round
 )

--- a/chaos/cases/task.go
+++ b/chaos/cases/task.go
@@ -74,7 +74,7 @@ func newTask(ctx context.Context, cli pb.MasterClient, taskFile string, schema s
 	var (
 		sourceDBs   = make([]*conn.BaseDB, 0, len(taskCfg.MySQLInstances))
 		sourceConns = make([]*dbConn, 0, len(taskCfg.MySQLInstances))
-		results     = make(results, 0, len(taskCfg.MySQLInstances))
+		res         = make(results, 0, len(taskCfg.MySQLInstances))
 	)
 	for i := range taskCfg.MySQLInstances { // only use necessary part of sources.
 		cfg := sourcesCfg[i]
@@ -88,7 +88,7 @@ func newTask(ctx context.Context, cli pb.MasterClient, taskFile string, schema s
 		}
 		sourceDBs = append(sourceDBs, db)
 		sourceConns = append(sourceConns, conn)
-		results = append(results, singleResult{})
+		res = append(res, singleResult{})
 	}
 
 	targetDB, err := conn.DefaultDBProvider.Apply(targetCfg)
@@ -112,7 +112,7 @@ func newTask(ctx context.Context, cli pb.MasterClient, taskFile string, schema s
 		schema:      schema,
 		tables:      make([]string, 0),
 		taskCfg:     taskCfg,
-		results:     results,
+		results:     res,
 	}
 	t.ss.SetDB(schema)
 	return t, nil
@@ -278,7 +278,7 @@ func (t *task) incrLoop() error {
 			}
 
 			// diff data
-			err = t.diffIncrData(ctx2)
+			err = t.diffIncrData(t.ctx)
 			if err != nil {
 				cancel2()
 				return err


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- chaos test will always return true when diff incremental data 😨
- alter table add column(timestamp) will have different default value between mysql:5.7 and tidb.

### What is changed and how it works?
- change context
- add session variable `explicit_defaults_for_timestamp`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - chaos test
