### PR TITLE
config: add warning, when users set configuration to mydumper/loader/syncer b…

### DIFF
--- a/_utils/terror_gen/errors_release.txt
+++ b/_utils/terror_gen/errors_release.txt
@@ -165,8 +165,7 @@ ErrConfigMoreThanOne,[code=20034:class=config:scope=internal:level=high], "Messa
 ErrConfigEtcdParse,[code=20035:class=config:scope=internal:level=high], "Message: incapable config of %s from etcd"
 ErrConfigMissingForBound,[code=20036:class=config:scope=internal:level=high], "Message: source bound %s doesn't have related source config in etcd"
 ErrConfigBinlogEventFilter,[code=20037:class=config:scope=internal:level=high], "Message: generate binlog event filter, Workaround: Please check the `filters` config in source and task configuration files."
-ErrConfigUnreferingCofig,[code=20038:class=config:scope=internal:level=high], "Message: instances don't refer configurations with xxx-config-name, Workaround: Please check the configuration files."
-ErrConfigGobalConfigUnused,[code=20039:class=config:scope=internal:level=high], "Message: partial function configurations are set in gobal configurations but instances don't use them, Workaround: Please check the configuration files."
+ErrConfigGlobalConfigsUnused,[code=20038:class=config:scope=internal:level=high], "Message: The configurations as following %v are set in gobal configuration but instances don't use them, Workaround: Please check the configuration files."
 ErrBinlogExtractPosition,[code=22001:class=binlog-op:scope=internal:level=high]
 ErrBinlogInvalidFilename,[code=22002:class=binlog-op:scope=internal:level=high], "Message: invalid binlog filename"
 ErrBinlogParsePosFromStr,[code=22003:class=binlog-op:scope=internal:level=high]

--- a/_utils/terror_gen/errors_release.txt
+++ b/_utils/terror_gen/errors_release.txt
@@ -165,6 +165,8 @@ ErrConfigMoreThanOne,[code=20034:class=config:scope=internal:level=high], "Messa
 ErrConfigEtcdParse,[code=20035:class=config:scope=internal:level=high], "Message: incapable config of %s from etcd"
 ErrConfigMissingForBound,[code=20036:class=config:scope=internal:level=high], "Message: source bound %s doesn't have related source config in etcd"
 ErrConfigBinlogEventFilter,[code=20037:class=config:scope=internal:level=high], "Message: generate binlog event filter, Workaround: Please check the `filters` config in source and task configuration files."
+ErrConfigUnreferingCofig,[code=20038:class=config:scope=internal:level=high], "Message: instances don't refer configurations with xxx-config-name, Workaround: Please check the configuration files."
+ErrConfigGobalConfigUnused,[code=20039:class=config:scope=internal:level=high], "Message: partial function configurations are set in gobal configurations but instances don't use them, Workaround: Please check the configuration files."
 ErrBinlogExtractPosition,[code=22001:class=binlog-op:scope=internal:level=high]
 ErrBinlogInvalidFilename,[code=22002:class=binlog-op:scope=internal:level=high], "Message: invalid binlog filename"
 ErrBinlogParsePosFromStr,[code=22003:class=binlog-op:scope=internal:level=high]

--- a/_utils/terror_gen/errors_release.txt
+++ b/_utils/terror_gen/errors_release.txt
@@ -165,7 +165,7 @@ ErrConfigMoreThanOne,[code=20034:class=config:scope=internal:level=high], "Messa
 ErrConfigEtcdParse,[code=20035:class=config:scope=internal:level=high], "Message: incapable config of %s from etcd"
 ErrConfigMissingForBound,[code=20036:class=config:scope=internal:level=high], "Message: source bound %s doesn't have related source config in etcd"
 ErrConfigBinlogEventFilter,[code=20037:class=config:scope=internal:level=high], "Message: generate binlog event filter, Workaround: Please check the `filters` config in source and task configuration files."
-ErrConfigGlobalConfigsUnused,[code=20038:class=config:scope=internal:level=high], "Message: The configurations as following %v are set in gobal configuration but instances don't use them, Workaround: Please check the configuration files."
+ErrConfigGlobalConfigsUnused,[code=20038:class=config:scope=internal:level=high], "Message: The configurations as following %v are set in global configuration but instances don't use them, Workaround: Please check the configuration files."
 ErrBinlogExtractPosition,[code=22001:class=binlog-op:scope=internal:level=high]
 ErrBinlogInvalidFilename,[code=22002:class=binlog-op:scope=internal:level=high], "Message: invalid binlog filename"
 ErrBinlogParsePosFromStr,[code=22003:class=binlog-op:scope=internal:level=high]

--- a/dm/config/task.go
+++ b/dm/config/task.go
@@ -482,7 +482,7 @@ func (c *TaskConfig) adjust() error {
 			*inst.Mydumper = *rule // ref mydumper config
 		}
 		if inst.Mydumper == nil {
-			if len(c.Mydumpers) != 0 {
+			if len(c.Mydumpers) != 0 && inst.MydumperThread == 0 {
 				log.L().Warn("mysql instance don't refer mydumper's configuration with mydumper-config-name, the default configuration will be used", zap.Int("mysql instance", i))
 				return terror.ErrConfigUnreferingCofig.Generate()
 			}
@@ -511,7 +511,7 @@ func (c *TaskConfig) adjust() error {
 			*inst.Loader = *rule // ref loader config
 		}
 		if inst.Loader == nil {
-			if len(c.Loaders) != 0 {
+			if len(c.Loaders) != 0 && inst.LoaderThread == 0 {
 				log.L().Warn("mysql instance don't refer loader's configuration with loader-config-name, the default configuration will be used", zap.Int("mysql instance", i))
 				return terror.ErrConfigUnreferingCofig.Generate()
 			}
@@ -532,7 +532,7 @@ func (c *TaskConfig) adjust() error {
 			*inst.Syncer = *rule // ref syncer config
 		}
 		if inst.Syncer == nil {
-			if len(c.Syncers) != 0 {
+			if len(c.Syncers) != 0 && inst.SyncerThread == 0 {
 				log.L().Warn("mysql instance don't refer syncer's configuration with syncer-config-name, the default configuration will be used", zap.Int("mysql instance", i))
 				return terror.ErrConfigUnreferingCofig.Generate()
 			}

--- a/dm/config/task.go
+++ b/dm/config/task.go
@@ -484,6 +484,7 @@ func (c *TaskConfig) adjust() error {
 		if inst.Mydumper == nil {
 			if len(c.Mydumpers) != 0 {
 				log.L().Warn("mysql instance don't refer mydumper's configuration with mydumper-config-name, the default configuration will be used", zap.Int("mysql instance", i))
+				return terror.ErrConfigUnreferingCofig.Generate()
 			}
 			defaultCfg := defaultMydumperConfig()
 			inst.Mydumper = &defaultCfg
@@ -512,6 +513,7 @@ func (c *TaskConfig) adjust() error {
 		if inst.Loader == nil {
 			if len(c.Loaders) != 0 {
 				log.L().Warn("mysql instance don't refer loader's configuration with loader-config-name, the default configuration will be used", zap.Int("mysql instance", i))
+				return terror.ErrConfigUnreferingCofig.Generate()
 			}
 			defaultCfg := defaultLoaderConfig()
 			inst.Loader = &defaultCfg
@@ -532,6 +534,7 @@ func (c *TaskConfig) adjust() error {
 		if inst.Syncer == nil {
 			if len(c.Syncers) != 0 {
 				log.L().Warn("mysql instance don't refer syncer's configuration with syncer-config-name, the default configuration will be used", zap.Int("mysql instance", i))
+				return terror.ErrConfigUnreferingCofig.Generate()
 			}
 			defaultCfg := defaultSyncerConfig()
 			inst.Syncer = &defaultCfg

--- a/dm/config/task.go
+++ b/dm/config/task.go
@@ -476,6 +476,9 @@ func (c *TaskConfig) adjust() error {
 			*inst.Mydumper = *rule // ref mydumper config
 		}
 		if inst.Mydumper == nil {
+			if len(c.Mydumpers) != 0 {
+				log.L().Warn("mysql instance don't refer mydumper's configuration with mydumper-config-name, the default configuration will be used", zap.Int("mysql instance", i))
+			}
 			defaultCfg := defaultMydumperConfig()
 			inst.Mydumper = &defaultCfg
 		} else if inst.Mydumper.ChunkFilesize == "" {
@@ -500,6 +503,9 @@ func (c *TaskConfig) adjust() error {
 			*inst.Loader = *rule // ref loader config
 		}
 		if inst.Loader == nil {
+			if len(c.Loaders) != 0 {
+				log.L().Warn("mysql instance don't refer loader's configuration with loader-config-name, the default configuration will be used", zap.Int("mysql instance", i))
+			}
 			defaultCfg := defaultLoaderConfig()
 			inst.Loader = &defaultCfg
 		}
@@ -516,6 +522,9 @@ func (c *TaskConfig) adjust() error {
 			*inst.Syncer = *rule // ref syncer config
 		}
 		if inst.Syncer == nil {
+			if len(c.Syncers) != 0 {
+				log.L().Warn("mysql instance don't refer syncer's configuration with syncer-config-name, the default configuration will be used", zap.Int("mysql instance", i))
+			}
 			defaultCfg := defaultSyncerConfig()
 			inst.Syncer = &defaultCfg
 		}

--- a/dm/config/task.go
+++ b/dm/config/task.go
@@ -483,7 +483,7 @@ func (c *TaskConfig) adjust() error {
 		}
 		if inst.Mydumper == nil {
 			if len(c.Mydumpers) != 0 {
-				log.L().Warn("mysql instance don't refer mydumper's configuration with mydumper-config-name, the default configuration will be used", zap.Int("mysql instance", i))
+				log.L().Warn("mysql instance don't refer mydumper's configuration with mydumper-config-name, the default configuration will be used", zap.String("mysql instance", inst.SourceID))
 			}
 			defaultCfg := defaultMydumperConfig()
 			inst.Mydumper = &defaultCfg
@@ -511,7 +511,7 @@ func (c *TaskConfig) adjust() error {
 		}
 		if inst.Loader == nil {
 			if len(c.Loaders) != 0 {
-				log.L().Warn("mysql instance don't refer loader's configuration with loader-config-name, the default configuration will be used", zap.Int("mysql instance", i))
+				log.L().Warn("mysql instance don't refer loader's configuration with loader-config-name, the default configuration will be used", zap.String("mysql instance", inst.SourceID))
 			}
 			defaultCfg := defaultLoaderConfig()
 			inst.Loader = &defaultCfg
@@ -531,7 +531,7 @@ func (c *TaskConfig) adjust() error {
 		}
 		if inst.Syncer == nil {
 			if len(c.Syncers) != 0 {
-				log.L().Warn("mysql instance don't refer syncer's configuration with syncer-config-name, the default configuration will be used", zap.Int("mysql instance", i))
+				log.L().Warn("mysql instance don't refer syncer's configuration with syncer-config-name, the default configuration will be used", zap.String("mysql instance", inst.SourceID))
 			}
 			defaultCfg := defaultSyncerConfig()
 			inst.Syncer = &defaultCfg

--- a/dm/config/task.go
+++ b/dm/config/task.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"sort"
 	"strings"
 	"time"
 
@@ -589,6 +590,7 @@ func (c *TaskConfig) adjust() error {
 	}
 
 	if len(unusedConfigs) != 0 {
+		sort.Strings(unusedConfigs)
 		return terror.ErrConfigGlobalConfigsUnused.Generate(unusedConfigs)
 	}
 

--- a/dm/config/task_test.go
+++ b/dm/config/task_test.go
@@ -131,7 +131,7 @@ mysql-instances:
 	taskConfig := NewTaskConfig()
 	err := taskConfig.Decode(correctTaskConfig)
 	c.Assert(err, IsNil)
-	var errorTaskConfig1 = `---
+	var errorTaskConfig = `---
 name: test
 task-mode: all
 shard-mode: "pessimistic"       
@@ -232,108 +232,9 @@ mysql-instances:
     syncer-config-name: "global2"
 `
 	taskConfig = NewTaskConfig()
-	err = taskConfig.Decode(errorTaskConfig1)
-	c.Assert(err, NotNil)
-	var errorTaskConfig2 = `---
-name: test
-task-mode: all
-shard-mode: "pessimistic"       
-meta-schema: "dm_meta"         
-timezone: "Asia/Shanghai"     
-case-sensitive: false        
-online-ddl-scheme: "gh-ost" 
-clean-dump-file: true     
-
-target-database:
-  host: "127.0.0.1"
-  port: 4000
-  user: "root"
-  password: ""
-
-routes:
-  route-rule-1:
-    schema-pattern: "test_*"
-    target-schema: "test"
-  route-rule-2:
-    schema-pattern: "test_*"
-    target-schema: "test"
-
-filters: 
-  filter-rule-1:
-    schema-pattern: "test_*"
-    table-pattern: "t_*"
-    events: ["truncate table", "drop table"]
-    action: Ignore
-  filter-rule-2:
-    schema-pattern: "test_*"
-    events: ["all dml"]
-    action: Do
-
-column-mappings:
-  column-mapping-rule-1:
-    schema-pattern: "test_*"
-    table-pattern: "t_*"
-    expression: "partition id"
-    source-column: "id"
-    target-column: "id"
-    arguments: ["1", "test", "t", "_"]
-  column-mapping-rule-2:
-    schema-pattern: "test_*"
-    table-pattern: "t_*"
-    expression: "partition id"
-    source-column: "id"
-    target-column: "id"
-    arguments: ["2", "test", "t", "_"]
-
-mydumpers:
-  global1:
-    threads: 4
-    chunk-filesize: 64
-    skip-tz-utc: true
-    extra-args: "--consistency none"
-  global2:
-    threads: 8
-    chunk-filesize: 128
-    skip-tz-utc: true
-    extra-args: "--consistency none"
-
-loaders:
-  global1:
-    pool-size: 16
-    dir: "./dumped_data1"
-  global2:
-    pool-size: 8
-    dir: "./dumped_data2"
-
-syncers:
-  global1:
-    worker-count: 16
-    batch: 100 
-    enable-ansi-quotes: true
-    safe-mode: false  
-  global2:
-    worker-count: 32
-    batch: 100 
-    enable-ansi-quotes: true
-    safe-mode: false  
-
-mysql-instances:
-  - source-id: "mysql-replica-01"
-    route-rules: ["route-rule-1"]
-    filter-rules: ["filter-rule-2"]
-    column-mapping-rules: ["column-mapping-rule-2"]
-    mydumper-config-name: "global1"
-    loader-config-name: "global1"
-    syncer-config-name: "global1"
-
-  - source-id: "mysql-replica-02"
-    route-rules: ["route-rule-1"]
-    filter-rules: ["filter-rule-1"]
-    column-mapping-rules: ["column-mapping-rule-1"]
-`
-	taskConfig = NewTaskConfig()
-	err = taskConfig.Decode(errorTaskConfig2)
-	c.Assert(err, NotNil)
+	err = taskConfig.Decode(errorTaskConfig)
+	c.Check(err, NotNil)
+	c.Assert(err, ErrorMatches, "*The configurations as following [route-rule-2 filter-rule-2 column-mapping-rule-2] are set in gobal configuration but*")
 }
 
 func (t *testConfig) TestInvalidTaskConfig(c *C) {

--- a/dm/config/task_test.go
+++ b/dm/config/task_test.go
@@ -234,7 +234,6 @@ mysql-instances:
 	taskConfig = NewTaskConfig()
 	err = taskConfig.Decode(errorTaskConfig)
 	c.Check(err, NotNil)
-	//c.Assert(err, ErrorMatches, "*The configurations as following [route-rule-2 filter-rule-2 column-mapping-rule-2] are set in global configuration but*")
 	c.Assert(err, ErrorMatches, `[\s\S]*The configurations as following \[column-mapping-rule-2 filter-rule-2 route-rule-2\] are set in global configuration[\s\S]*`)
 }
 

--- a/dm/config/task_test.go
+++ b/dm/config/task_test.go
@@ -14,7 +14,6 @@
 package config
 
 import (
-	"fmt"
 	"io/ioutil"
 	"path"
 	"sort"
@@ -131,7 +130,6 @@ mysql-instances:
 `
 	taskConfig := NewTaskConfig()
 	err := taskConfig.Decode(correctTaskConfig)
-	fmt.Println("-----error------", err)
 	c.Assert(err, IsNil)
 	var errorTaskConfig1 = `---
 name: test
@@ -235,7 +233,6 @@ mysql-instances:
 `
 	taskConfig = NewTaskConfig()
 	err = taskConfig.Decode(errorTaskConfig1)
-	fmt.Println("-----error1------", err)
 	c.Assert(err, NotNil)
 	var errorTaskConfig2 = `---
 name: test
@@ -336,7 +333,6 @@ mysql-instances:
 `
 	taskConfig = NewTaskConfig()
 	err = taskConfig.Decode(errorTaskConfig2)
-	fmt.Println("-----error2------", err)
 	c.Assert(err, NotNil)
 }
 

--- a/dm/config/task_test.go
+++ b/dm/config/task_test.go
@@ -234,7 +234,7 @@ mysql-instances:
 	taskConfig = NewTaskConfig()
 	err = taskConfig.Decode(errorTaskConfig)
 	c.Check(err, NotNil)
-	c.Assert(err, ErrorMatches, "*The configurations as following [route-rule-2 filter-rule-2 column-mapping-rule-2] are set in gobal configuration but*")
+	c.Assert(err, ErrorMatches, "*The configurations as following [route-rule-2 filter-rule-2 column-mapping-rule-2] are set in global configuration but*")
 }
 
 func (t *testConfig) TestInvalidTaskConfig(c *C) {

--- a/dm/config/task_test.go
+++ b/dm/config/task_test.go
@@ -234,7 +234,8 @@ mysql-instances:
 	taskConfig = NewTaskConfig()
 	err = taskConfig.Decode(errorTaskConfig)
 	c.Check(err, NotNil)
-	c.Assert(err, ErrorMatches, "*The configurations as following [route-rule-2 filter-rule-2 column-mapping-rule-2] are set in global configuration but*")
+	//c.Assert(err, ErrorMatches, "*The configurations as following [route-rule-2 filter-rule-2 column-mapping-rule-2] are set in global configuration but*")
+	c.Assert(err, ErrorMatches, `[\s\S]*The configurations as following [\s\S]* are set in global configuration[\s\S]*`)
 }
 
 func (t *testConfig) TestInvalidTaskConfig(c *C) {
@@ -469,7 +470,7 @@ filters:
 	c.Assert(err, IsNil)
 	taskConfig = NewTaskConfig()
 	err = taskConfig.DecodeFile(filepath)
-	c.Assert(err, IsNil)
+	c.Assert(err, NotNil)
 	c.Assert(taskConfig.IsSharding, IsTrue)
 	c.Assert(taskConfig.ShardMode, Equals, ShardOptimistic)
 	taskConfig.MySQLInstances[0].RouteRules = []string{"route-rule-1", "route-rule-2", "route-rule-1", "route-rule-2"}

--- a/dm/config/task_test.go
+++ b/dm/config/task_test.go
@@ -235,7 +235,7 @@ mysql-instances:
 	err = taskConfig.Decode(errorTaskConfig)
 	c.Check(err, NotNil)
 	//c.Assert(err, ErrorMatches, "*The configurations as following [route-rule-2 filter-rule-2 column-mapping-rule-2] are set in global configuration but*")
-	c.Assert(err, ErrorMatches, `[\s\S]*The configurations as following [\s\S]* are set in global configuration[\s\S]*`)
+	c.Assert(err, ErrorMatches, `[\s\S]*The configurations as following \[column-mapping-rule-2 filter-rule-2 route-rule-2\] are set in global configuration[\s\S]*`)
 }
 
 func (t *testConfig) TestInvalidTaskConfig(c *C) {

--- a/errors.toml
+++ b/errors.toml
@@ -1001,13 +1001,7 @@ workaround = "Please check the `filters` config in source and task configuration
 tags = ["internal", "high"]
 
 [error.DM-config-20038]
-message = "instances don't refer configurations with xxx-config-name"
-description = ""
-workaround = "Please check the configuration files."
-tags = ["internal", "high"]
-
-[error.DM-config-20039]
-message = "partial function configurations are set in gobal configurations but instances don't use them"
+message = "The configurations as following %v are set in gobal configuration but instances don't use them"
 description = ""
 workaround = "Please check the configuration files."
 tags = ["internal", "high"]

--- a/errors.toml
+++ b/errors.toml
@@ -1000,6 +1000,18 @@ description = ""
 workaround = "Please check the `filters` config in source and task configuration files."
 tags = ["internal", "high"]
 
+[error.DM-config-20038]
+message = "instances don't refer configurations with xxx-config-name"
+description = ""
+workaround = "Please check the configuration files."
+tags = ["internal", "high"]
+
+[error.DM-config-20039]
+message = "partial function configurations are set in gobal configurations but instances don't use them"
+description = ""
+workaround = "Please check the configuration files."
+tags = ["internal", "high"]
+
 [error.DM-binlog-op-22001]
 message = ""
 description = ""

--- a/errors.toml
+++ b/errors.toml
@@ -1001,7 +1001,7 @@ workaround = "Please check the `filters` config in source and task configuration
 tags = ["internal", "high"]
 
 [error.DM-config-20038]
-message = "The configurations as following %v are set in gobal configuration but instances don't use them"
+message = "The configurations as following %v are set in global configuration but instances don't use them"
 description = ""
 workaround = "Please check the configuration files."
 tags = ["internal", "high"]

--- a/pkg/terror/error_list.go
+++ b/pkg/terror/error_list.go
@@ -226,6 +226,7 @@ const (
 	codeConfigEtcdParse
 	codeConfigMissingForBound
 	codeConfigBinlogEventFilter
+	codeConfigGobalConfigUnused
 )
 
 // Binlog operation error code list
@@ -823,6 +824,7 @@ var (
 	ErrConfigEtcdParse              = New(codeConfigEtcdParse, ClassConfig, ScopeInternal, LevelHigh, "incapable config of %s from etcd", "")
 	ErrConfigMissingForBound        = New(codeConfigMissingForBound, ClassConfig, ScopeInternal, LevelHigh, "source bound %s doesn't have related source config in etcd", "")
 	ErrConfigBinlogEventFilter      = New(codeConfigBinlogEventFilter, ClassConfig, ScopeInternal, LevelHigh, "generate binlog event filter", "Please check the `filters` config in source and task configuration files.")
+	ErrConfigGobalConfigUnused      = New(codeConfigGobalConfigUnused, ClassConfig, ScopeInternal, LevelHigh, "partial function configurations are set in gobal configurations but instances don't use them", "Please check the configuration files.")
 
 	// Binlog operation error
 	ErrBinlogExtractPosition = New(codeBinlogExtractPosition, ClassBinlogOp, ScopeInternal, LevelHigh, "", "")

--- a/pkg/terror/error_list.go
+++ b/pkg/terror/error_list.go
@@ -226,6 +226,7 @@ const (
 	codeConfigEtcdParse
 	codeConfigMissingForBound
 	codeConfigBinlogEventFilter
+	codeConfigUnreferingConfig
 	codeConfigGobalConfigUnused
 )
 
@@ -824,6 +825,7 @@ var (
 	ErrConfigEtcdParse              = New(codeConfigEtcdParse, ClassConfig, ScopeInternal, LevelHigh, "incapable config of %s from etcd", "")
 	ErrConfigMissingForBound        = New(codeConfigMissingForBound, ClassConfig, ScopeInternal, LevelHigh, "source bound %s doesn't have related source config in etcd", "")
 	ErrConfigBinlogEventFilter      = New(codeConfigBinlogEventFilter, ClassConfig, ScopeInternal, LevelHigh, "generate binlog event filter", "Please check the `filters` config in source and task configuration files.")
+	ErrConfigUnreferingCofig        = New(codeConfigUnreferingConfig, ClassConfig, ScopeInternal, LevelHigh, "instances don't refer configurations with xxx-config-name", "Please check the configuration files.")
 	ErrConfigGobalConfigUnused      = New(codeConfigGobalConfigUnused, ClassConfig, ScopeInternal, LevelHigh, "partial function configurations are set in gobal configurations but instances don't use them", "Please check the configuration files.")
 
 	// Binlog operation error

--- a/pkg/terror/error_list.go
+++ b/pkg/terror/error_list.go
@@ -824,7 +824,7 @@ var (
 	ErrConfigEtcdParse              = New(codeConfigEtcdParse, ClassConfig, ScopeInternal, LevelHigh, "incapable config of %s from etcd", "")
 	ErrConfigMissingForBound        = New(codeConfigMissingForBound, ClassConfig, ScopeInternal, LevelHigh, "source bound %s doesn't have related source config in etcd", "")
 	ErrConfigBinlogEventFilter      = New(codeConfigBinlogEventFilter, ClassConfig, ScopeInternal, LevelHigh, "generate binlog event filter", "Please check the `filters` config in source and task configuration files.")
-	ErrConfigGlobalConfigsUnused    = New(codeConfigGlobalConfigsUnused, ClassConfig, ScopeInternal, LevelHigh, "The configurations as following %v are set in gobal configuration but instances don't use them", "Please check the configuration files.")
+	ErrConfigGlobalConfigsUnused    = New(codeConfigGlobalConfigsUnused, ClassConfig, ScopeInternal, LevelHigh, "The configurations as following %v are set in global configuration but instances don't use them", "Please check the configuration files.")
 
 	// Binlog operation error
 	ErrBinlogExtractPosition = New(codeBinlogExtractPosition, ClassBinlogOp, ScopeInternal, LevelHigh, "", "")

--- a/pkg/terror/error_list.go
+++ b/pkg/terror/error_list.go
@@ -226,8 +226,7 @@ const (
 	codeConfigEtcdParse
 	codeConfigMissingForBound
 	codeConfigBinlogEventFilter
-	codeConfigUnreferingConfig
-	codeConfigGobalConfigUnused
+	codeConfigGlobalConfigsUnused
 )
 
 // Binlog operation error code list
@@ -825,8 +824,7 @@ var (
 	ErrConfigEtcdParse              = New(codeConfigEtcdParse, ClassConfig, ScopeInternal, LevelHigh, "incapable config of %s from etcd", "")
 	ErrConfigMissingForBound        = New(codeConfigMissingForBound, ClassConfig, ScopeInternal, LevelHigh, "source bound %s doesn't have related source config in etcd", "")
 	ErrConfigBinlogEventFilter      = New(codeConfigBinlogEventFilter, ClassConfig, ScopeInternal, LevelHigh, "generate binlog event filter", "Please check the `filters` config in source and task configuration files.")
-	ErrConfigUnreferingCofig        = New(codeConfigUnreferingConfig, ClassConfig, ScopeInternal, LevelHigh, "instances don't refer configurations with xxx-config-name", "Please check the configuration files.")
-	ErrConfigGobalConfigUnused      = New(codeConfigGobalConfigUnused, ClassConfig, ScopeInternal, LevelHigh, "partial function configurations are set in gobal configurations but instances don't use them", "Please check the configuration files.")
+	ErrConfigGlobalConfigsUnused    = New(codeConfigGlobalConfigsUnused, ClassConfig, ScopeInternal, LevelHigh, "The configurations as following %v are set in gobal configuration but instances don't use them", "Please check the configuration files.")
 
 	// Binlog operation error
 	ErrBinlogExtractPosition = New(codeBinlogExtractPosition, ClassBinlogOp, ScopeInternal, LevelHigh, "", "")


### PR DESCRIPTION
…ut not use them

<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
For some configurations like routes/filters/mydumpers/loaders/syncers that users set in global configuration, this pr add “reference count” for these configurations.

### What is changed and how it works?
When some configurations are set in global configuration, but instances don't use thme. An error will return.

### Tests
+ unit test

