### PR TITLE
dmctl: change help message

### DIFF
--- a/dm/ctl/ctl.go
+++ b/dm/ctl/ctl.go
@@ -75,6 +75,7 @@ func NewRootCmd() *cobra.Command {
 		master.NewGetCfgCmd(),
 		master.NewHandleErrorCmd(),
 	)
+	// copied from (*cobra.Command).InitDefaultHelpCmd
 	helpCmd := &cobra.Command{
 		Use:   "help [command]",
 		Short: "Gets help about any command.",
@@ -85,10 +86,10 @@ Simply type ` + cmd.Name() + ` help [path to command] for full details.`,
 			cmd, _, e := c.Root().Find(args)
 			if cmd == nil || e != nil {
 				c.Printf("Unknown help topic %#q\n", args)
-				c.Root().Usage()
+				_ = c.Root().Usage()
 			} else {
 				cmd.InitDefaultHelpFlag() // make possible 'help' flag to be shown
-				cmd.Help()
+				_ = cmd.Help()
 			}
 		},
 	}

--- a/dm/ctl/ctl.go
+++ b/dm/ctl/ctl.go
@@ -75,6 +75,24 @@ func NewRootCmd() *cobra.Command {
 		master.NewGetCfgCmd(),
 		master.NewHandleErrorCmd(),
 	)
+	helpCmd := &cobra.Command{
+		Use:   "help [command]",
+		Short: "Gets help about any command.",
+		Long: `Help provides help for any command in the application.
+Simply type ` + cmd.Name() + ` help [path to command] for full details.`,
+
+		Run: func(c *cobra.Command, args []string) {
+			cmd, _, e := c.Root().Find(args)
+			if cmd == nil || e != nil {
+				c.Printf("Unknown help topic %#q\n", args)
+				c.Root().Usage()
+			} else {
+				cmd.InitDefaultHelpFlag() // make possible 'help' flag to be shown
+				cmd.Help()
+			}
+		},
+	}
+	cmd.SetHelpCommand(helpCmd)
 	return cmd
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
align with https://github.com/pingcap/docs-dm/pull/560

### What is changed and how it works?
overwrite builtin help command

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
```
» help
DM control

Usage:
  dmctl [command]

Available Commands:
  check-task      Checks the configuration file of the task.
  get-config      Gets the configuration.
  handle-error    `skip`/`replace`/`revert` the current error event or a specific binlog position (binlog-pos) event.
  help            Gets help about any command.
```


Related changes

 - Need to cherry-pick to the release branch
