### PR TITLE
loader: don't use ANSI_QUOTES for dumped data files

### DIFF
--- a/loader/convert_data.go
+++ b/loader/convert_data.go
@@ -51,7 +51,7 @@ func parseInsertStmt(sql []byte, table *tableInfo, columnMapping *cm.Mapping) ([
 	//	INSERT INTO `t1` (`id`,`uid`,`name`,`info`) VALUES
 	//	(1,10001,"Gabriel García Márquez",NULL),
 	//	(2,10002,"Cien años de soledad",NULL);
-	// otherwise dumped SQL file has content like folloing:
+	// otherwise dumped SQL file has content like following:
 	//	INSERT INTO `t1` VALUES
 	//	(1,"hello"),
 	//	(2,"world");

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -304,7 +304,6 @@ func (w *Worker) dispatchSQL(ctx context.Context, file string, offset int64, tab
 
 	lastOffset := cur
 
-	ansiquote := strings.Contains(w.cfg.SQLMode, "ANSI_QUOTES")
 	data := make([]byte, 0, 1024*1024)
 	br := bufio.NewReader(f)
 	for {
@@ -343,7 +342,8 @@ func (w *Worker) dispatchSQL(ctx context.Context, file string, offset int64, tab
 					return terror.Annotatef(err, "file %s", file)
 				}
 			} else if table.sourceTable != table.targetTable {
-				query = renameShardingTable(query, table.sourceTable, table.targetTable, ansiquote)
+				// dumped data files always use backquote as quotes
+				query = renameShardingTable(query, table.sourceTable, table.targetTable, false)
 			}
 
 			idx := strings.Index(query, "INSERT INTO")

--- a/tests/safe_mode/conf/dm-task.yaml
+++ b/tests/safe_mode/conf/dm-task.yaml
@@ -5,6 +5,7 @@ is-sharding: true
 meta-schema: "dm_meta"
 enable-heartbeat: false
 timezone: "Asia/Shanghai"
+ignore-checking-items: ["auto_increment_ID"]
 
 target-database:
   host: "127.0.0.1"
@@ -16,7 +17,6 @@ mysql-instances:
   - source-id: "mysql-replica-01"
     block-allow-list:  "instance"
     route-rules: ["sharding-route-rules-table", "sharding-route-rules-schema"]
-    column-mapping-rules: ["instance-1"]
     mydumper-config-name: "global"
     loader-config-name: "global"
     syncer-config-name: "global"
@@ -24,7 +24,6 @@ mysql-instances:
   - source-id: "mysql-replica-02"
     block-allow-list:  "instance"
     route-rules: ["sharding-route-rules-table", "sharding-route-rules-schema"]
-    column-mapping-rules: ["instance-2"]
     mydumper-config-name: "global"
     loader-config-name: "global"
     syncer-config-name: "global"
@@ -46,23 +45,6 @@ routes:
   sharding-route-rules-schema:
     schema-pattern: safe_mode_test
     target-schema: safe_mode_target
-
-column-mappings:
-  instance-1:
-    schema-pattern: "safe_mode_test"
-    table-pattern: "t*"
-    expression: "partition id"
-    source-column: "id"
-    target-column: "id"
-    arguments: ["1", "", "t"]
-
-  instance-2:
-    schema-pattern: "safe_mode_test"
-    table-pattern: "t*"
-    expression: "partition id"
-    source-column: "id"
-    target-column: "id"
-    arguments: ["2", "", "t"]
 
 mydumpers:
   global:

--- a/tests/safe_mode/data/db1.prepare.sql
+++ b/tests/safe_mode/data/db1.prepare.sql
@@ -2,6 +2,6 @@ drop database if exists `safe_mode_test`;
 create database `safe_mode_test`;
 use `safe_mode_test`;
 create table t1 (id bigint auto_increment, uid int, name varchar(80), primary key (`id`), unique key(`uid`)) DEFAULT CHARSET=utf8mb4;
-create table t2 (id bigint auto_increment, uid int, name varchar(80), primary key (`id`), unique key(`uid`)) DEFAULT CHARSET=utf8mb4;
+create table t2 (id bigint auto_increment, uid int, name varchar(80), primary key (`id`), unique key(`uid`)) DEFAULT CHARSET=utf8mb4 AUTO_INCREMENT = 100;
 insert into t1 (uid, name) values (10001, 'Gabriel García Márquez'), (10002, 'Cien años de soledad');
 insert into t2 (uid, name) values (20001, 'José Arcadio Buendía'), (20002, 'Úrsula Iguarán'), (20003, 'José Arcadio');

--- a/tests/safe_mode/data/db2.prepare.sql
+++ b/tests/safe_mode/data/db2.prepare.sql
@@ -1,7 +1,7 @@
 drop database if exists `safe_mode_test`;
 create database `safe_mode_test`;
 use `safe_mode_test`;
-create table t2 (id bigint auto_increment, uid int, name varchar(80), primary key (`id`), unique key(`uid`)) DEFAULT CHARSET=utf8mb4;
-create table t3 (id bigint auto_increment, uid int, name varchar(80), primary key (`id`), unique key(`uid`)) DEFAULT CHARSET=utf8mb4;
+create table t2 (id bigint auto_increment, uid int, name varchar(80), primary key (`id`), unique key(`uid`)) DEFAULT CHARSET=utf8mb4 AUTO_INCREMENT = 200;
+create table t3 (id bigint auto_increment, uid int, name varchar(80), primary key (`id`), unique key(`uid`)) DEFAULT CHARSET=utf8mb4 AUTO_INCREMENT = 300;
 insert into t2 (uid, name) values (40000, 'Remedios Moscote'), (40001, 'Amaranta');
 insert into t3 (uid, name) values (30001, 'Aureliano José'), (30002, 'Santa Sofía de la Piedad'), (30003, '17 Aurelianos');

--- a/tests/safe_mode/run.sh
+++ b/tests/safe_mode/run.sh
@@ -7,6 +7,7 @@ source $cur/../_utils/test_prepare
 WORK_DIR=$TEST_DIR/$TEST_NAME
 
 function consistency_none() {
+    run_sql_source2 "SET @@GLOBAL.SQL_MODE='ANSI_QUOTES'"
     run_sql_file $cur/data/db1.prepare.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
     check_contains 'Query OK, 2 rows affected'
     run_sql_file $cur/data/db2.prepare.sql $MYSQL_HOST2 $MYSQL_PORT2 $MYSQL_PASSWORD2
@@ -52,6 +53,7 @@ function consistency_none() {
     gtid2=$(grep "GTID:" $WORK_DIR/worker2/dumped_data.test/metadata|tail -1|awk -F: '{print $2,":",$3}'|tr -d ' ')
     check_log_contains $WORK_DIR/worker2/log/dm-worker.log "\[\"enable safe-mode because of inconsistent dump, will exit at\"\] \[task=test\] \[unit=\"binlog replication\"\] \[location=\"position: ($name2, $pos2), gtid-set: $gtid2\"\]"
 
+    run_sql_source2 "SET @@GLOBAL.SQL_MODE='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'"
     cleanup_data safe_mode_target
     cleanup_process $*
 }


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
in https://github.com/pingcap/dm/pull/1309, condition branch of dumped data file is not tested because of column-mapping, and it has a BUG

### What is changed and how it works?
don't use ANSI_QUOTES for dumped data files

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 
Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
