### PR TITLE
streamer: fix unstable CI introduced in #1364

### DIFF
--- a/pkg/streamer/reader.go
+++ b/pkg/streamer/reader.go
@@ -569,21 +569,13 @@ func (r *BinlogReader) parseFile(
 
 	wg.Add(1)
 	go func(latestPos int64) {
-		defer func() {
-			close(switchCh)
-			close(switchErrCh)
-			wg.Done()
-		}()
+		defer wg.Done()
 		needSwitchSubDir(newCtx, r.cfg.RelayDir, currentUUID, fullPath, latestPos, switchCh, switchErrCh)
 	}(latestPos)
 
 	wg.Add(1)
 	go func(latestPos int64) {
-		defer func() {
-			close(updatePathCh)
-			close(updateErrCh)
-			wg.Done()
-		}()
+		defer wg.Done()
 		relaySubDirUpdated(newCtx, watcherInterval, relayLogDir, fullPath, relayLogFile, latestPos, updatePathCh, updateErrCh)
 	}(latestPos)
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

in #1364, channels are closed in a goroutine when context is done, so in afterwards `select { case v := <- ch` we will read a `v` of zero value, which will cause wrong logic

https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/dm_ghpr_test/detail/dm_ghpr_test/8147/pipeline/72/

### What is changed and how it works?

we don't need to close channels if they are no longer referenced, gc will correctly clean them. (but if the values in channel need a explict `Close`, we should drain the channel and `Close` each one)

https://nanxiao.gitbooks.io/golang-101-hacks/content/posts/need-not-close-every-channel.html

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - hard to test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch (will cherry-pick to https://github.com/pingcap/dm/pull/1420 manually)
