### PR TITLE
streamer: add heartbeat for local streamer

### DIFF
--- a/pkg/streamer/reader_test.go
+++ b/pkg/streamer/reader_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/uuid"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/siddontang/go-mysql/mysql"
 	gmysql "github.com/siddontang/go-mysql/mysql"
 	"github.com/siddontang/go-mysql/replication"
@@ -62,6 +63,11 @@ func (t *testReaderSuite) SetUpSuite(c *C) {
 	t.lastPos = 0
 	t.lastGTID, err = gtid.ParserGTID(mysql.MySQLFlavor, "ba8f633f-1f15-11eb-b1c7-0242ac110002:0")
 	c.Assert(err, IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/dm/pkg/streamer/SetHeartbeatInterval", "return(10000)"), IsNil)
+}
+
+func (t *testReaderSuite) TearDownSuite(c *C) {
+	c.Assert(failpoint.Disable("github.com/pingcap/dm/pkg/streamer/SetHeartbeatInterval"), IsNil)
 }
 
 func (t *testReaderSuite) TestParseFileBase(c *C) {

--- a/pkg/streamer/streamer.go
+++ b/pkg/streamer/streamer.go
@@ -63,13 +63,10 @@ func (s *LocalStreamer) GetEvent(ctx context.Context) (*replication.BinlogEvent,
 		heartbeatInterval = time.Duration(i) * time.Second
 	})
 
-	// MySQL will send heartbeat event 30s by default
-	heartbeatTicker := time.NewTicker(heartbeatInterval)
-	heartbeatHeader := &replication.EventHeader{}
-	defer heartbeatTicker.Stop()
-
 	select {
-	case <-heartbeatTicker.C:
+	case <-time.After(heartbeatInterval):
+		// MySQL will send heartbeat event 30s by default
+		heartbeatHeader := &replication.EventHeader{}
 		return event.GenHeartbeatEvent(heartbeatHeader), nil
 	case c := <-s.ch:
 		return c, nil


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

currently relay will ignore heartbeat event before writing to relay logs. so when relay enabled, there's no heartbeat event which causes syncer can't advance its checkpoint when upstream is idle.

### What is changed and how it works?

peroidically send heartbeat event

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manually test (only do an insert in upstream, and check checkpoint advanced after 30s)

Code changes


Side effects


Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
