### PR TITLE
shardddl/optimistic: use init-schema for table without info when recover lock

### DIFF
--- a/dm/master/shardddl/optimist.go
+++ b/dm/master/shardddl/optimist.go
@@ -247,6 +247,12 @@ func (o *Optimist) rebuildLocks() (revSource, revInfo, revOperation int64, err e
 	}
 	o.logger.Info("get history shard DDL lock operation", zap.Int64("revision", revOperation))
 
+	initSchemas, revInitSchemas, err := optimism.GetAllInitSchemas(o.cli)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	o.logger.Info("get all init schemas", zap.Int64("revision", revInitSchemas))
+
 	colm, _, err := optimism.GetAllDroppedColumns(o.cli)
 	if err != nil {
 		// only log the error, and don't return it to forbid the startup of the DM-master leader.
@@ -255,7 +261,7 @@ func (o *Optimist) rebuildLocks() (revSource, revInfo, revOperation int64, err e
 	}
 
 	// recover the shard DDL lock based on history shard DDL info & lock operation.
-	err = o.recoverLocks(ifm, opm, colm)
+	err = o.recoverLocks(ifm, opm, colm, initSchemas)
 	if err != nil {
 		// only log the error, and don't return it to forbid the startup of the DM-master leader.
 		// then these unexpected locks can be handled by the user.
@@ -287,28 +293,64 @@ func sortInfos(ifm map[string]map[string]map[string]map[string]optimism.Info) []
 }
 
 // buildLockJoinedAndTTS build joined table and target table slice for lock by history infos
-func (o *Optimist) buildLockJoinedAndTTS(ifm map[string]map[string]map[string]map[string]optimism.Info) (map[string]schemacmp.Table, map[string][]optimism.TargetTable) {
-	lockJoined := make(map[string]schemacmp.Table)
-	lockTTS := make(map[string][]optimism.TargetTable)
+func (o *Optimist) buildLockJoinedAndTTS(
+	ifm map[string]map[string]map[string]map[string]optimism.Info,
+	initSchemas map[string]map[string]map[string]optimism.InitSchema) (
+	map[string]schemacmp.Table, map[string][]optimism.TargetTable) {
 
+	type infoKey struct {
+		lockID   string
+		source   string
+		upSchema string
+		upTable  string
+	}
+	infos := make(map[infoKey]optimism.Info)
+	lockTTS := make(map[string][]optimism.TargetTable)
 	for _, taskInfos := range ifm {
 		for _, sourceInfos := range taskInfos {
 			for _, schemaInfos := range sourceInfos {
 				for _, info := range schemaInfos {
 					lockID := utils.GenDDLLockID(info.Task, info.DownSchema, info.DownTable)
-					if joined, ok := lockJoined[lockID]; !ok {
-						lockJoined[lockID] = schemacmp.Encode(info.TableInfoBefore)
+					if _, ok := lockTTS[lockID]; !ok {
+						lockTTS[lockID] = o.tk.FindTables(info.Task, info.DownSchema, info.DownTable)
+					}
+					infos[infoKey{lockID, info.Source, info.UpSchema, info.UpTable}] = info
+				}
+			}
+		}
+	}
+
+	lockJoined := make(map[string]schemacmp.Table)
+	for lockID, tts := range lockTTS {
+		for _, tt := range tts {
+			for upSchema, tables := range tt.UpTables {
+				for upTable := range tables {
+					var table schemacmp.Table
+					if info, ok := infos[infoKey{lockID, tt.Source, upSchema, upTable}]; ok && info.TableInfoBefore != nil {
+						table = schemacmp.Encode(info.TableInfoBefore)
+					} else if initSchema, ok := initSchemas[tt.Task][tt.DownSchema][tt.DownTable]; ok {
+						// If there is no optimism.Info for a upstream table, it indicates the table structure
+						// hasn't been changed since last removeLock. So the init schema should be its table info.
+						table = schemacmp.Encode(initSchema.TableInfo)
 					} else {
-						newJoined, err := joined.Join(schemacmp.Encode(info.TableInfoBefore))
+						o.logger.Error(
+							"can not find table info for upstream table",
+							zap.String("source", tt.Source),
+							zap.String("up-schema", upSchema),
+							zap.String("up-table", upTable),
+						)
+						continue
+					}
+					if joined, ok := lockJoined[lockID]; !ok {
+						lockJoined[lockID] = table
+					} else {
+						newJoined, err := joined.Join(table)
 						// ignore error, will report it in TrySync later
 						if err != nil {
 							o.logger.Error(fmt.Sprintf("fail to join table info %s with %s, lockID: %s in recover lock", joined, newJoined, lockID), log.ShortError(err))
 						} else {
 							lockJoined[lockID] = newJoined
 						}
-					}
-					if _, ok := lockTTS[lockID]; !ok {
-						lockTTS[lockID] = o.tk.FindTables(info.Task, info.DownSchema, info.DownTable)
 					}
 				}
 			}
@@ -321,10 +363,11 @@ func (o *Optimist) buildLockJoinedAndTTS(ifm map[string]map[string]map[string]ma
 func (o *Optimist) recoverLocks(
 	ifm map[string]map[string]map[string]map[string]optimism.Info,
 	opm map[string]map[string]map[string]map[string]optimism.Operation,
-	colm map[string]map[string]map[string]map[string]map[string]struct{}) error {
+	colm map[string]map[string]map[string]map[string]map[string]struct{},
+	initSchemas map[string]map[string]map[string]optimism.InitSchema) error {
 	// construct joined table based on the shard DDL info.
 	o.logger.Info("build lock joined and tts")
-	lockJoined, lockTTS := o.buildLockJoinedAndTTS(ifm)
+	lockJoined, lockTTS := o.buildLockJoinedAndTTS(ifm, initSchemas)
 	// build lock and restore table info
 	o.logger.Info("rebuild locks and tables")
 	o.lk.RebuildLocksAndTables(o.cli, ifm, colm, lockJoined, lockTTS)

--- a/dm/master/shardddl/optimist_test.go
+++ b/dm/master/shardddl/optimist_test.go
@@ -1191,7 +1191,7 @@ func (t *testOptimist) TestBuildLockWithInitSchema(c *C) {
 		ti1 = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (a INT PRIMARY KEY, b INT)`)
 		ti2 = createTableInfo(c, p, se, tblID, `CREATE TABLE bar (a INT PRIMARY KEY)`)
 
-		ddlDropB   = "ALTER TABLE bar dROP COLUMN b"
+		ddlDropB   = "ALTER TABLE bar DROP COLUMN b"
 		ddlDropC   = "ALTER TABLE bar DROP COLUMN c"
 		infoDropB  = optimism.NewInfo(task, source1, "foo", "bar-1", downSchema, downTable, []string{ddlDropC}, ti0, []*model.TableInfo{ti1})
 		infoDropC  = optimism.NewInfo(task, source1, "foo", "bar-1", downSchema, downTable, []string{ddlDropB}, ti1, []*model.TableInfo{ti2})

--- a/dm/master/shardddl/optimist_test.go
+++ b/dm/master/shardddl/optimist_test.go
@@ -1139,8 +1139,8 @@ func (t *testOptimist) TestBuildLockJoinedAndTable(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	st1.AddTable("db", "tbl-1", downSchema, downTable)
-	st2.AddTable("db", "tbl-1", downSchema, downTable)
+	st1.AddTable("foo", "bar-1", downSchema, downTable)
+	st2.AddTable("foo", "bar-1", downSchema, downTable)
 
 	c.Assert(o.Start(ctx, etcdTestCli), IsNil)
 	_, err := optimism.PutSourceTables(etcdTestCli, st1)
@@ -1153,10 +1153,14 @@ func (t *testOptimist) TestBuildLockJoinedAndTable(c *C) {
 	_, err = optimism.PutInfo(etcdTestCli, i11)
 	c.Assert(err, IsNil)
 
+	stm, _, err := optimism.GetAllSourceTables(etcdTestCli)
+	c.Assert(err, IsNil)
+	o.tk.Init(stm)
+
 	ifm, _, err := optimism.GetAllInfo(etcdTestCli)
 	c.Assert(err, IsNil)
 
-	lockJoined, lockTTS := o.buildLockJoinedAndTTS(ifm)
+	lockJoined, lockTTS := o.buildLockJoinedAndTTS(ifm, nil)
 	c.Assert(len(lockJoined), Equals, 1)
 	c.Assert(len(lockTTS), Equals, 1)
 	joined, ok := lockJoined[utils.GenDDLLockID(task, downSchema, downTable)]

--- a/tests/_utils/test_prepare
+++ b/tests/_utils/test_prepare
@@ -208,7 +208,7 @@ function check_log_contain_with_retry() {
             echo "check log contain failed $k-th time (file not exist), retry later"
             continue
         fi
-        got=`grep "$text" $log1 | wc -l`
+        got=`grep -a "$text" $log1 | wc -l`
         if [[ $got -ne 0 ]]; then
             rc=1
             break
@@ -219,7 +219,7 @@ function check_log_contain_with_retry() {
                 echo "check log contain failed $k-th time (file not exist), retry later"
                 continue
             fi
-            got=`grep "$text" $log2 | wc -l`
+            got=`grep -a "$text" $log2 | wc -l`
             if [[ $got -ne 0 ]]; then
                 rc=1
                 break

--- a/tests/shardddl3/run.sh
+++ b/tests/shardddl3/run.sh
@@ -1020,19 +1020,23 @@ function DM_DropAddColumn_CASE() {
 
     restart_master_on_pos $reset "1"
 
-    run_sql_source1 "alter table ${shardddl1}.${tb1} drop column b;"
-    run_sql_source1 "insert into ${shardddl1}.${tb1} values(4);"
+    run_sql_source2 "alter table ${shardddl1}.${tb1} drop column c;"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(4,4);"
 
     restart_master_on_pos $reset "2"
-
-    run_sql_source2 "alter table ${shardddl1}.${tb1} drop column c;"
-    run_sql_source2 "insert into ${shardddl1}.${tb1} values(5,5);"
-
-    restart_master_on_pos $reset "3"
 
     # make sure column c is fully dropped in the downstream
     check_log_contain_with_retry 'finish to handle ddls in optimistic shard mode' $WORK_DIR/worker1/log/dm-worker.log
     check_log_contain_with_retry 'finish to handle ddls in optimistic shard mode' $WORK_DIR/worker2/log/dm-worker.log
+
+    run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
+        "show-ddl-locks" \
+        "no DDL lock exists" 1
+
+    run_sql_source1 "alter table ${shardddl1}.${tb1} drop column b;"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(5);"
+
+    restart_master_on_pos $reset "3"
 
     run_sql_source1 "alter table ${shardddl1}.${tb1} add column c int;"
     run_sql_source1 "insert into ${shardddl1}.${tb1} values(6,6);"


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In #1518, we always use table-info-before to rebuild locks, but ignore the upstream table who has no optimism.Info. In such a case, we may build an incorrect joined table.

Suppose there are two upstream tables tb1(a int, b int, c int) and tb2(a int, b int, c int).  A possible time series is:
```
t1: tb1 and tb2 are identical.
t2: tb1 drop column b, c.
t3: restart.
t4: joined becomes tb1's table-info-before, which is tb(a int). // The correct joined should be tb(a int, b int, c int).
```
### What is changed and how it works?
Use init-schema for table without info when recover lock.  If there is no optimism.Info for a upstream table, it indicates the table structure hasn't been changed since last removeLock. So the init schema should be its table info.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
