### PR TITLE
tests: remove `use-rowid` and `sql-mode` properties configuration of integration tests

### DIFF
--- a/tests/all_mode/conf/diff_config.toml
+++ b/tests/all_mode/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"
@@ -43,7 +41,6 @@ port = 3306
 user = "root"
 password = "123456"
 instance-id = "source-1"
-sql-mode = "ANSI_QUOTES"
 
 [[source-db]]
 host = "127.0.0.1"
@@ -51,7 +48,6 @@ port = 3307
 user = "root"
 password = "123456"
 instance-id = "source-2"
-sql-mode = "ANSI_QUOTES"
 
 [target-db]
 host = "127.0.0.1"

--- a/tests/all_mode/data/db1.prepare.sql
+++ b/tests/all_mode/data/db1.prepare.sql
@@ -1,12 +1,10 @@
 drop database if exists `all_mode`;
 create database `all_mode`;
 use `all_mode`;
-create table t1 (id int NOT NULL AUTO_INCREMENT, name varchar(20), PRIMARY KEY (id));
+create table `t1` (`id` int NOT NULL AUTO_INCREMENT, `name` varchar(20), PRIMARY KEY (`id`));
 -- test ANSI_QUOTES works with quote in string
-insert into t1 (id, name) values (1, 'ar"ya'), (2, 'catelyn');
-
--- test sql_mode=NO_AUTO_VALUE_ON_ZERO
-insert into t1 (id, name) values (0, 'lalala');
+insert into `t1` (`id`, `name`) values (1, 'ar"ya'), (2, 'catelyn');
+insert into `t1` (`id`, `name`) values (0, 'lalala');
 
 -- test block-allow-list
 drop database if exists `ignore_db`;

--- a/tests/all_mode/data/db1.prepare.sql
+++ b/tests/all_mode/data/db1.prepare.sql
@@ -1,10 +1,12 @@
 drop database if exists `all_mode`;
 create database `all_mode`;
 use `all_mode`;
-create table `t1` (`id` int NOT NULL AUTO_INCREMENT, `name` varchar(20), PRIMARY KEY (`id`));
+create table t1 (id int NOT NULL AUTO_INCREMENT, name varchar(20), PRIMARY KEY (id));
 -- test ANSI_QUOTES works with quote in string
-insert into `t1` (`id`, `name`) values (1, 'ar"ya'), (2, 'catelyn');
-insert into `t1` (`id`, `name`) values (0, 'lalala');
+insert into t1 (id, name) values (1, 'ar"ya'), (2, 'catelyn');
+
+-- test sql_mode=NO_AUTO_VALUE_ON_ZERO
+insert into t1 (id, name) values (0, 'lalala');
 
 -- test block-allow-list
 drop database if exists `ignore_db`;

--- a/tests/all_mode/data/db2.prepare.sql
+++ b/tests/all_mode/data/db2.prepare.sql
@@ -1,8 +1,8 @@
 drop database if exists `all_mode`;
 create database `all_mode`;
 use `all_mode`;
-create table t2 (id int auto_increment, name varchar(20), primary key (`id`));
-insert into t2 (name) values ('Arya'), ('Bran'), ('Sansa');
+create table `t2` (`id` int AUTO_INCREMENT, `name` varchar(20), primary key (`id`));
+insert into `t2` (`name`) values ('Arya'), ('Bran'), ('Sansa');
 
 -- test block-allow-list
 drop database if exists `ignore_db`;

--- a/tests/all_mode/data/db2.prepare.sql
+++ b/tests/all_mode/data/db2.prepare.sql
@@ -1,8 +1,8 @@
 drop database if exists `all_mode`;
 create database `all_mode`;
 use `all_mode`;
-create table `t2` (`id` int AUTO_INCREMENT, `name` varchar(20), primary key (`id`));
-insert into `t2` (`name`) values ('Arya'), ('Bran'), ('Sansa');
+create table t2 (id int auto_increment, name varchar(20), primary key (`id`));
+insert into t2 (name) values ('Arya'), ('Bran'), ('Sansa');
 
 -- test block-allow-list
 drop database if exists `ignore_db`;

--- a/tests/compatibility/conf/diff_config.toml
+++ b/tests/compatibility/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/dm_syncer/conf/diff_config.toml
+++ b/tests/dm_syncer/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/dm_syncer/conf/diff_config_blalist.toml
+++ b/tests/dm_syncer/conf/diff_config_blalist.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/dm_syncer/conf/diff_config_route_rules.toml
+++ b/tests/dm_syncer/conf/diff_config_route_rules.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/dmctl_basic/conf/diff_config.toml
+++ b/tests/dmctl_basic/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/dmctl_basic/conf/diff_config.toml
+++ b/tests/dmctl_basic/conf/diff_config.toml
@@ -22,7 +22,6 @@ schema = "dmctl"
 table = "t_target"
 ignore-columns = ["id"]
 is-sharding = true
-index-fields = "b"
 
 [[table-config.source-tables]]
 instance-id = "source-1"

--- a/tests/dmctl_command/conf/diff_config.toml
+++ b/tests/dmctl_command/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/drop_column_with_index/conf/diff_config.toml
+++ b/tests/drop_column_with_index/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/full_mode/conf/diff_config.toml
+++ b/tests/full_mode/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/ha/conf/diff_config.toml
+++ b/tests/ha/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/ha_cases/conf/diff-standalone-config.toml
+++ b/tests/ha_cases/conf/diff-standalone-config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/ha_cases/conf/diff_config.toml
+++ b/tests/ha_cases/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/ha_cases/conf/diff_config_multi_task.toml
+++ b/tests/ha_cases/conf/diff_config_multi_task.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/ha_master/conf/diff_config.toml
+++ b/tests/ha_master/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/handle_error/conf/diff_config.toml
+++ b/tests/handle_error/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/http_apis/conf/diff_config.toml
+++ b/tests/http_apis/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/import_v10x/conf/diff_config.toml
+++ b/tests/import_v10x/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/import_v10x/conf/diff_config.toml
+++ b/tests/import_v10x/conf/diff_config.toml
@@ -41,7 +41,6 @@ port = 3306
 user = "root"
 password = "123456"
 instance-id = "source-1"
-sql-mode = "ANSI_QUOTES"
 
 [[source-db]]
 host = "127.0.0.1"
@@ -49,7 +48,6 @@ port = 3307
 user = "root"
 password = "123456"
 instance-id = "source-2"
-sql-mode = "ANSI_QUOTES"
 
 [target-db]
 host = "127.0.0.1"

--- a/tests/incremental_mode/conf/diff_config.toml
+++ b/tests/incremental_mode/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/initial_unit/conf/diff_config.toml
+++ b/tests/initial_unit/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/load_interrupt/conf/diff_config.toml
+++ b/tests/load_interrupt/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/many_tables/conf/diff_config.toml
+++ b/tests/many_tables/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/online_ddl/conf/diff_config.toml
+++ b/tests/online_ddl/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/online_ddl/conf/diff_config.toml
+++ b/tests/online_ddl/conf/diff_config.toml
@@ -22,7 +22,6 @@ schema = "online_ddl"
 table = "t_target"
 ignore-columns = ["id"]
 is-sharding = true
-index-field = "uid"
 
 [[table-config.source-tables]]
 instance-id = "source-1"

--- a/tests/print_status/conf/diff_config.toml
+++ b/tests/print_status/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 use-checkpoint = false

--- a/tests/relay_interrupt/conf/diff_config.toml
+++ b/tests/relay_interrupt/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/retry_cancel/conf/diff_config.toml
+++ b/tests/retry_cancel/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/safe_mode/conf/diff_config.toml
+++ b/tests/safe_mode/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/safe_mode/conf/diff_config.toml
+++ b/tests/safe_mode/conf/diff_config.toml
@@ -22,7 +22,6 @@ schema = "safe_mode_target"
 table = "t_target"
 ignore-columns = ["id"]
 is-sharding = true
-index-field = "uid"
 
 [[table-config.source-tables]]
 instance-id = "source-1"

--- a/tests/sequence_safe_mode/conf/diff_config.toml
+++ b/tests/sequence_safe_mode/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/sequence_safe_mode/conf/diff_config.toml
+++ b/tests/sequence_safe_mode/conf/diff_config.toml
@@ -22,7 +22,6 @@ schema = "sequence_safe_mode_target"
 table = "t_target"
 ignore-columns = ["id"]
 is-sharding = true
-index-field = "uid"
 
 [[table-config.source-tables]]
 instance-id = "source-1"

--- a/tests/sequence_sharding/conf/diff_config.toml
+++ b/tests/sequence_sharding/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/sequence_sharding_optimistic/conf/diff_config.toml
+++ b/tests/sequence_sharding_optimistic/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/sequence_sharding_removemeta/conf/diff_config.toml
+++ b/tests/sequence_sharding_removemeta/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/shardddl1/conf/diff_config.toml
+++ b/tests/shardddl1/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/shardddl2/conf/diff_config.toml
+++ b/tests/shardddl2/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/shardddl3/conf/diff_config.toml
+++ b/tests/shardddl3/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/sharding/conf/diff_config.toml
+++ b/tests/sharding/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/sharding2/conf/diff_config.toml
+++ b/tests/sharding2/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/start_task/conf/diff_config.toml
+++ b/tests/start_task/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"


### PR DESCRIPTION
### What problem does this PR solve?

resolve #1435

### What is changed and how it works?

remove `use-rowid` and `sql-mode` properties configuration of integration tests

### Check List 

Tests 

 - Integration test

Code changes

 - No

Side effects

-  No

Related changes

 - Need to cherry-pick to the release branch

