### PR TITLE
dmctl: show help msg before validate cfg #1564

### DIFF
--- a/cmd/dm-ctl/main.go
+++ b/cmd/dm-ctl/main.go
@@ -119,7 +119,18 @@ func main() {
 		}
 		os.Exit(0)
 	default:
-		common.PrintLinesf("parse cmd flags err: %s", terror.Message(err))
+		// NOTE:  when `--help` in cmdArgs we need to print out the help msg.)
+		var needPrintHelp bool
+		for _, cmd := range cmdArgs {
+			if cmd == "--help" {
+				needPrintHelp = true
+			}
+		}
+		if needPrintHelp {
+			ctl.PrintHelp(cmdArgs)
+		} else {
+			common.PrintLinesf("parse cmd flags err: %s", terror.Message(err))
+		}
 		os.Exit(2)
 	}
 

--- a/cmd/dm-ctl/main.go
+++ b/cmd/dm-ctl/main.go
@@ -119,22 +119,15 @@ func main() {
 		}
 		os.Exit(0)
 	default:
-		// NOTE:  when `--help` in cmdArgs we need to print out the help msg.)
-		var needPrintHelp bool
+		// NOTE: when `--help` in cmdArgs we need to print out the help msg.
 		for _, cmd := range cmdArgs {
 			if cmd == "--help" {
-				needPrintHelp = true
-				break
+				ctl.PrintHelp(cmdArgs)
+				os.Exit(0)
 			}
 		}
-		exitCode := 2
-		if needPrintHelp {
-			exitCode = 0
-			ctl.PrintHelp(cmdArgs)
-		} else {
-			common.PrintLinesf("parse cmd flags err: %s", terror.Message(err))
-		}
-		os.Exit(exitCode)
+		common.PrintLinesf("parse cmd flags err: %s", terror.Message(err))
+		os.Exit(2)
 	}
 
 	err = cfg.Validate()

--- a/cmd/dm-ctl/main.go
+++ b/cmd/dm-ctl/main.go
@@ -124,10 +124,12 @@ func main() {
 		for _, cmd := range cmdArgs {
 			if cmd == "--help" {
 				needPrintHelp = true
+				break
 			}
 		}
 		if needPrintHelp {
 			ctl.PrintHelp(cmdArgs)
+			os.Exit(0)
 		} else {
 			common.PrintLinesf("parse cmd flags err: %s", terror.Message(err))
 		}

--- a/cmd/dm-ctl/main.go
+++ b/cmd/dm-ctl/main.go
@@ -127,13 +127,14 @@ func main() {
 				break
 			}
 		}
+		exitCode := 2
 		if needPrintHelp {
+			exitCode = 0
 			ctl.PrintHelp(cmdArgs)
-			os.Exit(0)
 		} else {
 			common.PrintLinesf("parse cmd flags err: %s", terror.Message(err))
 		}
-		os.Exit(2)
+		os.Exit(exitCode)
 	}
 
 	err = cfg.Validate()

--- a/dm/ctl/common/config.go
+++ b/dm/ctl/common/config.go
@@ -63,7 +63,7 @@ func NewConfig() *Config {
 
 	fs.BoolVar(&cfg.printVersion, "V", false, "Prints version and exit.")
 	fs.StringVar(&cfg.ConfigFile, "config", "", "Path to config file.")
-	fs.StringVar(&cfg.MasterAddr, "master-addr", "", "Master API server address.")
+	fs.StringVar(&cfg.MasterAddr, "master-addr", "", "Master API server address, this parameter is required when interacting with the dm-master")
 	fs.StringVar(&cfg.RPCTimeoutStr, "rpc-timeout", defaultRPCTimeout, fmt.Sprintf("RPC timeout, default is %s.", defaultRPCTimeout))
 	fs.StringVar(&cfg.encrypt, EncryptCmdName, "", "Encrypts plaintext to ciphertext.")
 	fs.StringVar(&cfg.SSLCA, "ssl-ca", "", "Path of file that contains list of trusted SSL CAs for connection.")
@@ -150,7 +150,7 @@ func (c *Config) Parse(arguments []string) (finish bool, err error) {
 	}
 
 	if c.MasterAddr == "" {
-		return false, errors.Errorf("--master-addr not provided, use --help to see help messages")
+		return false, errors.Errorf("--master-addr not provided, use `dmtcl --help` to see help messages")
 	}
 
 	return false, errors.Trace(c.adjust())

--- a/dm/master/metrics/metrics.go
+++ b/dm/master/metrics/metrics.go
@@ -149,7 +149,7 @@ func ReportDDLPending(task, oldStatus, newStatus string) {
 	}
 }
 
-// RemoveDDLPending removes all counter of this task
+// RemoveDDLPending removes all counter of this task.
 func RemoveDDLPending(task string) {
 	ddlPendingCounter.DeleteAllAboutLabels(prometheus.Labels{"task": task})
 }

--- a/dm/worker/worker.go
+++ b/dm/worker/worker.go
@@ -482,7 +482,7 @@ func (w *Worker) OperateSubTask(name string, op pb.TaskOp) error {
 	return err
 }
 
-// QueryStatus query worker's sub tasks' status. If relay enabled, also return source status
+// QueryStatus query worker's sub tasks' status. If relay enabled, also return source status.
 func (w *Worker) QueryStatus(ctx context.Context, name string) ([]*pb.SubTaskStatus, *pb.RelayStatus, error) {
 	w.RLock()
 	defer w.RUnlock()
@@ -522,7 +522,7 @@ func (w *Worker) QueryStatus(ctx context.Context, name string) ([]*pb.SubTaskSta
 	return subtaskStatus, relayStatus, nil
 }
 
-// postProcessStatus fills the status of sync unit with master binlog location and other related fields
+// postProcessStatus fills the status of sync unit with master binlog location and other related fields.
 func (w *Worker) postProcessStatus(
 	subtaskStatus []*pb.SubTaskStatus,
 	masterBinlogPos string,

--- a/tests/dmctl_command/run.sh
+++ b/tests/dmctl_command/run.sh
@@ -52,13 +52,8 @@ function run() {
     # it should print the usage for start-task
     $PWD/bin/dmctl.test DEVEL start-task --help > $WORK_DIR/help.log
     help_msg=$(cat $WORK_DIR/help.log)
-    help_msg_cnt=$(echo "${help_msg}" | grep  "Usage:" | wc -l |xargs)
-    if [ "$help_msg_cnt" != 1 ]; then
-        echo "dmctl case 4 help failed: $help_msg"
-        exit 1
-    fi
-    echo $help_msg | grep -q "Usage:"
-    if [ $? -ne 0 ]; then
+    help_msg_cnt=$(echo "${help_msg}" | grep  "Usage:" | wc -l)
+    if [ "$help_msg_cnt" -ne 1 ]; then
         echo "dmctl case 4 help failed: $help_msg"
         exit 1
     fi

--- a/tests/dmctl_command/run.sh
+++ b/tests/dmctl_command/run.sh
@@ -47,6 +47,22 @@ function run() {
         exit 1
     fi
 
+
+    # check dmctl command start-task --help
+    # it should print the usage for start-task
+    $PWD/bin/dmctl.test DEVEL start-task --help > $WORK_DIR/help.log
+    help_msg=$(cat $WORK_DIR/help.log)
+    help_msg_cnt=$(echo "${help_msg}" | grep  "Usage:" | wc -l |xargs)
+    if [ "$help_msg_cnt" != 1 ]; then
+        echo "dmctl case 4 help failed: $help_msg"
+        exit 1
+    fi
+    echo $help_msg | grep -q "Usage:"
+    if [ $? -ne 0 ]; then
+        echo "dmctl case 4 help failed: $help_msg"
+        exit 1
+    fi
+
     # run normal task with command
     run_sql_file $cur/data/db1.prepare.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
     check_contains 'Query OK, 2 rows affected'


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

#1564 

### What is changed and how it works?

dmctl：print help msg when user input `--help` before validate the dmctl config

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test

Code changes
- `cmd/dm-ctl/main.go`
- `dm/ctl/common/config.go `

Side effects
- None

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

