### PR TITLE
optimist: only update table info if no conflict

### DIFF
--- a/dm/ctl/ctl.go
+++ b/dm/ctl/ctl.go
@@ -83,13 +83,13 @@ func NewRootCmd() *cobra.Command {
 Simply type ` + cmd.Name() + ` help [path to command] for full details.`,
 
 		Run: func(c *cobra.Command, args []string) {
-			cmd, _, e := c.Root().Find(args)
-			if cmd == nil || e != nil {
+			cmd2, _, e := c.Root().Find(args)
+			if cmd2 == nil || e != nil {
 				c.Printf("Unknown help topic %#q\n", args)
 				_ = c.Root().Usage()
 			} else {
-				cmd.InitDefaultHelpFlag() // make possible 'help' flag to be shown
-				_ = cmd.Help()
+				cmd2.InitDefaultHelpFlag() // make possible 'help' flag to be shown
+				_ = cmd2.Help()
 			}
 		},
 	}

--- a/pkg/shardddl/optimism/lock.go
+++ b/pkg/shardddl/optimism/lock.go
@@ -156,18 +156,23 @@ func (l *Lock) TrySync(callerSource, callerSchema, callerTable string,
 	prevTable := l.tables[callerSource][callerSchema][callerTable]
 	oldJoined := l.joined
 
-	// update table info and joined info base on the last new table info
 	lastTableInfo := schemacmp.Encode(newTIs[len(newTIs)-1])
-	log.L().Info("update table info", zap.String("lock", l.ID), zap.String("source", callerSource), zap.String("schema", callerSchema), zap.String("table", callerTable),
-		zap.Stringer("from", prevTable), zap.Stringer("to", lastTableInfo), zap.Strings("ddls", ddls))
-	l.tables[callerSource][callerSchema][callerTable] = lastTableInfo
-
 	lastJoined, err := joinTable(lastTableInfo)
 	if err != nil {
 		return emptyDDLs, err
 	}
-	// update the current joined table info, it should be logged in `if cmp != 0` block below.
-	l.joined = lastJoined
+
+	defer func() {
+		// only update table info and joined info if no error
+		if err == nil {
+			// update table info and joined info base on the last new table info
+			log.L().Info("update table info", zap.String("lock", l.ID), zap.String("source", callerSource), zap.String("schema", callerSchema), zap.String("table", callerTable),
+				zap.Stringer("from", l.tables[callerSource][callerSchema][callerTable]), zap.Stringer("to", lastTableInfo), zap.Strings("ddls", ddls))
+			l.tables[callerSource][callerSchema][callerTable] = lastTableInfo
+			// update the current joined table info, it should be logged in `if cmp != 0` block below.
+			l.joined = lastJoined
+		}
+	}()
 
 	newDDLs = []string{}
 	nextTable := prevTable
@@ -180,8 +185,9 @@ func (l *Lock) TrySync(callerSource, callerSchema, callerTable string,
 		nextTable = schemacmp.Encode(newTI)
 		// special case: check whether DDLs making the schema become part of larger and another part of smaller.
 		if _, err = prevTable.Compare(nextTable); err != nil {
-			return emptyDDLs, terror.ErrShardDDLOptimismTrySyncFail.Delegate(
+			err = terror.ErrShardDDLOptimismTrySyncFail.Delegate(
 				err, l.ID, fmt.Sprintf("there will be conflicts if DDLs %s are applied to the downstream. old table info: %s, new table info: %s", ddls, prevTable, nextTable))
+			return emptyDDLs, err
 		}
 
 		// special case: if the DDL does not affect the schema at all, assume it is
@@ -206,6 +212,7 @@ func (l *Lock) TrySync(callerSource, callerSchema, callerTable string,
 			// resolving conflict in non-intrusive mode.
 			log.L().Warn("resolving conflict", zap.String("lock", l.ID), zap.String("source", callerSource), zap.String("schema", callerSchema), zap.String("table", callerTable),
 				zap.Stringer("joined-from", oldJoined), zap.Stringer("joined-to", newJoined), zap.Strings("ddls", ddls))
+			err = nil
 			return ddls, nil
 		}
 		if cmp != 0 {
@@ -262,8 +269,9 @@ func (l *Lock) TrySync(callerSource, callerSchema, callerTable string,
 		// compare the current table's info with joined info.
 		cmp, err = nextTable.Compare(newJoined)
 		if err != nil {
-			return emptyDDLs, terror.ErrShardDDLOptimismTrySyncFail.Delegate(
+			err = terror.ErrShardDDLOptimismTrySyncFail.Delegate(
 				err, l.ID, "can't compare table info (new table info) %s with (new joined table info) %s", nextTable, newJoined) // NOTE: this should not happen.
+			return emptyDDLs, err
 		}
 		if cmp < 0 {
 			// no need to replicate DDLs, because has a larger joined schema (in the downstream).

--- a/pkg/shardddl/optimism/lock.go
+++ b/pkg/shardddl/optimism/lock.go
@@ -185,9 +185,8 @@ func (l *Lock) TrySync(callerSource, callerSchema, callerTable string,
 		nextTable = schemacmp.Encode(newTI)
 		// special case: check whether DDLs making the schema become part of larger and another part of smaller.
 		if _, err = prevTable.Compare(nextTable); err != nil {
-			err = terror.ErrShardDDLOptimismTrySyncFail.Delegate(
+			return emptyDDLs, terror.ErrShardDDLOptimismTrySyncFail.Delegate(
 				err, l.ID, fmt.Sprintf("there will be conflicts if DDLs %s are applied to the downstream. old table info: %s, new table info: %s", ddls, prevTable, nextTable))
-			return emptyDDLs, err
 		}
 
 		// special case: if the DDL does not affect the schema at all, assume it is
@@ -212,7 +211,6 @@ func (l *Lock) TrySync(callerSource, callerSchema, callerTable string,
 			// resolving conflict in non-intrusive mode.
 			log.L().Warn("resolving conflict", zap.String("lock", l.ID), zap.String("source", callerSource), zap.String("schema", callerSchema), zap.String("table", callerTable),
 				zap.Stringer("joined-from", oldJoined), zap.Stringer("joined-to", newJoined), zap.Strings("ddls", ddls))
-			err = nil
 			return ddls, nil
 		}
 		if cmp != 0 {
@@ -269,9 +267,8 @@ func (l *Lock) TrySync(callerSource, callerSchema, callerTable string,
 		// compare the current table's info with joined info.
 		cmp, err = nextTable.Compare(newJoined)
 		if err != nil {
-			err = terror.ErrShardDDLOptimismTrySyncFail.Delegate(
+			return emptyDDLs, terror.ErrShardDDLOptimismTrySyncFail.Delegate(
 				err, l.ID, "can't compare table info (new table info) %s with (new joined table info) %s", nextTable, newJoined) // NOTE: this should not happen.
-			return emptyDDLs, err
 		}
 		if cmp < 0 {
 			// no need to replicate DDLs, because has a larger joined schema (in the downstream).

--- a/pkg/shardddl/optimism/lock_test.go
+++ b/pkg/shardddl/optimism/lock_test.go
@@ -874,6 +874,7 @@ func (t *testLock) TestLockTrySyncConflictNonIntrusive(c *C) {
 	c.Assert(DDLs, DeepEquals, []string{})
 	c.Assert(l.versions, DeepEquals, vers)
 	cmp, err = l.tables[source][db][tbls[1]].Compare(l.Joined())
+	// join table isn't updated
 	c.Assert(err, IsNil)
 	c.Assert(cmp, Equals, -1)
 	ready = l.Ready()


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #1484 

### What is changed and how it works?
If a ddl conflict with previous one, do not update table info in master, so we can use handle-error replace to replace a new ddl and no conflict.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
