### PR TITLE
test: fix unstable shardddl test case DM-143

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -224,7 +224,7 @@ func (c *Checker) Init(ctx context.Context) (err error) {
 				continue
 			}
 
-			c.checkList = append(c.checkList, check.NewShardingTablesCheck(name, dbs, shardingSet, columnMapping, checkingShardID))
+			c.checkList = append(c.checkList, check.NewShardingTablesChecker(name, dbs, shardingSet, columnMapping, checkingShardID))
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -52,3 +52,5 @@ go 1.13
 replace github.com/siddontang/go-mysql v1.1.1-0.20200824131207-0c5789dd0bd3 => github.com/lance6716/go-mysql v1.1.1-0.20210303100354-b0e44c2c5623
 
 replace github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726 => github.com/lance6716/go v0.0.0-20210312094856-8a1d496ae7d4
+
+replace github.com/pingcap/tidb-tools v5.0.0-rc.0.20210318094904-51a9e0c86386+incompatible => github.com/gozssky/tidb-tools v5.0.0-rc.0.20210416081403-5e7bcacac139+incompatible

--- a/go.sum
+++ b/go.sum
@@ -429,6 +429,8 @@ github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gozssky/tidb-tools v5.0.0-rc.0.20210416081403-5e7bcacac139+incompatible h1:mvtOpniLC+kTDVNgelaCT1nFT/xprBlipM4QsWy5sz8=
+github.com/gozssky/tidb-tools v5.0.0-rc.0.20210416081403-5e7bcacac139+incompatible/go.mod h1:1Z4m3t2yg0tWloE4X//BnzOy/QNMDkTehQYqR9URQv4=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 h1:THDBEeQ9xZ8JEaCLyLQqXMMdRqNr0QAUJTIkQAUtFjg=
@@ -844,8 +846,6 @@ github.com/pingcap/tidb-tools v4.0.1+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnw
 github.com/pingcap/tidb-tools v4.0.5-0.20200820082341-afeaaaaaa153+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tidb-tools v4.0.5-0.20200820092506-34ea90c93237+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tidb-tools v4.0.9-0.20201127090955-2707c97b3853+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
-github.com/pingcap/tidb-tools v5.0.0-rc.0.20210318094904-51a9e0c86386+incompatible h1:tgUbSovpQ12sd5W0eclXlzZh+hWhgLhvdqRy2BMiXyQ=
-github.com/pingcap/tidb-tools v5.0.0-rc.0.20210318094904-51a9e0c86386+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pingcap/tipb v0.0.0-20200417094153-7316d94df1ee/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pingcap/tipb v0.0.0-20200604070248-508f03b0b342/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=

--- a/tests/shardddl4/run.sh
+++ b/tests/shardddl4/run.sh
@@ -890,10 +890,21 @@ function DM_143_CASE {
     run_sql_source2 "insert into ${shardddl1}.${tb2} values(30),(31),(32),(33),(34),(35),(130),(131),(132),(133),(134),(135);"
 
     run_sql_source1 "delete from ${shardddl1}.${tb1} where id >= 100;"
-    run_sql_source2 "delete from ${shardddl1}.${tb1} where id >= 100;"
-    run_sql_source2 "delete from ${shardddl1}.${tb2} where id >= 100;"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(16),(17);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(26),(27),(126),(127);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(36),(37),(136),(137);"
     run_sql_source1 "alter table ${shardddl1}.${tb1} drop partition p1;"
+
+    run_sql_source2 "delete from ${shardddl1}.${tb1} where id >= 100;"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(18),(19);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(28),(29);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(38),(39),(138),(139);"
     run_sql_source2 "alter table ${shardddl1}.${tb1} drop partition p1;"
+
+    run_sql_source2 "delete from ${shardddl1}.${tb2} where id >= 100;"
+    run_sql_source1 "insert into ${shardddl1}.${tb1} values(40),(41);"
+    run_sql_source2 "insert into ${shardddl1}.${tb1} values(50),(51);"
+    run_sql_source2 "insert into ${shardddl1}.${tb2} values(60),(61);"
     run_sql_source2 "alter table ${shardddl1}.${tb2} drop partition p1;"
 
     check_sync_diff $WORK_DIR $cur/conf/diff_config.toml


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix unstable shardddl test case DM-143. See #1412.

### What is changed and how it works?
schemacmp doesn't really support comparing partition before, which causes this unstable test.
Partition comparing will be implemented in tidb-tools.
Do not merge this PR before [tidb-tools#431](https://github.com/pingcap/tidb-tools/pull/431).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test



