### PR TITLE
shardddl: support combine ddls in one sql for optimistic sharding mode

### DIFF
--- a/_utils/terror_gen/errors_release.txt
+++ b/_utils/terror_gen/errors_release.txt
@@ -371,6 +371,7 @@ ErrMasterAdvertisePeerURLsNotValid,[code=38050:class=dm-master:scope=internal:le
 ErrMasterTLSConfigNotValid,[code=38051:class=dm-master:scope=internal:level=high], "Message: TLS config not valid, Workaround: Please check the `ssl-ca`, `ssl-cert` and `ssl-key` config in master configuration file."
 ErrMasterBoundChanging,[code=38052:class=dm-master:scope=internal:level=low], "Message: source bound is changed too frequently, last old bound %s:, new bound %s, Workaround: Please try again later"
 ErrMasterFailToImportFromV10x,[code=38053:class=dm-master:scope=internal:level=high], "Message: fail to import DM cluster from v1.0.x, Workaround: Please confirm that you have not violated any restrictions in the upgrade documentation."
+ErrMasterInconsistentOptimisticDDLsAndInfo,[code=38054:class=dm-master:scope=internal:level=high], "Message: inconsistent count of optimistic ddls and table infos, ddls: %d, table info: %d"
 ErrWorkerParseFlagSet,[code=40001:class=dm-worker:scope=internal:level=medium], "Message: parse dm-worker config flag set"
 ErrWorkerInvalidFlag,[code=40002:class=dm-worker:scope=internal:level=medium], "Message: '%s' is an invalid flag"
 ErrWorkerDecodeConfigFromFile,[code=40003:class=dm-worker:scope=internal:level=medium], "Message: toml decode file, Workaround: Please check the configuration file has correct TOML format."

--- a/dm/master/server_test.go
+++ b/dm/master/server_test.go
@@ -633,7 +633,7 @@ func (t *testMaster) TestStartTaskWithRemoveMeta(c *check.C) {
 		DDLs1    = []string{"ALTER TABLE bar ADD COLUMN c1 INT"}
 		tiBefore = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY)`)
 		tiAfter1 = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 TEXT)`)
-		info1    = optimism.NewInfo(taskName, sources[0], "foo-1", "bar-1", schema, table, DDLs1, tiBefore, tiAfter1)
+		info1    = optimism.NewInfo(taskName, sources[0], "foo-1", "bar-1", schema, table, DDLs1, tiBefore, []*model.TableInfo{tiAfter1})
 		op1      = optimism.NewOperation(ID, taskName, sources[0], info1.UpSchema, info1.UpTable, DDLs1, optimism.ConflictNone, false)
 	)
 

--- a/dm/master/shardddl/optimist_test.go
+++ b/dm/master/shardddl/optimist_test.go
@@ -191,13 +191,13 @@ func (t *testOptimist) testOptimist(c *C, restart int) {
 		ti1              = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 INT)`)
 		ti2              = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 INT, c2 INT)`)
 		ti3              = ti1
-		i11              = optimism.NewInfo(task, source1, "foo", "bar-1", downSchema, downTable, DDLs1, ti0, ti1)
-		i12              = optimism.NewInfo(task, source1, "foo", "bar-2", downSchema, downTable, DDLs1, ti0, ti1)
-		i21              = optimism.NewInfo(task, source1, "foo", "bar-1", downSchema, downTable, DDLs2, ti1, ti2)
+		i11              = optimism.NewInfo(task, source1, "foo", "bar-1", downSchema, downTable, DDLs1, ti0, []*model.TableInfo{ti1})
+		i12              = optimism.NewInfo(task, source1, "foo", "bar-2", downSchema, downTable, DDLs1, ti0, []*model.TableInfo{ti1})
+		i21              = optimism.NewInfo(task, source1, "foo", "bar-1", downSchema, downTable, DDLs2, ti1, []*model.TableInfo{ti2})
 		i23              = optimism.NewInfo(task, source2, "foo-2", "bar-3", downSchema, downTable,
-			[]string{`CREATE TABLE bar (id INT PRIMARY KEY, c1 INT, c2 INT)`}, ti2, ti2)
-		i31 = optimism.NewInfo(task, source1, "foo", "bar-1", downSchema, downTable, DDLs3, ti2, ti3)
-		i33 = optimism.NewInfo(task, source2, "foo-2", "bar-3", downSchema, downTable, DDLs3, ti2, ti3)
+			[]string{`CREATE TABLE bar (id INT PRIMARY KEY, c1 INT, c2 INT)`}, ti2, []*model.TableInfo{ti2})
+		i31 = optimism.NewInfo(task, source1, "foo", "bar-1", downSchema, downTable, DDLs3, ti2, []*model.TableInfo{ti3})
+		i33 = optimism.NewInfo(task, source2, "foo-2", "bar-3", downSchema, downTable, DDLs3, ti2, []*model.TableInfo{ti3})
 	)
 
 	st1.AddTable("foo", "bar-1", downSchema, downTable)
@@ -661,9 +661,9 @@ func (t *testOptimist) TestOptimistLockConflict(c *C) {
 		ti1                = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 TEXT)`)
 		ti2                = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 DATETIME)`)
 		ti3                = ti0
-		i1                 = optimism.NewInfo(task, source1, "foo", "bar-1", downSchema, downTable, DDLs1, ti0, ti1)
-		i2                 = optimism.NewInfo(task, source1, "foo", "bar-2", downSchema, downTable, DDLs2, ti0, ti2)
-		i3                 = optimism.NewInfo(task, source1, "foo", "bar-2", downSchema, downTable, DDLs3, ti2, ti3)
+		i1                 = optimism.NewInfo(task, source1, "foo", "bar-1", downSchema, downTable, DDLs1, ti0, []*model.TableInfo{ti1})
+		i2                 = optimism.NewInfo(task, source1, "foo", "bar-2", downSchema, downTable, DDLs2, ti0, []*model.TableInfo{ti2})
+		i3                 = optimism.NewInfo(task, source1, "foo", "bar-2", downSchema, downTable, DDLs3, ti2, []*model.TableInfo{ti3})
 	)
 
 	st1.AddTable("foo", "bar-1", downSchema, downTable)
@@ -756,10 +756,10 @@ func (t *testOptimist) TestOptimistLockMultipleTarget(c *C) {
 		DDLs               = []string{"ALTER TABLE bar ADD COLUMN c1 TEXT"}
 		ti0                = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY)`)
 		ti1                = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 TEXT)`)
-		i11                = optimism.NewInfo(task, source, upSchema, upTables[0], downSchema, downTable1, DDLs, ti0, ti1)
-		i12                = optimism.NewInfo(task, source, upSchema, upTables[1], downSchema, downTable1, DDLs, ti0, ti1)
-		i21                = optimism.NewInfo(task, source, upSchema, upTables[2], downSchema, downTable2, DDLs, ti0, ti1)
-		i22                = optimism.NewInfo(task, source, upSchema, upTables[3], downSchema, downTable2, DDLs, ti0, ti1)
+		i11                = optimism.NewInfo(task, source, upSchema, upTables[0], downSchema, downTable1, DDLs, ti0, []*model.TableInfo{ti1})
+		i12                = optimism.NewInfo(task, source, upSchema, upTables[1], downSchema, downTable1, DDLs, ti0, []*model.TableInfo{ti1})
+		i21                = optimism.NewInfo(task, source, upSchema, upTables[2], downSchema, downTable2, DDLs, ti0, []*model.TableInfo{ti1})
+		i22                = optimism.NewInfo(task, source, upSchema, upTables[3], downSchema, downTable2, DDLs, ti0, []*model.TableInfo{ti1})
 	)
 
 	sts.AddTable(upSchema, upTables[0], downSchema, downTable1)
@@ -941,9 +941,9 @@ func (t *testOptimist) TestOptimistInitSchema(c *C) {
 		ti0         = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY)`)
 		ti1         = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 TEXT)`)
 		ti2         = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 TEXT, c2 INT)`)
-		i11         = optimism.NewInfo(task, source, upSchema, upTables[0], downSchema, downTable, DDLs1, ti0, ti1)
-		i12         = optimism.NewInfo(task, source, upSchema, upTables[1], downSchema, downTable, DDLs1, ti0, ti1)
-		i21         = optimism.NewInfo(task, source, upSchema, upTables[0], downSchema, downTable, DDLs2, ti1, ti2)
+		i11         = optimism.NewInfo(task, source, upSchema, upTables[0], downSchema, downTable, DDLs1, ti0, []*model.TableInfo{ti1})
+		i12         = optimism.NewInfo(task, source, upSchema, upTables[1], downSchema, downTable, DDLs1, ti0, []*model.TableInfo{ti1})
+		i21         = optimism.NewInfo(task, source, upSchema, upTables[0], downSchema, downTable, DDLs2, ti1, []*model.TableInfo{ti2})
 	)
 
 	st.AddTable(upSchema, upTables[0], downSchema, downTable)

--- a/errors.toml
+++ b/errors.toml
@@ -2236,6 +2236,12 @@ description = ""
 workaround = "Please confirm that you have not violated any restrictions in the upgrade documentation."
 tags = ["internal", "high"]
 
+[error.DM-dm-master-38054]
+message = "inconsistent count of optimistic ddls and table infos, ddls: %d, table info: %d"
+description = ""
+workaround = ""
+tags = ["internal", "high"]
+
 [error.DM-dm-worker-40001]
 message = "parse dm-worker config flag set"
 description = ""

--- a/pkg/ha/keepalive.go
+++ b/pkg/ha/keepalive.go
@@ -99,9 +99,9 @@ func KeepAlive(ctx context.Context, cli *clientv3.Client, workerName string, kee
 	grantAndPutKV := func(k, v string, ttl int64) (clientv3.LeaseID, error) {
 		cliCtx, cancel := context.WithTimeout(ctx, etcdutil.DefaultRequestTimeout)
 		defer cancel()
-		lease, err := cli.Grant(cliCtx, ttl)
-		if err != nil {
-			return 0, err
+		lease, err2 := cli.Grant(cliCtx, ttl)
+		if err2 != nil {
+			return 0, err2
 		}
 		_, err = cli.Put(cliCtx, k, v, clientv3.WithLease(lease.ID))
 		if err != nil {

--- a/pkg/shardddl/optimism/info.go
+++ b/pkg/shardddl/optimism/info.go
@@ -44,8 +44,8 @@ type Info struct {
 	DownTable  string   `json:"down-table"`  // downstream/target table name
 	DDLs       []string `json:"ddls"`        // DDL statements
 
-	TableInfoBefore *model.TableInfo `json:"table-info-before"` // the tracked table schema before applying the DDLs
-	TableInfoAfter  *model.TableInfo `json:"table-info-after"`  // the tracked table schema after applying the DDLs
+	TableInfoBefore *model.TableInfo   `json:"table-info-before"` // the tracked table schema before applying the DDLs
+	TableInfosAfter []*model.TableInfo `json:"table-info-after"`  // the tracked table schema after applying the DDLs
 
 	// only used to report to the caller of the watcher, do not marsh it.
 	// if it's true, it means the Info has been deleted in etcd.
@@ -57,7 +57,7 @@ type Info struct {
 
 // NewInfo creates a new Info instance.
 func NewInfo(task, source, upSchema, upTable, downSchema, downTable string,
-	DDLs []string, tableInfoBefore, tableInfoAfter *model.TableInfo) Info {
+	DDLs []string, tableInfoBefore *model.TableInfo, tableInfosAfter []*model.TableInfo) Info {
 	return Info{
 		Task:            task,
 		Source:          source,
@@ -67,7 +67,7 @@ func NewInfo(task, source, upSchema, upTable, downSchema, downTable string,
 		DownTable:       downTable,
 		DDLs:            DDLs,
 		TableInfoBefore: tableInfoBefore,
-		TableInfoAfter:  tableInfoAfter,
+		TableInfosAfter: tableInfosAfter,
 	}
 }
 

--- a/pkg/shardddl/optimism/info_test.go
+++ b/pkg/shardddl/optimism/info_test.go
@@ -105,9 +105,9 @@ func (t *testForEtcd) TestInfoEtcd(c *C) {
 		tblI2              = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 INT)`)
 		tblI3              = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 INT, c2 INT)`)
 		tblI4              = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 INT, c2 INT, c3 INT)`)
-		i11                = NewInfo(task1, source1, upSchema, upTable, downSchema, downTable, []string{"ALTER TABLE bar ADD COLUMN c1 INT"}, tblI1, tblI2)
-		i12                = NewInfo(task1, source2, upSchema, upTable, downSchema, downTable, []string{"ALTER TABLE bar ADD COLUMN c2 INT"}, tblI2, tblI3)
-		i21                = NewInfo(task2, source1, upSchema, upTable, downSchema, downTable, []string{"ALTER TABLE bar ADD COLUMN c3 INT"}, tblI3, tblI4)
+		i11                = NewInfo(task1, source1, upSchema, upTable, downSchema, downTable, []string{"ALTER TABLE bar ADD COLUMN c1 INT"}, tblI1, []*model.TableInfo{tblI2})
+		i12                = NewInfo(task1, source2, upSchema, upTable, downSchema, downTable, []string{"ALTER TABLE bar ADD COLUMN c2 INT"}, tblI2, []*model.TableInfo{tblI3})
+		i21                = NewInfo(task2, source1, upSchema, upTable, downSchema, downTable, []string{"ALTER TABLE bar ADD COLUMN c3 INT"}, tblI3, []*model.TableInfo{tblI4})
 	)
 
 	// put the same key twice.

--- a/pkg/shardddl/optimism/keeper.go
+++ b/pkg/shardddl/optimism/keeper.go
@@ -50,7 +50,7 @@ func (lk *LockKeeper) TrySync(info Info, tts []TargetTable) (string, []string, e
 		l = lk.locks[lockID]
 	}
 
-	newDDLs, err := l.TrySync(info.Source, info.UpSchema, info.UpTable, info.DDLs, info.TableInfoAfter, tts, info.Version)
+	newDDLs, err := l.TrySync(info.Source, info.UpSchema, info.UpTable, info.DDLs, info.TableInfosAfter, tts, info.Version)
 	return lockID, newDDLs, err
 }
 

--- a/pkg/shardddl/optimism/keeper_test.go
+++ b/pkg/shardddl/optimism/keeper_test.go
@@ -16,6 +16,7 @@ package optimism
 import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser"
+	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/util/mock"
 )
 
@@ -42,9 +43,9 @@ func (t *testKeeper) TestLockKeeper(c *C) {
 		tiBefore       = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY)`)
 		tiAfter        = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 INT)`)
 
-		i11 = NewInfo(task1, source1, upSchema, upTable, downSchema, downTable, DDLs, tiBefore, tiAfter)
-		i12 = NewInfo(task1, source2, upSchema, upTable, downSchema, downTable, DDLs, tiBefore, tiAfter)
-		i21 = NewInfo(task2, source1, upSchema, upTable, downSchema, downTable, DDLs, tiBefore, tiAfter)
+		i11 = NewInfo(task1, source1, upSchema, upTable, downSchema, downTable, DDLs, tiBefore, []*model.TableInfo{tiAfter})
+		i12 = NewInfo(task1, source2, upSchema, upTable, downSchema, downTable, DDLs, tiBefore, []*model.TableInfo{tiAfter})
+		i21 = NewInfo(task2, source1, upSchema, upTable, downSchema, downTable, DDLs, tiBefore, []*model.TableInfo{tiAfter})
 
 		tts1 = []TargetTable{
 			newTargetTable(task1, source1, downSchema, downTable, map[string]map[string]struct{}{upSchema: {upTable: struct{}{}}}),
@@ -131,10 +132,10 @@ func (t *testKeeper) TestLockKeeperMultipleTarget(c *C) {
 		tiBefore       = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY)`)
 		tiAfter        = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 INT)`)
 
-		i11 = NewInfo(task, source, upSchema, upTables[0], downSchema, downTable1, DDLs, tiBefore, tiAfter)
-		i12 = NewInfo(task, source, upSchema, upTables[1], downSchema, downTable1, DDLs, tiBefore, tiAfter)
-		i21 = NewInfo(task, source, upSchema, upTables[0], downSchema, downTable2, DDLs, tiBefore, tiAfter)
-		i22 = NewInfo(task, source, upSchema, upTables[1], downSchema, downTable2, DDLs, tiBefore, tiAfter)
+		i11 = NewInfo(task, source, upSchema, upTables[0], downSchema, downTable1, DDLs, tiBefore, []*model.TableInfo{tiAfter})
+		i12 = NewInfo(task, source, upSchema, upTables[1], downSchema, downTable1, DDLs, tiBefore, []*model.TableInfo{tiAfter})
+		i21 = NewInfo(task, source, upSchema, upTables[0], downSchema, downTable2, DDLs, tiBefore, []*model.TableInfo{tiAfter})
+		i22 = NewInfo(task, source, upSchema, upTables[1], downSchema, downTable2, DDLs, tiBefore, []*model.TableInfo{tiAfter})
 
 		tts1 = []TargetTable{
 			newTargetTable(task, source, downSchema, downTable1, map[string]map[string]struct{}{

--- a/pkg/shardddl/optimism/lock.go
+++ b/pkg/shardddl/optimism/lock.go
@@ -90,7 +90,7 @@ func NewLock(ID, task, downSchema, downTable string, ti *model.TableInfo, tts []
 // for non-intrusive, a broadcast mechanism needed to notify conflict tables after the conflict has resolved, or even a block mechanism needed.
 // for intrusive, a DML prune or transform mechanism needed for two different schemas (before and after the conflict resolved).
 func (l *Lock) TrySync(callerSource, callerSchema, callerTable string,
-	ddls []string, newTI *model.TableInfo, tts []TargetTable, infoVersion int64) (newDDLs []string, err error) {
+	ddls []string, newTIs []*model.TableInfo, tts []TargetTable, infoVersion int64) (newDDLs []string, err error) {
 	l.mu.Lock()
 	defer func() {
 		if len(newDDLs) > 0 {
@@ -100,33 +100,6 @@ func (l *Lock) TrySync(callerSource, callerSchema, callerTable string,
 		}
 		l.mu.Unlock()
 	}()
-
-	// handle the case where <callerSource, callerSchema, callerTable>
-	// is not in old source tables and current new source tables.
-	// duplicate append is not a problem.
-	tts = append(tts, newTargetTable(l.Task, callerSource, l.DownSchema, l.DownTable,
-		map[string]map[string]struct{}{callerSchema: {callerTable: struct{}{}}}))
-	// add any new source tables.
-	l.addTables(tts)
-	if val, ok := l.versions[callerSource][callerSchema][callerTable]; !ok || val < infoVersion {
-		l.versions[callerSource][callerSchema][callerTable] = infoVersion
-	}
-
-	var emptyDDLs = []string{}
-	oldTable := l.tables[callerSource][callerSchema][callerTable]
-	newTable := schemacmp.Encode(newTI)
-
-	// special case: check whether DDLs making the schema become part of larger and another part of smaller.
-	if _, err = oldTable.Compare(newTable); err != nil {
-		return emptyDDLs, terror.ErrShardDDLOptimismTrySyncFail.Delegate(
-			err, l.ID, fmt.Sprintf("there will be conflicts if DDLs %s are applied to the downstream. old table info: %s, new table info: %s", ddls, oldTable, newTable))
-	}
-
-	oldJoined := l.joined
-	newJoined := newTable
-	l.tables[callerSource][callerSchema][callerTable] = newTable
-	log.L().Info("update table info", zap.String("lock", l.ID), zap.String("source", callerSource), zap.String("schema", callerSchema), zap.String("table", callerTable),
-		zap.Stringer("from", oldTable), zap.Stringer("to", newTable), zap.Strings("ddls", ddls))
 
 	oldSynced := l.synced
 	defer func() {
@@ -141,94 +114,133 @@ func (l *Lock) TrySync(callerSource, callerSchema, callerTable string,
 		}
 	}()
 
-	// special case: if the DDL does not affect the schema at all, assume it is
-	// idempotent and just execute the DDL directly.
-	// if any real conflicts after joined exist, they will be detected by the following steps.
-	var cmp int
-	if cmp, err = newTable.Compare(oldJoined); err == nil && cmp == 0 {
-		return ddls, nil
+	// handle the case where <callerSource, callerSchema, callerTable>
+	// is not in old source tables and current new source tables.
+	// duplicate append is not a problem.
+	tts = append(tts, newTargetTable(l.Task, callerSource, l.DownSchema, l.DownTable,
+		map[string]map[string]struct{}{callerSchema: {callerTable: struct{}{}}}))
+	// add any new source tables.
+	l.addTables(tts)
+	if val, ok := l.versions[callerSource][callerSchema][callerTable]; !ok || val < infoVersion {
+		l.versions[callerSource][callerSchema][callerTable] = infoVersion
 	}
 
-	// try to join tables.
-	for source, schemaTables := range l.tables {
-		for schema, tables := range schemaTables {
-			for table, ti := range tables {
-				if source != callerSource || schema != callerSchema || table != callerTable {
-					newJoined2, err2 := newJoined.Join(ti)
-					if err2 != nil {
-						// NOTE: conflict detected.
-						return emptyDDLs, terror.ErrShardDDLOptimismTrySyncFail.Delegate(
-							err2, l.ID, fmt.Sprintf("fail to join table info %s with %s", newJoined, ti))
+	var emptyDDLs = []string{}
+	newDDLs = []string{}
+	oldTable := l.tables[callerSource][callerSchema][callerTable]
+	oldJoined := l.joined
+	newTable := oldTable
+	newJoined := oldJoined
+
+	for idx, newTI := range newTIs {
+		oldTable = newTable
+		oldJoined = newJoined
+		newTable = schemacmp.Encode(newTI)
+		// special case: check whether DDLs making the schema become part of larger and another part of smaller.
+		if _, err = oldTable.Compare(newTable); err != nil {
+			return emptyDDLs, terror.ErrShardDDLOptimismTrySyncFail.Delegate(
+				err, l.ID, fmt.Sprintf("there will be conflicts if DDLs %s are applied to the downstream. old table info: %s, new table info: %s", ddls, oldTable, newTable))
+		}
+		newJoined = newTable
+
+		// special case: if the DDL does not affect the schema at all, assume it is
+		// idempotent and just execute the DDL directly.
+		// if any real conflicts after joined exist, they will be detected by the following steps.
+		var cmp int
+		if cmp, err = newTable.Compare(oldJoined); err == nil && cmp == 0 {
+			newDDLs = append(newDDLs, ddls[idx])
+			continue
+		}
+
+		// try to join tables.
+		for source, schemaTables := range l.tables {
+			for schema, tables := range schemaTables {
+				for table, ti := range tables {
+					if source != callerSource || schema != callerSchema || table != callerTable {
+						newJoined2, err2 := newJoined.Join(ti)
+						if err2 != nil {
+							// NOTE: conflict detected.
+							return emptyDDLs, terror.ErrShardDDLOptimismTrySyncFail.Delegate(
+								err2, l.ID, fmt.Sprintf("fail to join table info %s with %s", newJoined, ti))
+						}
+						newJoined = newJoined2
 					}
-					newJoined = newJoined2
 				}
 			}
 		}
+
+		cmp, err = oldJoined.Compare(newJoined)
+		// FIXME: Compute DDLs through schema diff instead of propagating DDLs directly.
+		// and now we MUST ensure different sources execute same DDLs to the downstream multiple times is safe.
+		if err != nil {
+			// resolving conflict in non-intrusive mode.
+			log.L().Warn("resolving conflict", zap.String("lock", l.ID), zap.String("source", callerSource), zap.String("schema", callerSchema), zap.String("table", callerTable),
+				zap.Stringer("joined-from", oldJoined), zap.Stringer("joined-to", newJoined), zap.Strings("ddls", ddls))
+			return ddls, nil
+		}
+		if cmp != 0 {
+			// < 0: the joined schema become larger after applied these DDLs.
+			//      this often happens when executing `ADD COLUMN` for the FIRST table.
+			// > 0: the joined schema become smaller after applied these DDLs.
+			//      this often happens when executing `DROP COLUMN` for the LAST table.
+			// for these two cases, we should execute the DDLs to the downstream to update the schema.
+			log.L().Info("joined table info changed", zap.String("lock", l.ID), zap.Int("cmp", cmp), zap.Stringer("from", oldJoined), zap.Stringer("to", newJoined),
+				zap.String("source", callerSource), zap.String("schema", callerSchema), zap.String("table", callerTable), zap.Strings("ddls", ddls))
+			newDDLs = append(newDDLs, ddls[idx])
+			continue
+		}
+
+		// NOTE: now, different DM-workers do not wait for each other when executing DDL/DML,
+		// when coordinating the shard DDL between multiple DM-worker instances,
+		// a possible sequences:
+		//   1. DM-worker-A do this `trySync` and DM-master let it to `ADD COLUMN`.
+		//   2. DM-worker-B do this `trySync` again.
+		//   3. DM-worker-B replicate DML to the downstream.
+		//   4. DM-worker-A replicate `ADD COLUMN` to the downstream.
+		// in order to support DML from DM-worker-B matches the downstream schema,
+		// two strategies exist:
+		//   A. DM-worker-B waits for DM-worker-A to finish the replication of the DDL before replicating DML.
+		//   B. DM-worker-B also replicates the DDL before replicating DML,
+		//      but this MUST ensure we can tolerate replicating the DDL multiple times.
+		// for `DROP COLUMN` or other DDL which makes the schema become smaller,
+		// this is not a problem because all DML with larger schema should already replicated to the downstream,
+		// and any DML with smaller schema can fit both the larger or smaller schema.
+		// To make it easy to implement, we will temporarily choose strategy-B.
+
+		cmp, _ = oldTable.Compare(newTable) // we have checked `err` returned above.
+		if cmp < 0 {
+			// let every table to replicate the DDL.
+			newDDLs = append(newDDLs, ddls[idx])
+			continue
+		} else if cmp > 0 {
+			// do nothing except the last table.
+			continue
+		}
+
+		// compare the current table's info with joined info.
+		cmp, err = newTable.Compare(newJoined)
+		if err != nil {
+			return emptyDDLs, terror.ErrShardDDLOptimismTrySyncFail.Delegate(
+				err, l.ID, "can't compare table info (new table info) %s with (new joined table info) %s", newTable, newJoined) // NOTE: this should not happen.
+		}
+		if cmp < 0 {
+			// no need to replicate DDLs, because has a larger joined schema (in the downstream).
+			// FIXME: if the previous tables reached the joined schema has not replicated to the downstream,
+			// now, they should re-try until replicated successfully, try to implement better strategy later.
+			continue
+		}
+		log.L().Warn("new table info >= new joined table info", zap.Stringer("table info", newTable), zap.Stringer("joined table info", newJoined))
+		return ddls, nil // NOTE: this should not happen.
 	}
+
+	log.L().Info("update table info", zap.String("lock", l.ID), zap.String("source", callerSource), zap.String("schema", callerSchema), zap.String("table", callerTable),
+		zap.Stringer("from", l.tables[callerSource][callerSchema][callerTable]), zap.Stringer("to", newTable), zap.Strings("ddls", ddls))
+	l.tables[callerSource][callerSchema][callerTable] = newTable
 
 	// update the current joined table info, if it's actually changed it should be logged in `if cmp != 0` block.
 	l.joined = newJoined
 
-	cmp, err = oldJoined.Compare(newJoined)
-	// FIXME: Compute DDLs through schema diff instead of propagating DDLs directly.
-	// and now we MUST ensure different sources execute same DDLs to the downstream multiple times is safe.
-	if err != nil {
-		// resolving conflict in non-intrusive mode.
-		log.L().Warn("resolving conflict", zap.String("lock", l.ID), zap.String("source", callerSource), zap.String("schema", callerSchema), zap.String("table", callerTable),
-			zap.Stringer("joined-from", oldJoined), zap.Stringer("joined-to", newJoined), zap.Strings("ddls", ddls))
-		return ddls, nil
-	}
-	if cmp != 0 {
-		// < 0: the joined schema become larger after applied these DDLs.
-		//      this often happens when executing `ADD COLUMN` for the FIRST table.
-		// > 0: the joined schema become smaller after applied these DDLs.
-		//      this often happens when executing `DROP COLUMN` for the LAST table.
-		// for these two cases, we should execute the DDLs to the downstream to update the schema.
-		log.L().Info("joined table info changed", zap.String("lock", l.ID), zap.Int("cmp", cmp), zap.Stringer("from", oldJoined), zap.Stringer("to", newJoined),
-			zap.String("source", callerSource), zap.String("schema", callerSchema), zap.String("table", callerTable), zap.Strings("ddls", ddls))
-		return ddls, nil
-	}
-
-	// NOTE: now, different DM-workers do not wait for each other when executing DDL/DML,
-	// when coordinating the shard DDL between multiple DM-worker instances,
-	// a possible sequences:
-	//   1. DM-worker-A do this `trySync` and DM-master let it to `ADD COLUMN`.
-	//   2. DM-worker-B do this `trySync` again.
-	//   3. DM-worker-B replicate DML to the downstream.
-	//   4. DM-worker-A replicate `ADD COLUMN` to the downstream.
-	// in order to support DML from DM-worker-B matches the downstream schema,
-	// two strategies exist:
-	//   A. DM-worker-B waits for DM-worker-A to finish the replication of the DDL before replicating DML.
-	//   B. DM-worker-B also replicates the DDL before replicating DML,
-	//      but this MUST ensure we can tolerate replicating the DDL multiple times.
-	// for `DROP COLUMN` or other DDL which makes the schema become smaller,
-	// this is not a problem because all DML with larger schema should already replicated to the downstream,
-	// and any DML with smaller schema can fit both the larger or smaller schema.
-	// To make it easy to implement, we will temporarily choose strategy-B.
-
-	cmp, _ = oldTable.Compare(newTable) // we have checked `err` returned above.
-	if cmp < 0 {
-		// let every table to replicate the DDL.
-		return ddls, nil
-	} else if cmp > 0 {
-		// do nothing except the last table.
-		return emptyDDLs, nil
-	}
-
-	// compare the current table's info with joined info.
-	cmp, err = newTable.Compare(newJoined)
-	if err != nil {
-		return emptyDDLs, terror.ErrShardDDLOptimismTrySyncFail.Delegate(
-			err, l.ID, "can't compare table info (new table info) %s with (new joined table info) %s", newTable, newJoined) // NOTE: this should not happen.
-	}
-	if cmp < 0 {
-		// no need to replicate DDLs, because has a larger joined schema (in the downstream).
-		// FIXME: if the previous tables reached the joined schema has not replicated to the downstream,
-		// now, they should re-try until replicated successfully, try to implement better strategy later.
-		return emptyDDLs, nil
-	}
-	log.L().Warn("new table info >= new joined table info", zap.Stringer("table info", newTable), zap.Stringer("joined table info", newJoined))
-	return ddls, nil // NOTE: this should not happen.
+	return newDDLs, nil
 }
 
 // TryRemoveTable tries to remove a table in the lock.

--- a/pkg/shardddl/optimism/lock_test.go
+++ b/pkg/shardddl/optimism/lock_test.go
@@ -100,7 +100,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 		for _, db := range dbs {
 			for _, tbl := range tbls {
 				vers[source][db][tbl]++
-				DDLs, err := l.TrySync(source, db, tbl, DDLs1, ti1, tts, vers[source][db][tbl])
+				DDLs, err := l.TrySync(source, db, tbl, DDLs1, []*model.TableInfo{ti1}, tts, vers[source][db][tbl])
 				c.Assert(err, IsNil)
 				c.Assert(DDLs, DeepEquals, DDLs1)
 				c.Assert(l.versions, DeepEquals, vers)
@@ -119,7 +119,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 
 	// CASE: TrySync again after synced is idempotent.
 	vers[sources[0]][dbs[0]][tbls[0]]++
-	DDLs, err := l.TrySync(sources[0], dbs[0], tbls[0], DDLs1, ti1, tts, vers[sources[0]][dbs[0]][tbls[0]])
+	DDLs, err := l.TrySync(sources[0], dbs[0], tbls[0], DDLs1, []*model.TableInfo{ti1}, tts, vers[sources[0]][dbs[0]][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -129,7 +129,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	// CASE: need to add more than one DDL to reach the desired schema (schema become larger).
 	// add two columns for one table.
 	vers[sources[0]][dbs[0]][tbls[0]]++
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs2, ti2, tts, vers[sources[0]][dbs[0]][tbls[0]])
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs2, []*model.TableInfo{ti2_1, ti2}, tts, vers[sources[0]][dbs[0]][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -139,7 +139,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 
 	// TrySync again is idempotent (more than one DDL).
 	vers[sources[0]][dbs[0]][tbls[0]]++
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs2, ti2, tts, vers[sources[0]][dbs[0]][tbls[0]])
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs2, []*model.TableInfo{ti2_1, ti2}, tts, vers[sources[0]][dbs[0]][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -149,7 +149,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 
 	// add only the first column for another table.
 	vers[sources[0]][dbs[0]][tbls[1]]++
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[0:1], ti2_1, tts, vers[sources[0]][dbs[0]][tbls[1]]) // use ti2_1 info
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[0:1], []*model.TableInfo{ti2_1}, tts, vers[sources[0]][dbs[0]][tbls[1]]) // use ti2_1 info
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2[0:1])
 	c.Assert(l.versions, DeepEquals, vers)
@@ -166,7 +166,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 
 	// TrySync again (only the first DDL).
 	vers[sources[0]][dbs[0]][tbls[1]]++
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[0:1], ti2_1, tts, vers[sources[0]][dbs[0]][tbls[1]])
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[0:1], []*model.TableInfo{ti2_1}, tts, vers[sources[0]][dbs[0]][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{}) // NOTE: special case, joined has larger schema.
 	c.Assert(l.versions, DeepEquals, vers)
@@ -175,7 +175,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 
 	// add the second column for another table.
 	vers[sources[0]][dbs[0]][tbls[1]]++
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[1:2], ti2, tts, vers[sources[0]][dbs[0]][tbls[1]]) // use ti2 info.
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[1:2], []*model.TableInfo{ti2}, tts, vers[sources[0]][dbs[0]][tbls[1]]) // use ti2 info.
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2[1:2])
 	c.Assert(l.versions, DeepEquals, vers)
@@ -191,13 +191,23 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 
 	// Try again (for the second DDL).
 	vers[sources[0]][dbs[0]][tbls[1]]++
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[1:2], ti2, tts, vers[sources[0]][dbs[0]][tbls[1]])
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs2[1:2], []*model.TableInfo{ti2}, tts, vers[sources[0]][dbs[0]][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2[1:2])
 	c.Assert(l.versions, DeepEquals, vers)
 
 	// try add columns for all tables to reach the same schema.
-	t.trySyncForAllTablesLarger(c, l, DDLs2, ti2, tts, vers)
+	resultDDLs := map[string]map[string]map[string][]string{
+		sources[0]: {
+			dbs[0]: {tbls[0]: DDLs2[1:], tbls[1]: DDLs2[1:]},
+			dbs[1]: {tbls[0]: DDLs2, tbls[1]: DDLs2},
+		},
+		sources[1]: {
+			dbs[0]: {tbls[0]: DDLs2, tbls[1]: DDLs2},
+			dbs[1]: {tbls[0]: DDLs2, tbls[1]: DDLs2},
+		},
+	}
+	t.trySyncForAllTablesLarger(c, l, DDLs2, []*model.TableInfo{ti2_1, ti2}, tts, vers, resultDDLs)
 	t.checkLockSynced(c, l)
 	t.checkLockNoDone(c, l)
 
@@ -220,7 +230,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 			for _, tbl := range tbls {
 				syncedCount++
 				vers[source][db][tbl]++
-				DDLs, err = l.TrySync(source, db, tbl, DDLs3, ti3, tts, vers[source][db][tbl])
+				DDLs, err = l.TrySync(source, db, tbl, DDLs3, []*model.TableInfo{ti3}, tts, vers[source][db][tbl])
 				c.Assert(err, IsNil)
 				c.Assert(l.versions, DeepEquals, vers)
 				synced, remain = l.IsSynced()
@@ -243,7 +253,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 	// CASE: need to drop more than one DDL to reach the desired schema (schema become smaller).
 	// drop two columns for one table.
 	vers[sources[0]][dbs[0]][tbls[0]]++
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs4, ti4, tts, vers[sources[0]][dbs[0]][tbls[0]])
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs4, []*model.TableInfo{ti4_1, ti4}, tts, vers[sources[0]][dbs[0]][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
 	c.Assert(l.versions, DeepEquals, vers)
@@ -253,9 +263,9 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 
 	// TrySync again is idempotent.
 	vers[sources[0]][dbs[0]][tbls[0]]++
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs4, ti4, tts, vers[sources[0]][dbs[0]][tbls[0]])
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[0], DDLs4, []*model.TableInfo{ti4_1, ti4}, tts, vers[sources[0]][dbs[0]][tbls[0]])
 	c.Assert(err, IsNil)
-	c.Assert(DDLs, DeepEquals, []string{})
+	c.Assert(DDLs, DeepEquals, DDLs4[:1])
 	c.Assert(l.versions, DeepEquals, vers)
 	ready = l.Ready()
 	c.Assert(ready[sources[0]][dbs[0]][tbls[0]], IsFalse)
@@ -263,7 +273,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 
 	// drop only the first column for another table.
 	vers[sources[0]][dbs[0]][tbls[1]]++
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[0:1], ti4_1, tts, vers[sources[0]][dbs[0]][tbls[1]])
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[0:1], []*model.TableInfo{ti4_1}, tts, vers[sources[0]][dbs[0]][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
 	c.Assert(l.versions, DeepEquals, vers)
@@ -276,14 +286,14 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 
 	// TrySync again (only the first DDL).
 	vers[sources[0]][dbs[0]][tbls[1]]++
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[0:1], ti4_1, tts, vers[sources[0]][dbs[0]][tbls[1]])
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[0:1], []*model.TableInfo{ti4_1}, tts, vers[sources[0]][dbs[0]][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
 	c.Assert(l.versions, DeepEquals, vers)
 
 	// drop the second column for another table.
 	vers[sources[0]][dbs[0]][tbls[1]]++
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[1:2], ti4, tts, vers[sources[0]][dbs[0]][tbls[1]]) // use ti4 info.
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[1:2], []*model.TableInfo{ti4}, tts, vers[sources[0]][dbs[0]][tbls[1]]) // use ti4 info.
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
 	c.Assert(l.versions, DeepEquals, vers)
@@ -296,7 +306,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 
 	// TrySync again (for the second DDL).
 	vers[sources[0]][dbs[0]][tbls[1]]++
-	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[1:2], ti4, tts, vers[sources[0]][dbs[0]][tbls[1]])
+	DDLs, err = l.TrySync(sources[0], dbs[0], tbls[1], DDLs4[1:2], []*model.TableInfo{ti4}, tts, vers[sources[0]][dbs[0]][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
 	c.Assert(l.versions, DeepEquals, vers)
@@ -307,7 +317,7 @@ func (t *testLock) TestLockTrySyncNormal(c *C) {
 		for schema, tables := range schemaTables {
 			for table, synced2 := range tables {
 				if synced2 { // do not `TrySync` again for previous two (un-synced now).
-					DDLs, err = l.TrySync(source, schema, table, DDLs4, ti4, tts, vers[source][schema][table])
+					DDLs, err = l.TrySync(source, schema, table, DDLs4, []*model.TableInfo{ti4_1, ti4}, tts, vers[source][schema][table])
 					c.Assert(err, IsNil)
 					c.Assert(l.versions, DeepEquals, vers)
 					remain--
@@ -364,7 +374,7 @@ func (t *testLock) TestLockTrySyncIndex(c *C) {
 	// try sync for one table, `DROP INDEX` returned directly (to make schema become more compatible).
 	// `DROP INDEX` is handled like `ADD COLUMN`.
 	vers[source][db][tbls[0]]++
-	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
+	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, []*model.TableInfo{ti1}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -375,7 +385,7 @@ func (t *testLock) TestLockTrySyncIndex(c *C) {
 
 	// try sync for another table, also got `DROP INDEX` now.
 	vers[source][db][tbls[1]]++
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts, vers[source][db][tbls[1]])
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, []*model.TableInfo{ti1}, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -384,7 +394,7 @@ func (t *testLock) TestLockTrySyncIndex(c *C) {
 	// try sync for one table, `ADD INDEX` not returned directly (to keep the schema more compatible).
 	// `ADD INDEX` is handled like `DROP COLUMN`.
 	vers[source][db][tbls[0]]++
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs2, ti2, tts, vers[source][db][tbls[0]])
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs2, []*model.TableInfo{ti2}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{}) // no DDLs returned
 	c.Assert(l.versions, DeepEquals, vers)
@@ -395,7 +405,7 @@ func (t *testLock) TestLockTrySyncIndex(c *C) {
 
 	// try sync for another table, got `ADD INDEX` now.
 	vers[source][db][tbls[1]]++
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, []*model.TableInfo{ti2}, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -443,28 +453,28 @@ func (t *testLock) TestLockTrySyncNullNotNull(c *C) {
 	for i := 0; i < 2; i++ { // two round
 		// try sync for one table, from `NULL` to `NOT NULL`, no DDLs returned.
 		vers[source][db][tbls[0]]++
-		DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
+		DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, []*model.TableInfo{ti1}, tts, vers[source][db][tbls[0]])
 		c.Assert(err, IsNil)
 		c.Assert(DDLs, DeepEquals, []string{})
 		c.Assert(l.versions, DeepEquals, vers)
 
 		// try sync for another table, DDLs returned.
 		vers[source][db][tbls[1]]++
-		DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts, vers[source][db][tbls[1]])
+		DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, []*model.TableInfo{ti1}, tts, vers[source][db][tbls[1]])
 		c.Assert(err, IsNil)
 		c.Assert(DDLs, DeepEquals, DDLs1)
 		c.Assert(l.versions, DeepEquals, vers)
 
 		// try sync for one table, from `NOT NULL` to `NULL`, DDLs returned.
 		vers[source][db][tbls[0]]++
-		DDLs, err = l.TrySync(source, db, tbls[0], DDLs2, ti2, tts, vers[source][db][tbls[0]])
+		DDLs, err = l.TrySync(source, db, tbls[0], DDLs2, []*model.TableInfo{ti2}, tts, vers[source][db][tbls[0]])
 		c.Assert(err, IsNil)
 		c.Assert(DDLs, DeepEquals, DDLs2)
 		c.Assert(l.versions, DeepEquals, vers)
 
 		// try sync for another table, from `NOT NULL` to `NULL`, DDLs, returned.
 		vers[source][db][tbls[1]]++
-		DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
+		DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, []*model.TableInfo{ti2}, tts, vers[source][db][tbls[1]])
 		c.Assert(err, IsNil)
 		c.Assert(DDLs, DeepEquals, DDLs2)
 		c.Assert(l.versions, DeepEquals, vers)
@@ -509,14 +519,14 @@ func (t *testLock) TestLockTrySyncIntBigint(c *C) {
 
 	// try sync for one table, from `INT` to `BIGINT`, DDLs returned.
 	vers[source][db][tbls[0]]++
-	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
+	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, []*model.TableInfo{ti1}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
 	c.Assert(l.versions, DeepEquals, vers)
 
 	// try sync for another table, DDLs returned.
 	vers[source][db][tbls[1]]++
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts, vers[source][db][tbls[1]])
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, []*model.TableInfo{ti1}, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -560,7 +570,7 @@ func (t *testLock) TestLockTrySyncNoDiff(c *C) {
 
 	// try sync for one table.
 	vers[source][db][tbls[0]]++
-	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
+	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, []*model.TableInfo{ti1}, tts, vers[source][db][tbls[0]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
 	c.Assert(l.versions, DeepEquals, vers)
@@ -604,7 +614,7 @@ func (t *testLock) TestLockTrySyncNewTable(c *C) {
 
 	// TrySync for a new table as the caller.
 	vers[source2][db2][tbl2]++
-	DDLs, err := l.TrySync(source2, db2, tbl2, DDLs1, ti1, tts, vers[source2][db2][tbl2])
+	DDLs, err := l.TrySync(source2, db2, tbl2, DDLs1, []*model.TableInfo{ti1}, tts, vers[source2][db2][tbl2])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -628,7 +638,7 @@ func (t *testLock) TestLockTrySyncNewTable(c *C) {
 	vers[source2][db2][tbl1] = 0
 
 	vers[source1][db1][tbl1]++
-	DDLs, err = l.TrySync(source1, db1, tbl1, DDLs1, ti1, tts, vers[source1][db1][tbl1])
+	DDLs, err = l.TrySync(source1, db1, tbl1, DDLs1, []*model.TableInfo{ti1}, tts, vers[source1][db1][tbl1])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -696,7 +706,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	// CASE: revert for single DDL.
 	// TrySync for one table.
 	vers[source][db][tbls[0]]++
-	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
+	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, []*model.TableInfo{ti1}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -712,7 +722,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 
 	// revert for the table, become synced again.
 	vers[source][db][tbls[0]]++
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs2, ti2, tts, vers[source][db][tbls[0]])
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs2, []*model.TableInfo{ti2}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -722,7 +732,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	// CASE: revert for multiple DDLs.
 	// TrySync for one table.
 	vers[source][db][tbls[0]]++
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs3, ti3, tts, vers[source][db][tbls[0]])
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs3, []*model.TableInfo{ti4, ti3}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs3)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -738,7 +748,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 
 	// revert part of the DDLs.
 	vers[source][db][tbls[0]]++
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs4, ti4, tts, vers[source][db][tbls[0]])
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs4, []*model.TableInfo{ti4}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs4)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -753,7 +763,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 
 	// revert the reset part of the DDLs.
 	vers[source][db][tbls[0]]++
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs5, ti5, tts, vers[source][db][tbls[0]])
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs5, []*model.TableInfo{ti5}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs5)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -763,7 +773,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 	// CASE: revert part of multiple DDLs.
 	// TrySync for one table.
 	vers[source][db][tbls[0]]++
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs6, ti6, tts, vers[source][db][tbls[0]])
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs6, []*model.TableInfo{ti7, ti6}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs6)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -778,7 +788,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 
 	// revert part of the DDLs.
 	vers[source][db][tbls[0]]++
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs7, ti7, tts, vers[source][db][tbls[0]])
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs7, []*model.TableInfo{ti7}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs7)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -793,7 +803,7 @@ func (t *testLock) TestLockTrySyncRevert(c *C) {
 
 	// TrySync for another table.
 	vers[source][db][tbls[1]]++
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs8, ti8, tts, vers[source][db][tbls[1]])
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs8, []*model.TableInfo{ti8}, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs8)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -820,8 +830,10 @@ func (t *testLock) TestLockTrySyncConflictNonIntrusive(c *C) {
 		ti0              = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY)`)
 		ti1              = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 TEXT)`)
 		ti2              = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 DATETIME, c2 INT)`)
+		ti2_1            = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 DATETIME)`)
 		ti3              = ti0
 		ti4              = ti2
+		ti4_1            = ti2_1
 
 		tables = map[string]map[string]struct{}{db: {tbls[0]: struct{}{}, tbls[1]: struct{}{}}}
 		tts    = []TargetTable{newTargetTable(task, source, downSchema, downTable, tables)}
@@ -840,7 +852,7 @@ func (t *testLock) TestLockTrySyncConflictNonIntrusive(c *C) {
 
 	// TrySync for the first table, construct the joined schema.
 	vers[source][db][tbls[0]]++
-	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
+	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, []*model.TableInfo{ti1}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -856,7 +868,7 @@ func (t *testLock) TestLockTrySyncConflictNonIntrusive(c *C) {
 
 	// TrySync for the second table with another schema (add two columns, one of them will cause conflict).
 	vers[source][db][tbls[1]]++
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, []*model.TableInfo{ti2_1, ti2}, tts, vers[source][db][tbls[1]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
 	c.Assert(l.versions, DeepEquals, vers)
@@ -868,7 +880,7 @@ func (t *testLock) TestLockTrySyncConflictNonIntrusive(c *C) {
 
 	// TrySync for the first table to resolve the conflict.
 	vers[source][db][tbls[0]]++
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs3, ti3, tts, vers[source][db][tbls[0]])
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs3, []*model.TableInfo{ti3}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs3)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -884,7 +896,7 @@ func (t *testLock) TestLockTrySyncConflictNonIntrusive(c *C) {
 
 	// TrySync for the first table.
 	vers[source][db][tbls[0]]++
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs4, ti4, tts, vers[source][db][tbls[0]])
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs4, []*model.TableInfo{ti4_1, ti4}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs4)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -942,7 +954,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	// CASE: conflict happen, revert all changes to resolve the conflict.
 	// TrySync for the first table, construct the joined schema.
 	vers[source][db][tbls[0]]++
-	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
+	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, []*model.TableInfo{ti1}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -958,7 +970,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 
 	// TrySync for the second table with another schema (add two columns, one of them will cause conflict).
 	vers[source][db][tbls[1]]++
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, []*model.TableInfo{ti3, ti2}, tts, vers[source][db][tbls[1]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
 	c.Assert(l.versions, DeepEquals, vers)
@@ -970,7 +982,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 
 	// TrySync again.
 	vers[source][db][tbls[1]]++
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, []*model.TableInfo{ti3, ti2}, tts, vers[source][db][tbls[1]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
 	c.Assert(l.versions, DeepEquals, vers)
@@ -980,7 +992,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 
 	// TrySync for the second table to drop the non-conflict column, the conflict should still exist.
 	vers[source][db][tbls[1]]++
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs3, ti3, tts, vers[source][db][tbls[1]])
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs3, []*model.TableInfo{ti3}, tts, vers[source][db][tbls[1]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
 	c.Assert(l.versions, DeepEquals, vers)
@@ -992,7 +1004,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 
 	// TrySync for the second table to drop the conflict column, the conflict should be resolved.
 	vers[source][db][tbls[1]]++
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs4, ti4, tts, vers[source][db][tbls[1]])
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs4, []*model.TableInfo{ti4}, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, []string{})
 	c.Assert(l.versions, DeepEquals, vers)
@@ -1004,7 +1016,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 
 	// TrySync for the second table as we did for the first table, the lock should be synced.
 	vers[source][db][tbls[1]]++
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, ti1, tts, vers[source][db][tbls[1]])
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs1, []*model.TableInfo{ti1}, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -1017,7 +1029,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	// CASE: conflict happen, revert part of changes to resolve the conflict.
 	// TrySync for the first table, construct the joined schema.
 	vers[source][db][tbls[0]]++
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs5, ti5, tts, vers[source][db][tbls[0]])
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs5, []*model.TableInfo{ti5}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs5)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -1033,7 +1045,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 
 	// TrySync for the second table with another schema (add two columns, one of them will cause conflict).
 	vers[source][db][tbls[1]]++
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs6, ti6, tts, vers[source][db][tbls[1]])
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs6, []*model.TableInfo{ti6}, tts, vers[source][db][tbls[1]])
 	c.Assert(terror.ErrShardDDLOptimismTrySyncFail.Equal(err), IsTrue)
 	c.Assert(DDLs, DeepEquals, []string{})
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
@@ -1046,7 +1058,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 	// TrySync for the second table to drop the conflict column, the conflict should be resolved.
 	// but both of tables are not synced now.
 	vers[source][db][tbls[1]]++
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs7, ti7, tts, vers[source][db][tbls[1]])
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs7, []*model.TableInfo{ti7}, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs7) // special case: these DDLs should not be replicated to the downstream.
 	c.Assert(l.versions, DeepEquals, vers)
@@ -1062,7 +1074,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 
 	// TrySync for the first table to become synced.
 	vers[source][db][tbls[0]]++
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs8_1, ti8, tts, vers[source][db][tbls[0]])
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs8_1, []*model.TableInfo{ti8}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs8_1)
 	ready = l.Ready()
@@ -1070,7 +1082,7 @@ func (t *testLock) TestLockTrySyncConflictIntrusive(c *C) {
 
 	// TrySync for the second table to become synced.
 	vers[source][db][tbls[1]]++
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs8_2, ti8, tts, vers[source][db][tbls[1]])
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs8_2, []*model.TableInfo{ti8}, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs8_2)
 	ready = l.Ready()
@@ -1118,7 +1130,7 @@ func (t *testLock) TestTryRemoveTable(c *C) {
 	// CASE: remove a table as normal.
 	// TrySync for the first table.
 	vers[source][db][tbl1]++
-	DDLs, err := l.TrySync(source, db, tbl1, DDLs1, ti1, tts, vers[source][db][tbl1])
+	DDLs, err := l.TrySync(source, db, tbl1, DDLs1, []*model.TableInfo{ti1}, tts, vers[source][db][tbl1])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -1142,7 +1154,7 @@ func (t *testLock) TestTryRemoveTable(c *C) {
 	// CASE: remove a table will not rebuild joined schema now.
 	// TrySync to add the second back.
 	vers[source][db][tbl2] = 1
-	DDLs, err = l.TrySync(source, db, tbl2, DDLs2, ti2, tts, vers[source][db][tbl1])
+	DDLs, err = l.TrySync(source, db, tbl2, DDLs2, []*model.TableInfo{ti2}, tts, vers[source][db][tbl1])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -1207,7 +1219,7 @@ func (t *testLock) TestLockTryMarkDone(c *C) {
 
 	// TrySync for the first table, no table has done the DDLs operation.
 	vers[source][db][tbls[0]]++
-	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, ti1, tts, vers[source][db][tbls[0]])
+	DDLs, err := l.TrySync(source, db, tbls[0], DDLs1, []*model.TableInfo{ti1}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs1)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -1222,7 +1234,7 @@ func (t *testLock) TestLockTryMarkDone(c *C) {
 
 	// TrySync for the second table, the joined schema become larger.
 	vers[source][db][tbls[1]]++
-	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, ti2, tts, vers[source][db][tbls[1]])
+	DDLs, err = l.TrySync(source, db, tbls[1], DDLs2, []*model.TableInfo{ti1, ti2}, tts, vers[source][db][tbls[1]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs2)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -1241,7 +1253,7 @@ func (t *testLock) TestLockTryMarkDone(c *C) {
 
 	// TrySync for the first table, all tables become synced.
 	vers[source][db][tbls[0]]++
-	DDLs, err = l.TrySync(source, db, tbls[0], DDLs3, ti3, tts, vers[source][db][tbls[0]])
+	DDLs, err = l.TrySync(source, db, tbls[0], DDLs3, []*model.TableInfo{ti3}, tts, vers[source][db][tbls[0]])
 	c.Assert(err, IsNil)
 	c.Assert(DDLs, DeepEquals, DDLs3)
 	c.Assert(l.versions, DeepEquals, vers)
@@ -1271,13 +1283,13 @@ func (t *testLock) TestLockTryMarkDone(c *C) {
 }
 
 func (t *testLock) trySyncForAllTablesLarger(c *C, l *Lock,
-	DDLs []string, ti *model.TableInfo, tts []TargetTable, vers map[string]map[string]map[string]int64) {
+	DDLs []string, tis []*model.TableInfo, tts []TargetTable, vers map[string]map[string]map[string]int64, resultDDLs map[string]map[string]map[string][]string) {
 	for source, schemaTables := range l.Ready() {
 		for schema, tables := range schemaTables {
 			for table := range tables {
-				DDLs2, err := l.TrySync(source, schema, table, DDLs, ti, tts, vers[source][schema][table])
+				DDLs2, err := l.TrySync(source, schema, table, DDLs, tis, tts, vers[source][schema][table])
 				c.Assert(err, IsNil)
-				c.Assert(DDLs2, DeepEquals, DDLs)
+				c.Assert(DDLs2, DeepEquals, resultDDLs[source][schema][table])
 			}
 		}
 	}

--- a/pkg/terror/error_list.go
+++ b/pkg/terror/error_list.go
@@ -468,6 +468,7 @@ const (
 	codeMasterTLSConfigNotValid
 	codeMasterBoundChanging
 	codeMasterFailToImportFromV10x
+	codeMasterInconsistentOptimistDDLsAndInfo
 )
 
 // DM-worker error code
@@ -1054,6 +1055,8 @@ var (
 	ErrMasterBoundChanging = New(codeMasterBoundChanging, ClassDMMaster, ScopeInternal, LevelLow, "source bound is changed too frequently, last old bound %s:, new bound %s", "Please try again later")
 
 	ErrMasterFailToImportFromV10x = New(codeMasterFailToImportFromV10x, ClassDMMaster, ScopeInternal, LevelHigh, "fail to import DM cluster from v1.0.x", "Please confirm that you have not violated any restrictions in the upgrade documentation.")
+
+	ErrMasterInconsistentOptimisticDDLsAndInfo = New(codeMasterInconsistentOptimistDDLsAndInfo, ClassDMMaster, ScopeInternal, LevelHigh, "inconsistent count of optimistic ddls and table infos, ddls: %d, table info: %d", "")
 
 	// DM-worker error
 	ErrWorkerParseFlagSet            = New(codeWorkerParseFlagSet, ClassDMWorker, ScopeInternal, LevelMedium, "parse dm-worker config flag set", "")

--- a/relay/meta_test.go
+++ b/relay/meta_test.go
@@ -165,8 +165,8 @@ func (r *testMetaSuite) TestLocalMeta(c *C) {
 		err = lm.Save(cs.pos, cs.gset)
 		c.Assert(err, IsNil)
 
-		currentUUID, pos2 := lm.Pos()
-		c.Assert(currentUUID, Equals, cs.uuidWithSuffix)
+		currentUUID2, pos2 := lm.Pos()
+		c.Assert(currentUUID2, Equals, cs.uuidWithSuffix)
 		c.Assert(pos2, DeepEquals, cs.pos)
 
 		currentUUID, gset = lm.GTID()

--- a/syncer/shardddl/optimist.go
+++ b/syncer/shardddl/optimist.go
@@ -81,8 +81,8 @@ func (o *Optimist) Reset() {
 
 // ConstructInfo constructs a shard DDL info.
 func (o *Optimist) ConstructInfo(upSchema, upTable, downSchema, downTable string,
-	DDLs []string, tiBefore *model.TableInfo, tiAfter *model.TableInfo) optimism.Info {
-	return optimism.NewInfo(o.task, o.source, upSchema, upTable, downSchema, downTable, DDLs, tiBefore, tiAfter)
+	DDLs []string, tiBefore *model.TableInfo, tisAfter []*model.TableInfo) optimism.Info {
+	return optimism.NewInfo(o.task, o.source, upSchema, upTable, downSchema, downTable, DDLs, tiBefore, tisAfter)
 }
 
 // PutInfo puts the shard DDL info into etcd and returns the revision.

--- a/syncer/shardddl/optimist_test.go
+++ b/syncer/shardddl/optimist_test.go
@@ -81,13 +81,13 @@ func (t *testOptimist) TestOptimist(c *C) {
 		tiBefore       = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY)`)
 		tiAfter1       = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 TEXT)`)
 		tiAfter2       = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (id INT PRIMARY KEY, c1 DATETIME)`)
-		info1          = o.ConstructInfo("foo-1", "bar-1", downSchema, downTable, DDLs1, tiBefore, tiAfter1)
+		info1          = o.ConstructInfo("foo-1", "bar-1", downSchema, downTable, DDLs1, tiBefore, []*model.TableInfo{tiAfter1})
 		op1            = optimism.NewOperation(ID, task, source, info1.UpSchema, info1.UpTable, DDLs1, optimism.ConflictNone, false)
-		info2          = o.ConstructInfo("foo-1", "bar-2", downSchema, downTable, DDLs2, tiBefore, tiAfter2)
+		info2          = o.ConstructInfo("foo-1", "bar-2", downSchema, downTable, DDLs2, tiBefore, []*model.TableInfo{tiAfter2})
 		op2            = optimism.NewOperation(ID, task, source, info2.UpSchema, info2.UpTable, DDLs2, optimism.ConflictDetected, false)
 
 		infoCreate = o.ConstructInfo("foo-new", "bar-new", downSchema, downTable,
-			[]string{`CREATE TABLE bar (id INT PRIMARY KEY)`}, tiBefore, tiBefore) // same table info.
+			[]string{`CREATE TABLE bar (id INT PRIMARY KEY)`}, tiBefore, []*model.TableInfo{tiBefore}) // same table info.
 		infoDrop = o.ConstructInfo("foo-new", "bar-new", downSchema, downTable,
 			[]string{`DROP TABLE bar`}, nil, nil) // both table infos are nil.
 	)

--- a/tests/shardddl2/run.sh
+++ b/tests/shardddl2/run.sh
@@ -738,6 +738,20 @@ function DM_ADD_DROP_COLUMNS_CASE {
     run_sql_source2 "insert into ${shardddl1}.${tb1} values(28,now(),28);"
     run_sql_source2 "insert into ${shardddl1}.${tb2} values(29,now(),29);"
 
+    # drop and add
+    run_sql_source1 "alter table ${shardddl1}.${tb1} drop column col4, add column col5 int;"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(31,now(),31);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(32,now(),32);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(33,now(),33);"
+    run_sql_source2 "alter table ${shardddl1}.${tb1} drop column col4, add column col5 int;"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(34,now(),34);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(35,now(),35);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(36,now(),36);"
+    run_sql_source2 "alter table ${shardddl1}.${tb2} drop column col4, add column col5 int;"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(37,now(),37);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(38,now(),38);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(39,now(),39);"
+
     check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
 }
 
@@ -754,20 +768,94 @@ function DM_ADD_DROP_COLUMNS() {
     "clean_table" "optimistic"
 }
 
+function DM_COLUMN_INDEX_CASE {
+    # add col and index
+    run_sql_source1 "alter table ${shardddl1}.${tb1} add column col3 int, add index idx_col1(col1);"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(1,1,1,1);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(2,2,2);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(3,3,3);"
+    run_sql_source2 "alter table ${shardddl1}.${tb1} add column col3 int, add index idx_col1(col1);"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(4,4,4,4);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(5,5,5,5);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(6,6,6);"
+    run_sql_source2 "alter table ${shardddl1}.${tb2} add column col3 int, add index idx_col1(col1);"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(7,7,7,7);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(8,8,8,8);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(9,9,9,9);"
+
+    # drop col and index
+    run_sql_source1 "alter table ${shardddl1}.${tb1} drop column col2, drop index idx_col1;"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(11,11,11);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(12,12,12,12);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(13,13,13,13);"
+    run_sql_source2 "alter table ${shardddl1}.${tb1} drop column col2, drop index idx_col1;"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(14,14,14);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(15,15,15);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(16,16,16,16);"
+    run_sql_source2 "alter table ${shardddl1}.${tb2} drop column col2, drop index idx_col1;"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(17,17,17);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(18,18,18);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(19,19,19);"
+
+    # drop col, add index
+    run_sql_source1 "alter table ${shardddl1}.${tb1} drop column col1, add index idx_col3(col3);"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(21,21);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(22,22,22);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(23,23,23);"
+    run_sql_source2 "alter table ${shardddl1}.${tb1} drop column col1, add index idx_col3(col3);"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(24,24);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(25,25);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(26,26,26);"
+    run_sql_source2 "alter table ${shardddl1}.${tb2} drop column col1, add index idx_col3(col3);"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(27,27);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(28,28);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(29,29);"
+
+    # add col, drop index
+    run_sql_source1 "alter table ${shardddl1}.${tb1} add column col4 int, drop index idx_col3;"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(31,31,31);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(32,32);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(33,33);"
+    run_sql_source2 "alter table ${shardddl1}.${tb1} add column col4 int, drop index idx_col3;"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(34,34,34);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(35,35,35);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(36,36);"
+    run_sql_source2 "alter table ${shardddl1}.${tb2} add column col4 int, drop index idx_col3;"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(37,37,37);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(38,38,38);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(39,39,39);"
+
+    check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
+}
+
+function DM_COLUMN_INDEX() {
+    run_case COLUMN_INDEX "double-source-pessimistic" \
+    "run_sql_source1 \"create table ${shardddl1}.${tb1} (a int primary key, col1 int, col2 int);\"; \
+     run_sql_source2 \"create table ${shardddl1}.${tb1} (a int primary key, col1 int, col2 int);\"; \
+     run_sql_source2 \"create table ${shardddl1}.${tb2} (a int primary key, col1 int, col2 int);\"" \
+    "clean_table" "pessimistic"
+    run_case COLUMN_INDEX "double-source-optimistic" \
+    "run_sql_source1 \"create table ${shardddl1}.${tb1} (a int primary key, col1 int, col2 int);\"; \
+     run_sql_source2 \"create table ${shardddl1}.${tb1} (a int primary key, col1 int, col2 int);\"; \
+     run_sql_source2 \"create table ${shardddl1}.${tb2} (a int primary key, col1 int, col2 int);\"" \
+    "clean_table" "optimistic"
+}
+
 function run() {
     init_cluster
     init_database
-#    start=36
-#    end=70
-#    except=(042 044 045 052 053 054 055 060 061 069 070)
-#    for i in $(seq -f "%03g" ${start} ${end}); do
-#        if [[ ${except[@]} =~ $i ]]; then
-#            continue
-#        fi
-#        DM_${i}
-#        sleep 1
-#    done
+    start=36
+    end=70
+    except=(042 044 045 052 053 054 055 060 061 069 070)
+    for i in $(seq -f "%03g" ${start} ${end}); do
+        if [[ ${except[@]} =~ $i ]]; then
+            continue
+        fi
+        DM_${i}
+        sleep 1
+    done
     DM_ADD_DROP_COLUMNS
+    DM_COLUMN_INDEX
 }
 
 cleanup_data $shardddl


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
support combine ddls like `alter table add column col4 int, drop column col3;` for optimistic sharding mode

### What is changed and how it works?
send all table infos to master per split ddl, master join theme one by one.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
