### PR TITLE
worker: move relay related function together

### DIFF
--- a/dm/worker/server.go
+++ b/dm/worker/server.go
@@ -566,10 +566,11 @@ func (s *Server) startWorker(cfg *config.SourceConfig) error {
 
 	subTaskCfgs := make([]*config.SubTaskConfig, 0, len(subTaskCfgm))
 	for _, subTaskCfg := range subTaskCfgm {
-		if err2 := copyConfigFromSource(&subTaskCfg, cfg); err2 != nil {
+		clone := subTaskCfg
+		if err2 := copyConfigFromSource(&clone, cfg); err2 != nil {
 			return err2
 		}
-		subTaskCfgs = append(subTaskCfgs, &subTaskCfg)
+		subTaskCfgs = append(subTaskCfgs, &clone)
 	}
 
 	log.L().Info("starting to handle mysql source", zap.String("sourceCfg", cfg.String()), zap.Reflect("subTasks", subTaskCfgs))

--- a/dm/worker/server.go
+++ b/dm/worker/server.go
@@ -566,14 +566,10 @@ func (s *Server) startWorker(cfg *config.SourceConfig) error {
 
 	subTaskCfgs := make([]*config.SubTaskConfig, 0, len(subTaskCfgm))
 	for _, subTaskCfg := range subTaskCfgm {
-		subTaskCfg.LogLevel = s.cfg.LogLevel
-		subTaskCfg.LogFile = s.cfg.LogFile
-		subTaskCfg.LogFormat = s.cfg.LogFormat
-		subTaskCfgClone := subTaskCfg
-		if err = copyConfigFromSource(&subTaskCfgClone, cfg); err != nil {
-			return err
+		if err2 := copyConfigFromSource(&subTaskCfg, cfg); err2 != nil {
+			return err2
 		}
-		subTaskCfgs = append(subTaskCfgs, &subTaskCfgClone)
+		subTaskCfgs = append(subTaskCfgs, &subTaskCfg)
 	}
 
 	log.L().Info("starting to handle mysql source", zap.String("sourceCfg", cfg.String()), zap.Reflect("subTasks", subTaskCfgs))

--- a/dm/worker/server.go
+++ b/dm/worker/server.go
@@ -582,8 +582,8 @@ func (s *Server) startWorker(cfg *config.SourceConfig) error {
 
 	if cfg.EnableRelay {
 		s.UpdateKeepAliveTTL(s.cfg.RelayKeepAliveTTL)
-		if err := w.EnableRelay(); err != nil {
-			return err
+		if err2 := w.EnableRelay(); err2 != nil {
+			return err2
 		}
 	}
 	go w.Start()

--- a/dm/worker/server_test.go
+++ b/dm/worker/server_test.go
@@ -532,14 +532,10 @@ func (t *testServer) testStopWorkerWhenLostConnect(c *C, s *Server, ETCD *embed.
 }
 
 func (t *testServer) TestGetMinLocInAllSubTasks(c *C) {
-	subTaskCfg := []*config.SubTaskConfig{
-		{
-			Name: "test2",
-		}, {
-			Name: "test3",
-		}, {
-			Name: "test1",
-		},
+	subTaskCfg := map[string]config.SubTaskConfig{
+		"test2": {Name: "test2"},
+		"test3": {Name: "test3"},
+		"test1": {Name: "test1"},
 	}
 	minLoc, err := getMinLocInAllSubTasks(context.Background(), subTaskCfg)
 	c.Assert(err, IsNil)
@@ -666,7 +662,7 @@ func (t *testServer) TestUnifyMasterBinlogPos(c *C) {
 	c.Assert(relay.RelayCatchUpMaster, IsTrue)
 }
 
-func getFakeLocForSubTask(ctx context.Context, subTaskCfg *config.SubTaskConfig) (minLoc *binlog.Location, err error) {
+func getFakeLocForSubTask(ctx context.Context, subTaskCfg config.SubTaskConfig) (minLoc *binlog.Location, err error) {
 	gset1, _ := gtid.ParserGTID(mysql.MySQLFlavor, "ba8f633f-1f15-11eb-b1c7-0242ac110001:1-30")
 	gset2, _ := gtid.ParserGTID(mysql.MySQLFlavor, "ba8f633f-1f15-11eb-b1c7-0242ac110001:1-50")
 	gset3, _ := gtid.ParserGTID(mysql.MySQLFlavor, "ba8f633f-1f15-11eb-b1c7-0242ac110001:1-50,ba8f633f-1f15-11eb-b1c7-0242ac110002:1")

--- a/dm/worker/server_test.go
+++ b/dm/worker/server_test.go
@@ -532,6 +532,7 @@ func (t *testServer) testStopWorkerWhenLostConnect(c *C, s *Server, ETCD *embed.
 }
 
 func (t *testServer) TestGetMinLocInAllSubTasks(c *C) {
+
 	subTaskCfg := map[string]config.SubTaskConfig{
 		"test2": {Name: "test2"},
 		"test3": {Name: "test3"},
@@ -542,8 +543,9 @@ func (t *testServer) TestGetMinLocInAllSubTasks(c *C) {
 	c.Assert(minLoc.Position.Name, Equals, "mysql-binlog.00001")
 	c.Assert(minLoc.Position.Pos, Equals, uint32(12))
 
-	for _, subtask := range subTaskCfg {
-		subtask.EnableGTID = true
+	for k, cfg := range subTaskCfg {
+		cfg.EnableGTID = true
+		subTaskCfg[k] = cfg
 	}
 
 	minLoc, err = getMinLocInAllSubTasks(context.Background(), subTaskCfg)

--- a/dm/worker/worker.go
+++ b/dm/worker/worker.go
@@ -242,16 +242,6 @@ func (w *Worker) EnableRelay() error {
 	return nil
 }
 
-// EnableSubtask TODO
-func (w *Worker) EnableSubtask() {
-
-}
-
-// DisableSubtask TODO
-func (w *Worker) DisableSubtask() {
-
-}
-
 // StartSubTask creates a sub task an run it
 func (w *Worker) StartSubTask(cfg *config.SubTaskConfig, expectStage pb.Stage) error {
 	w.Lock()

--- a/dm/worker/worker.go
+++ b/dm/worker/worker.go
@@ -177,6 +177,13 @@ func (w *Worker) EnableRelay() error {
 	if err != nil {
 		return err
 	}
+	for k, subTaskCfg := range subTaskCfgs {
+		if err2 := copyConfigFromSource(&subTaskCfg, w.cfg); err2 != nil {
+			return err2
+		}
+		subTaskCfgs[k] = subTaskCfg
+	}
+
 	dctx, dcancel := context.WithTimeout(w.etcdClient.Ctx(), time.Duration(len(subTaskCfgs))*3*time.Second)
 	defer dcancel()
 	minLoc, err1 := getMinLocInAllSubTasks(dctx, subTaskCfgs)

--- a/dm/worker/worker_test.go
+++ b/dm/worker/worker_test.go
@@ -410,7 +410,7 @@ func (t *testWorkerEtcdCompact) TestWatchRelayStageEtcdCompact(c *C) {
 	// step 3: trigger etcd compaction and check whether we can receive it through watcher, then we delete relay stage
 	_, err = etcdCli.Compact(ctx, rev)
 	c.Assert(err, IsNil)
-	rev, err = ha.DeleteSourceCfgRelayStageSourceBound(etcdCli, sourceCfg.SourceID, cfg.Name)
+	_, err = ha.DeleteSourceCfgRelayStageSourceBound(etcdCli, sourceCfg.SourceID, cfg.Name)
 	c.Assert(err, IsNil)
 	relayStageCh := make(chan ha.Stage, 10)
 	relayErrCh := make(chan error, 10)

--- a/dm/worker/worker_test.go
+++ b/dm/worker/worker_test.go
@@ -252,7 +252,7 @@ func (t *testWorkerEtcdCompact) TestWatchSubtaskStageEtcdCompact(c *C) {
 	defer cancel()
 	defer w.Close()
 	go func() {
-		w.Start(false)
+		w.Start()
 	}()
 	c.Assert(utils.WaitSomething(50, 100*time.Millisecond, func() bool {
 		return w.closed.Get() == closedFalse
@@ -366,7 +366,8 @@ func (t *testWorkerEtcdCompact) TestWatchRelayStageEtcdCompact(c *C) {
 	defer cancel()
 	defer w.Close()
 	go func() {
-		w.Start(true)
+		c.Assert(w.EnableRelay(), IsNil)
+		w.Start()
 	}()
 	c.Assert(utils.WaitSomething(50, 100*time.Millisecond, func() bool {
 		return w.closed.Get() == closedFalse

--- a/tests/ha_cases/run.sh
+++ b/tests/ha_cases/run.sh
@@ -511,7 +511,6 @@ function test_stop_task() {
 
 
 function test_multi_task_reduce_and_restart_worker() {
-    # here
     echo "[$(date)] <<<<<< start test_multi_task_reduce_and_restart_worker >>>>>>"
     test_multi_task_running
 

--- a/tests/ha_cases/run.sh
+++ b/tests/ha_cases/run.sh
@@ -511,6 +511,7 @@ function test_stop_task() {
 
 
 function test_multi_task_reduce_and_restart_worker() {
+    # here
     echo "[$(date)] <<<<<< start test_multi_task_reduce_and_restart_worker >>>>>>"
     test_multi_task_running
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
only a refactoring, support control worker only enable functionality of relay (or subtask, in future), so we could control the behaviour of worker more flexible

### What is changed and how it works?
move relay-related function into one function`EnableRelay`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - pass original test

Code changes

 - Has exported function/method change

Side effects


Related changes

 - Need to cherry-pick to the release branch
