### PR TITLE
grafana: fix duplicate panel id and position

### DIFF
--- a/dm/dm-ansible/scripts/dm.json
+++ b/dm/dm-ansible/scripts/dm.json
@@ -2007,7 +2007,7 @@
             "x": 12,
             "y": 10
           },
-          "id": 5,
+          "id": 7,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -2495,7 +2495,7 @@
           "gridPos": {
             "h": 7,
             "w": 6,
-            "x": 12,
+            "x": 18,
             "y": 17
           },
           "id": 25,


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
there's two `"id": 5` and `x, y = 12, 17` panels

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the `dm/dm-ansible`
