### PR TITLE
worker: delete taskState when task is stopped/finished

### DIFF
--- a/dm/dm-ansible/scripts/dm.json
+++ b/dm/dm-ansible/scripts/dm.json
@@ -75,7 +75,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_TEST-CLUSTER}",
-      "description": "The current state of subtasks in instances.\n\n0: Invalid\n\n1: New\n\n2: Running\n\n3: Paused\n\n4: Stopped\n\n5: Finished",
+      "description": "The current state of subtasks in instances.\n\n0: Invalid\n\n1: New\n\n2: Running\n\n3: Paused",
       "fill": 1,
       "gridPos": {
         "h": 7,

--- a/dm/dm-ansible/scripts/dm_instances.json
+++ b/dm/dm-ansible/scripts/dm_instances.json
@@ -1096,7 +1096,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "The current state of subtasks in the instance.\n\n0: Invalid\n\n1: New\n\n2: Running\n\n3: Paused\n\n4: Stopped\n\n5: Finished",
+          "description": "The current state of subtasks in the instance.\n\n0: Invalid\n\n1: New\n\n2: Running\n\n3: Paused",
           "fill": 1,
           "gridPos": {
             "h": 7,

--- a/dm/worker/metrics.go
+++ b/dm/worker/metrics.go
@@ -138,7 +138,3 @@ func InitStatus(lis net.Listener) {
 		log.L().Error("status server returned", log.ShortError(err))
 	}
 }
-
-func (st *SubTask) removeLabelValuesWithTaskInMetrics(task string, source string) {
-	taskState.DeleteAllAboutLabels(prometheus.Labels{"task": task, "source_id": source})
-}

--- a/dm/worker/subtask.go
+++ b/dm/worker/subtask.go
@@ -392,7 +392,7 @@ func (st *SubTask) setStageAndResult(stage pb.Stage, result *pb.ProcessResult) {
 	st.Lock()
 	defer st.Unlock()
 	st.stage = stage
-	taskState.WithLabelValues(st.cfg.Name, st.cfg.SourceID).Set(float64(st.stage))
+	updateTaskState(st.cfg.Name, st.cfg.SourceID, st.stage)
 	st.result = result
 }
 

--- a/tests/_utils/check_metric_not_contains
+++ b/tests/_utils/check_metric_not_contains
@@ -22,5 +22,5 @@ while [ $counter -lt $retry_count ]; do
     sleep 1
 done
 
-echo "metric $metric_name has invalid value $metric"
+echo "metric $metric_name has invalid count $metric"
 exit 1

--- a/tests/_utils/check_metric_not_contains
+++ b/tests/_utils/check_metric_not_contains
@@ -1,0 +1,26 @@
+#!/bin/bash
+# parameter 1: port
+# parameter 2: metric name
+# parameter 3: retry count, if check failed we will wait 1s before next retry, until retry time exceeds retry count
+
+set -eu
+
+port=$1
+metric_name=$2
+retry_count=$3
+
+shift 3
+
+counter=0
+while [ $counter -lt $retry_count ]; do
+    metric=$(curl -s http://127.0.0.1:$port/metrics | grep $metric_name | wc -l)
+    if [ $metric -eq 0 ]; then
+        exit 0
+    fi
+    ((counter+=1))
+    echo "wait for valid metric for $counter-th time"
+    sleep 1
+done
+
+echo "metric $metric_name has invalid value $metric"
+exit 1

--- a/tests/all_mode/run.sh
+++ b/tests/all_mode/run.sh
@@ -134,9 +134,13 @@ function test_stop_task_before_checkpoint(){
     dmctl_start_task "$cur/conf/dm-task.yaml" "--remove-meta"
     check_log_contain_with_retry 'wait loader stop after init checkpoint' $WORK_DIR/worker1/log/dm-worker.log
     check_log_contain_with_retry 'wait loader stop after init checkpoint' $WORK_DIR/worker2/log/dm-worker.log
+    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 0 2
+    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 0 2
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
             "stop-task test"\
             "\"result\": true" 3
+    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 -1 1
+    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 -1 1
 
     # restart dm-worker
     pkill -9 dm-worker.test 2>/dev/null || true
@@ -153,9 +157,13 @@ function test_stop_task_before_checkpoint(){
     dmctl_start_task "$cur/conf/dm-task.yaml"
     check_log_contain_with_retry 'wait loader stop before load checkpoint' $WORK_DIR/worker1/log/dm-worker.log
     check_log_contain_with_retry 'wait loader stop before load checkpoint' $WORK_DIR/worker2/log/dm-worker.log
+    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 0 2
+    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 0 2
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
             "stop-task test"\
             "\"result\": true" 3
+    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 -1 1
+    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 -1 1
 
     dmctl_start_task "$cur/conf/dm-task.yaml"
     check_sync_diff $WORK_DIR $cur/conf/diff_config.toml

--- a/tests/all_mode/run.sh
+++ b/tests/all_mode/run.sh
@@ -134,13 +134,13 @@ function test_stop_task_before_checkpoint(){
     dmctl_start_task "$cur/conf/dm-task.yaml" "--remove-meta"
     check_log_contain_with_retry 'wait loader stop after init checkpoint' $WORK_DIR/worker1/log/dm-worker.log
     check_log_contain_with_retry 'wait loader stop after init checkpoint' $WORK_DIR/worker2/log/dm-worker.log
-    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 0 2
-    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 0 2
+    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 1 3
+    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 1 3
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
             "stop-task test"\
             "\"result\": true" 3
-    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 -1 1
-    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 -1 1
+    check_metric_not_contains $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3
+    check_metric_not_contains $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3
 
     # restart dm-worker
     pkill -9 dm-worker.test 2>/dev/null || true
@@ -157,13 +157,13 @@ function test_stop_task_before_checkpoint(){
     dmctl_start_task "$cur/conf/dm-task.yaml"
     check_log_contain_with_retry 'wait loader stop before load checkpoint' $WORK_DIR/worker1/log/dm-worker.log
     check_log_contain_with_retry 'wait loader stop before load checkpoint' $WORK_DIR/worker2/log/dm-worker.log
-    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 0 2
-    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 0 2
+    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 1 3
+    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 1 3
     run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
             "stop-task test"\
             "\"result\": true" 3
-    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 -1 1
-    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 -1 1
+    check_metric_not_contains $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3
+    check_metric_not_contains $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3
 
     dmctl_start_task "$cur/conf/dm-task.yaml"
     check_sync_diff $WORK_DIR $cur/conf/diff_config.toml

--- a/tests/full_mode/run.sh
+++ b/tests/full_mode/run.sh
@@ -179,8 +179,9 @@ function run() {
 
     # start DM task only
     dmctl_start_task "$cur/conf/dm-task.yaml" "--remove-meta"
-    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 1 3
-    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 1 3
+    # Don't check task state here. The task may be finished very soon so that we can't get task state here.
+    # check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 1 3
+    # check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 1 3
 
     # use sync_diff_inspector to check full dump loader
     check_sync_diff $WORK_DIR $cur/conf/diff_config.toml

--- a/tests/full_mode/run.sh
+++ b/tests/full_mode/run.sh
@@ -179,6 +179,8 @@ function run() {
 
     # start DM task only
     dmctl_start_task "$cur/conf/dm-task.yaml" "--remove-meta"
+    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 0 2
+    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 0 2
 
     # use sync_diff_inspector to check full dump loader
     check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
@@ -186,6 +188,9 @@ function run() {
     echo "check dump files have been cleaned"
     ls $WORK_DIR/worker1/dumped_data.test && exit 1 || echo "worker1 auto removed dump files"
     ls $WORK_DIR/worker2/dumped_data.test && exit 1 || echo "worker2 auto removed dump files"
+    # check task finished and metric cleaned
+    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 -1 1
+    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 -1 1
     run_sql_both_source "SET @@GLOBAL.SQL_MODE='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'"
 }
 

--- a/tests/full_mode/run.sh
+++ b/tests/full_mode/run.sh
@@ -179,8 +179,8 @@ function run() {
 
     # start DM task only
     dmctl_start_task "$cur/conf/dm-task.yaml" "--remove-meta"
-    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 0 2
-    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 0 2
+    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 1 3
+    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 1 3
 
     # use sync_diff_inspector to check full dump loader
     check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
@@ -189,8 +189,8 @@ function run() {
     ls $WORK_DIR/worker1/dumped_data.test && exit 1 || echo "worker1 auto removed dump files"
     ls $WORK_DIR/worker2/dumped_data.test && exit 1 || echo "worker2 auto removed dump files"
     # check task finished and metric cleaned
-    check_metric $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3 -1 1
-    check_metric $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3 -1 1
+    check_metric_not_contains $WORKER1_PORT 'dm_worker_task_state{source_id="mysql-replica-01",task="test"}' 3
+    check_metric_not_contains $WORKER2_PORT 'dm_worker_task_state{source_id="mysql-replica-02",task="test"}' 3
     run_sql_both_source "SET @@GLOBAL.SQL_MODE='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'"
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #1594

### What is changed and how it works?
delete taskState when task is stopped/finished

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

When task is running:
```
dm_worker_cpu_usage 3.528409857613362
# HELP dm_worker_task_state state of task, 0 - invalidStage, 1 - New, 2 - Running, 3 - Paused, 4 - Stopped, 5 - Finished
# TYPE dm_worker_task_state gauge
dm_worker_task_state{source_id="mysql-replica-01",task="testdm"} 2
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
```
After task is stopped:
```
# HELP dm_worker_cpu_usage the cpu usage of worker
# TYPE dm_worker_cpu_usage gauge
dm_worker_cpu_usage 3.521312888533776
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 2.6124e-05
go_gc_duration_seconds{quantile="0.25"} 3.0232e-05
```

Related changes

 - Need to cherry-pick to the release branch
