### PR TITLE
*: show an unsynced message for workers which didn't get any shard DDL

### DIFF
--- a/dm/master/server.go
+++ b/dm/master/server.go
@@ -719,6 +719,7 @@ func (s *Server) fillUnsyncedStatus(resps []*pb.QueryStatusResponse) {
 			if syncStatus == nil || len(syncStatus.UnresolvedGroups) != 0 {
 				continue
 			}
+			// TODO: look at s.optimist when `query-status` support show `UnresolvedGroups` in optimistic mode.
 			locks := s.pessimist.ShowLocks(subtaskStatus.Name, []string{resp.SourceStatus.Source})
 			if len(locks) == 0 {
 				continue

--- a/dm/master/server.go
+++ b/dm/master/server.go
@@ -691,8 +691,28 @@ func (s *Server) QueryStatus(ctx context.Context, req *pb.QueryStatusListRequest
 
 	resps := s.getStatusFromWorkers(ctx, sources, req.Name, queryRelayWorker)
 
-	// adjust unsynced field in sync status, task-name -> set(target-table)
-	// because if a DM-worker doesn't receive any shard DDL, it doesn't even know it's unsynced for itself
+	s.fillUnsyncedStatus(resps)
+
+	workerRespMap := make(map[string][]*pb.QueryStatusResponse, len(sources))
+	for _, workerResp := range resps {
+		workerRespMap[workerResp.SourceStatus.Source] = append(workerRespMap[workerResp.SourceStatus.Source], workerResp)
+	}
+
+	sort.Strings(sources)
+	workerResps := make([]*pb.QueryStatusResponse, 0, len(sources))
+	for _, worker := range sources {
+		workerResps = append(workerResps, workerRespMap[worker]...)
+	}
+	resp := &pb.QueryStatusListResponse{
+		Result:  true,
+		Sources: workerResps,
+	}
+	return resp, nil
+}
+
+// adjust unsynced field in sync status, task-name -> set(target-table)
+// because if a DM-worker doesn't receive any shard DDL, it doesn't even know it's unsynced for itself
+func (*Server) fillUnsyncedStatus(resps []*pb.QueryStatusResponse) {
 	unsyncedMap := make(map[string]map[string]struct{})
 	for _, resp := range resps {
 		for _, subtaskStatus := range resp.SubTaskStatus {
@@ -729,22 +749,6 @@ func (s *Server) QueryStatus(ctx context.Context, req *pb.QueryStatusListRequest
 			}
 		}
 	}
-
-	workerRespMap := make(map[string][]*pb.QueryStatusResponse, len(sources))
-	for _, workerResp := range resps {
-		workerRespMap[workerResp.SourceStatus.Source] = append(workerRespMap[workerResp.SourceStatus.Source], workerResp)
-	}
-
-	sort.Strings(sources)
-	workerResps := make([]*pb.QueryStatusResponse, 0, len(sources))
-	for _, worker := range sources {
-		workerResps = append(workerResps, workerRespMap[worker]...)
-	}
-	resp := &pb.QueryStatusListResponse{
-		Result:  true,
-		Sources: workerResps,
-	}
-	return resp, nil
 }
 
 // ShowDDLLocks implements MasterServer.ShowDDLLocks.

--- a/dm/master/server_test.go
+++ b/dm/master/server_test.go
@@ -155,6 +155,8 @@ var (
 	testEtcdCluster       *integration.ClusterV3
 	keepAliveTTL          = int64(10)
 	etcdTestCli           *clientv3.Client
+	testEtcdCluster2      *integration.ClusterV3
+	etcdTestCli2          *clientv3.Client
 )
 
 func TestMaster(t *testing.T) {
@@ -165,8 +167,11 @@ func TestMaster(t *testing.T) {
 
 	testEtcdCluster = integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
 	defer testEtcdCluster.Terminate(t)
-
 	etcdTestCli = testEtcdCluster.RandClient()
+
+	testEtcdCluster2 = integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
+	defer testEtcdCluster2.Terminate(t)
+	etcdTestCli2 = testEtcdCluster2.RandClient()
 
 	check.TestingT(t)
 }
@@ -393,162 +398,180 @@ func (t *testMaster) TestQueryStatus(c *check.C) {
 }
 
 func (t *testMaster) TestFillUnsyncedStatus(c *check.C) {
-	s := &Server{}
+	var (
+		logger  = log.L()
+		task1   = "task1"
+		task2   = "task2"
+		source1 = "source1"
+		source2 = "source2"
+		sources = []string{source1, source2}
+	)
 	cases := []struct {
+		infos    []pessimism.Info
 		input    []*pb.QueryStatusResponse
 		expected []*pb.QueryStatusResponse
 	}{
-		{
-			nil,
-			nil,
-		},
 		// test it could work
 		{
+			[]pessimism.Info{
+				{
+					Task:   task1,
+					Source: source1,
+					Schema: "db",
+					Table:  "tbl",
+				},
+			},
 			[]*pb.QueryStatusResponse{
 				{
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name: "task1",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
-							UnresolvedGroups: []*pb.ShardingGroup{{Target: "target1", Unsynced: []string{"table1"}}},
-						}},
-					}},
+					SourceStatus: &pb.SourceStatus{
+						Source: source1,
+					},
+					SubTaskStatus: []*pb.SubTaskStatus{
+						{
+							Name: task1,
+							Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
+								UnresolvedGroups: []*pb.ShardingGroup{{Target: "`db`.`tbl`", Unsynced: []string{"table1"}}},
+							}},
+						},
+						{
+							Name:   task2,
+							Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{}},
+						},
+					},
 				}, {
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name:   "task1",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{}},
-					}},
-				}, {
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name:   "task1",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{}},
-					}},
-				}},
+					SourceStatus: &pb.SourceStatus{
+						Source: source2,
+					},
+					SubTaskStatus: []*pb.SubTaskStatus{
+						{
+							Name:   task1,
+							Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{}},
+						},
+						{
+							Name:   task2,
+							Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{}},
+						},
+					},
+				},
+			},
 			[]*pb.QueryStatusResponse{
 				{
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name: "task1",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
-							UnresolvedGroups: []*pb.ShardingGroup{{Target: "target1", Unsynced: []string{"table1"}}},
-						}},
-					}},
+					SourceStatus: &pb.SourceStatus{
+						Source: source1,
+					},
+					SubTaskStatus: []*pb.SubTaskStatus{
+						{
+							Name: task1,
+							Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
+								UnresolvedGroups: []*pb.ShardingGroup{{Target: "`db`.`tbl`", Unsynced: []string{"table1"}}},
+							}},
+						},
+						{
+							Name:   task2,
+							Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{}},
+						},
+					},
 				}, {
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name: "task1",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
-							UnresolvedGroups: []*pb.ShardingGroup{{Target: "target1", Unsynced: []string{"this DM-worker doesn't receive any shard DDL of this group"}}},
-						}},
-					}},
-				}, {
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name: "task1",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
-							UnresolvedGroups: []*pb.ShardingGroup{{Target: "target1", Unsynced: []string{"this DM-worker doesn't receive any shard DDL of this group"}}},
-						}},
-					}},
-				}},
+					SourceStatus: &pb.SourceStatus{
+						Source: source2,
+					},
+					SubTaskStatus: []*pb.SubTaskStatus{
+						{
+							Name: task1,
+							Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
+								UnresolvedGroups: []*pb.ShardingGroup{{Target: "`db`.`tbl`", Unsynced: []string{"this DM-worker doesn't receive any shard DDL of this group"}}},
+							}},
+						},
+						{
+							Name:   task2,
+							Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{}},
+						},
+					},
+				},
+			},
 		},
-		// test multiple task
+		// test won't interfere not sync status
 		{
+			[]pessimism.Info{
+				{
+					Task:   task1,
+					Source: source1,
+					Schema: "db",
+					Table:  "tbl",
+				},
+			},
 			[]*pb.QueryStatusResponse{
 				{
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name: "task1",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
-							UnresolvedGroups: []*pb.ShardingGroup{{Target: "target1", Unsynced: []string{"table1"}}},
-						}},
-					}},
+					SourceStatus: &pb.SourceStatus{
+						Source: source1,
+					},
+					SubTaskStatus: []*pb.SubTaskStatus{
+						{
+							Name: task1,
+							Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
+								UnresolvedGroups: []*pb.ShardingGroup{{Target: "`db`.`tbl`", Unsynced: []string{"table1"}}},
+							}},
+						},
+					},
 				}, {
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name:   "task2",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{}},
-					}},
-				}},
+					SourceStatus: &pb.SourceStatus{
+						Source: source2,
+					},
+					SubTaskStatus: []*pb.SubTaskStatus{
+						{
+							Name:   task1,
+							Status: &pb.SubTaskStatus_Load{Load: &pb.LoadStatus{}},
+						},
+					},
+				},
+			},
 			[]*pb.QueryStatusResponse{
 				{
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name: "task1",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
-							UnresolvedGroups: []*pb.ShardingGroup{{Target: "target1", Unsynced: []string{"table1"}}},
-						}},
-					}},
+					SourceStatus: &pb.SourceStatus{
+						Source: source1,
+					},
+					SubTaskStatus: []*pb.SubTaskStatus{
+						{
+							Name: task1,
+							Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
+								UnresolvedGroups: []*pb.ShardingGroup{{Target: "`db`.`tbl`", Unsynced: []string{"table1"}}},
+							}},
+						},
+					},
 				}, {
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name:   "task2",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{}},
-					}},
-				}},
-		},
-		// test not sync stage
-		{
-			[]*pb.QueryStatusResponse{
-				{
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name:   "task1",
-						Status: &pb.SubTaskStatus_Load{},
-					}},
-				}, {
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name: "task1",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
-							UnresolvedGroups: []*pb.ShardingGroup{{Target: "target1", Unsynced: []string{"table1"}}},
-						}},
-					}},
-				}},
-			[]*pb.QueryStatusResponse{
-				{
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name:   "task1",
-						Status: &pb.SubTaskStatus_Load{},
-					}},
-				}, {
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name: "task1",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
-							UnresolvedGroups: []*pb.ShardingGroup{{Target: "target1", Unsynced: []string{"table1"}}},
-						}},
-					}},
-				}},
-		},
-		// test won't overwrite existing unsynced
-		{
-			[]*pb.QueryStatusResponse{
-				{
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name: "task1",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
-							UnresolvedGroups: []*pb.ShardingGroup{{Target: "target1", Unsynced: []string{"table1"}}},
-						}},
-					}},
-				}, {
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name: "task1",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
-							UnresolvedGroups: []*pb.ShardingGroup{{Target: "target1", Unsynced: []string{"table2"}}},
-						}},
-					}},
-				}},
-			[]*pb.QueryStatusResponse{
-				{
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name: "task1",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
-							UnresolvedGroups: []*pb.ShardingGroup{{Target: "target1", Unsynced: []string{"table1"}}},
-						}},
-					}},
-				}, {
-					SubTaskStatus: []*pb.SubTaskStatus{{
-						Name: "task1",
-						Status: &pb.SubTaskStatus_Sync{Sync: &pb.SyncStatus{
-							UnresolvedGroups: []*pb.ShardingGroup{{Target: "target1", Unsynced: []string{"table2"}}},
-						}},
-					}},
-				}},
+					SourceStatus: &pb.SourceStatus{
+						Source: source2,
+					},
+					SubTaskStatus: []*pb.SubTaskStatus{
+						{
+							Name:   task1,
+							Status: &pb.SubTaskStatus_Load{Load: &pb.LoadStatus{}},
+						},
+					},
+				},
+			},
 		},
 	}
 
+	// test pessimistic mode
 	for _, ca := range cases {
+		s := &Server{}
+		s.pessimist = shardddl.NewPessimist(&logger, func(task string) []string { return sources })
+		c.Assert(s.pessimist.Start(context.Background(), etcdTestCli2), check.IsNil)
+		for _, i := range ca.infos {
+			_, err := pessimism.PutInfo(etcdTestCli2, i)
+			c.Assert(err, check.IsNil)
+		}
+		if len(ca.infos) > 0 {
+			utils.WaitSomething(20, 100*time.Millisecond, func() bool {
+				return len(s.pessimist.ShowLocks("", nil)) > 0
+			})
+		}
+
 		s.fillUnsyncedStatus(ca.input)
 		c.Assert(ca.input, check.DeepEquals, ca.expected)
+		_, err := pessimism.DeleteInfosOperations(etcdTestCli2, ca.infos, nil)
+		c.Assert(err, check.IsNil)
 	}
 }
 

--- a/dm/worker/worker.go
+++ b/dm/worker/worker.go
@@ -506,8 +506,10 @@ func (w *Worker) QueryStatus(ctx context.Context, name string) ([]*pb.SubTaskSta
 		w.dbMutex.Lock()
 		if w.db == nil {
 			var err error
-			w.db, err = conn.DefaultDBProvider.Apply(w.cfg.From)
+			w.l.Info("will open a connection to get master status", zap.Any("upstream config", w.cfg.From))
+			w.db, err = conn.DefaultDBProvider.Apply(w.cfg.DecryptPassword().From)
 			if err != nil {
+				w.l.Error("can't open a connection to get master status", zap.Error(err))
 				w.dbMutex.Unlock()
 				return subtaskStatus, relayStatus, err
 			}

--- a/dm/worker/worker_test.go
+++ b/dm/worker/worker_test.go
@@ -15,6 +15,7 @@ package worker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -171,15 +171,26 @@ func GenDDLLockID(task, schema, table string) string {
 	return fmt.Sprintf("%s-%s", task, dbutil.TableName(schema, table))
 }
 
+var lockIDPattern = regexp.MustCompile("(.*)\\-\\`(.*)\\`.\\`(.*)\\`")
+
 // ExtractTaskFromLockID extract task from lockID.
 func ExtractTaskFromLockID(lockID string) string {
-	pattern := regexp.MustCompile("(.*)\\-\\`(.*)\\`.\\`(.*)\\`")
-	strs := pattern.FindStringSubmatch(lockID)
+	strs := lockIDPattern.FindStringSubmatch(lockID)
 	// strs should be [full-lock-ID, task, db, table] if successful matched
 	if len(strs) < 4 {
 		return ""
 	}
 	return strs[1]
+}
+
+// ExtractDBAndTableFromLockID extract schema and table from lockID
+func ExtractDBAndTableFromLockID(lockID string) (string, string) {
+	strs := lockIDPattern.FindStringSubmatch(lockID)
+	// strs should be [full-lock-ID, task, db, table] if successful matched
+	if len(strs) < 4 {
+		return "", ""
+	}
+	return strs[2], strs[3]
 }
 
 // NonRepeatStringsEqual is used to compare two un-ordered, non-repeat-element string slice is equal.

--- a/tests/sequence_sharding_removemeta/run.sh
+++ b/tests/sequence_sharding_removemeta/run.sh
@@ -70,6 +70,9 @@ function run() {
         "show-ddl-locks" \
         "\"ID\": \"$lock_id\"" 1 \
         "$ddl" 1
+    run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
+        "query-status $TEST_NAME" \
+        "this DM-worker doesn't receive any shard DDL of this group" 1
 
     check_metric $MASTER_PORT 'dm_master_ddl_state_number{task="sequence_sharding_removemeta",type="Un-synced"}' 3 0 2
     dmctl_stop_task $task_name

--- a/tests/sequence_sharding_removemeta/run.sh
+++ b/tests/sequence_sharding_removemeta/run.sh
@@ -44,6 +44,10 @@ function run() {
         "show-ddl-locks" \
         "\"ID\": \"$lock_id\"" 1 \
         "$ddl" 1
+    run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
+        "query-status $TEST_NAME" \
+        "this DM-worker doesn't receive any shard DDL of this group" 0 \
+        "\"masterBinlog\": \"\"" 0
     check_metric $MASTER_PORT 'dm_master_ddl_state_number{task="sequence_sharding_removemeta",type="Un-synced"}' 3 0 2
 
     dmctl_stop_task $task_name


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
some users don't use `show-ddl-locks` to get unsynced tables, they use `query-status` instead, so we also show reasonable message in `query-status`

### What is changed and how it works?
- re-fill the related field
- also fix a BUG that forget to decrypt password before open connection to upstream which introduced in https://github.com/pingcap/dm/pull/1619

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has (user) interface methods change

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
