### PR TITLE
scheduler: close workers grpc connections timely

### DIFF
--- a/dm/master/scheduler/scheduler.go
+++ b/dm/master/scheduler/scheduler.go
@@ -1263,6 +1263,10 @@ func (s *Scheduler) recoverWorkersBounds(cli *clientv3.Client) (int64, error) {
 		}
 	}
 
+	failpoint.Inject("failToRecoverWorkersBounds", func(_ failpoint.Value) {
+		log.L().Info("mock failure", zap.String("failpoint", "failToRecoverWorkersBounds"))
+		failpoint.Return(0, errors.New("failToRecoverWorkersBounds"))
+	})
 	// 5. delete invalid source bound info in etcd
 	if len(sbm) > 0 {
 		invalidSourceBounds := make([]string, 0, len(sbm))

--- a/dm/master/scheduler/scheduler_test.go
+++ b/dm/master/scheduler/scheduler_test.go
@@ -1240,7 +1240,6 @@ func (t *testScheduler) TestCloseAllWorkers(c *C) {
 		logger = log.L()
 		s      = NewScheduler(&logger, config.Security{})
 		names  []string
-		infos  []ha.WorkerInfo
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1250,7 +1249,6 @@ func (t *testScheduler) TestCloseAllWorkers(c *C) {
 
 	for i, name := range names {
 		info := ha.NewWorkerInfo(name, fmt.Sprintf("127.0.0.1:%d", 50801+i))
-		infos = append(infos, info)
 		_, err := ha.PutWorkerInfo(etcdTestCli, info)
 		c.Assert(err, IsNil)
 	}

--- a/dm/master/scheduler/scheduler_test.go
+++ b/dm/master/scheduler/scheduler_test.go
@@ -15,6 +15,7 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"go.etcd.io/etcd/integration"
 
 	"github.com/pingcap/dm/dm/config"
+	"github.com/pingcap/dm/dm/master/workerrpc"
 	"github.com/pingcap/dm/dm/pb"
 	"github.com/pingcap/dm/pkg/ha"
 	"github.com/pingcap/dm/pkg/log"
@@ -1223,4 +1225,44 @@ func (t *testScheduler) TestStartStopSource(c *C) {
 	workers, err = s.GetRelayWorkers(sourceID1)
 	c.Assert(err, IsNil)
 	c.Assert(workers, HasLen, 0)
+}
+
+func checkAllWorkersClosed(c *C, s *Scheduler, closed bool) {
+	for _, worker := range s.workers {
+		cli, ok := worker.cli.(*workerrpc.GRPCClient)
+		c.Assert(ok, IsTrue)
+		c.Assert(cli.Closed(), Equals, closed)
+	}
+}
+
+func (t *testScheduler) TestCloseAllWorkers(c *C) {
+	var (
+		logger = log.L()
+		s      = NewScheduler(&logger, config.Security{})
+		names  []string
+		infos  []ha.WorkerInfo
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	for i := 1; i < 4; i++ {
+		names = append(names, fmt.Sprintf("worker%d", i))
+	}
+
+	for i, name := range names {
+		info := ha.NewWorkerInfo(name, fmt.Sprintf("127.0.0.1:%d", 50801+i))
+		infos = append(infos, info)
+		_, err := ha.PutWorkerInfo(etcdTestCli, info)
+		c.Assert(err, IsNil)
+	}
+
+	c.Assert(failpoint.Enable("github.com/pingcap/dm/dm/master/scheduler/failToRecoverWorkersBounds", "return"), IsNil)
+	// Test closed when fail to start
+	c.Assert(s.Start(ctx, etcdTestCli), ErrorMatches, "failToRecoverWorkersBounds")
+	checkAllWorkersClosed(c, s, true)
+	c.Assert(failpoint.Disable("github.com/pingcap/dm/dm/master/scheduler/failToRecoverWorkersBounds"), IsNil)
+
+	c.Assert(s.Start(ctx, etcdTestCli), IsNil)
+	checkAllWorkersClosed(c, s, false)
+	s.Close()
+	checkAllWorkersClosed(c, s, true)
 }

--- a/dm/master/scheduler/scheduler_test.go
+++ b/dm/master/scheduler/scheduler_test.go
@@ -1256,11 +1256,14 @@ func (t *testScheduler) TestCloseAllWorkers(c *C) {
 	c.Assert(failpoint.Enable("github.com/pingcap/dm/dm/master/scheduler/failToRecoverWorkersBounds", "return"), IsNil)
 	// Test closed when fail to start
 	c.Assert(s.Start(ctx, etcdTestCli), ErrorMatches, "failToRecoverWorkersBounds")
+	c.Assert(s.workers, HasLen, 3)
 	checkAllWorkersClosed(c, s, true)
 	c.Assert(failpoint.Disable("github.com/pingcap/dm/dm/master/scheduler/failToRecoverWorkersBounds"), IsNil)
 
+	s.workers = map[string]*Worker{}
 	c.Assert(s.Start(ctx, etcdTestCli), IsNil)
 	checkAllWorkersClosed(c, s, false)
 	s.Close()
+	c.Assert(s.workers, HasLen, 3)
 	checkAllWorkersClosed(c, s, true)
 }

--- a/dm/master/server.go
+++ b/dm/master/server.go
@@ -1883,10 +1883,10 @@ func (s *Server) OperateSchema(ctx context.Context, req *pb.OperateSchemaRequest
 	}, nil
 }
 
-func (s *Server) createMasterClientByName(ctx context.Context, name string) (pb.MasterClient, error) {
+func (s *Server) createMasterClientByName(ctx context.Context, name string) (pb.MasterClient, *grpc.ClientConn, error) {
 	listResp, err := s.etcdClient.MemberList(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	clientURLs := []string{}
 	for _, m := range listResp.Members {
@@ -1898,11 +1898,11 @@ func (s *Server) createMasterClientByName(ctx context.Context, name string) (pb.
 		}
 	}
 	if len(clientURLs) == 0 {
-		return nil, errors.New("master not found")
+		return nil, nil, errors.New("master not found")
 	}
 	tls, err := toolutils.NewTLS(s.cfg.SSLCA, s.cfg.SSLCert, s.cfg.SSLKey, s.cfg.AdvertiseAddr, s.cfg.CertAllowedCN)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var conn *grpc.ClientConn
@@ -1911,12 +1911,12 @@ func (s *Server) createMasterClientByName(ctx context.Context, name string) (pb.
 		conn, err = grpc.Dial(clientURL, tls.ToGRPCDialOption(), grpc.WithBackoffMaxDelay(3*time.Second))
 		if err == nil {
 			masterClient := pb.NewMasterClient(conn)
-			return masterClient, nil
+			return masterClient, conn, nil
 		}
 		log.L().Error("can not dial to master", zap.String("name", name), zap.String("client url", clientURL), log.ShortError(err))
 	}
 	// return last err
-	return nil, err
+	return nil, nil, err
 }
 
 // GetMasterCfg implements MasterServer.GetMasterCfg.
@@ -1971,12 +1971,13 @@ func (s *Server) GetCfg(ctx context.Context, req *pb.GetCfgRequest) (*pb.GetCfgR
 			return resp2, nil
 		}
 
-		masterClient, err := s.createMasterClientByName(ctx, req.Name)
+		masterClient, grpcConn, err := s.createMasterClientByName(ctx, req.Name)
 		if err != nil {
 			resp2.Msg = err.Error()
 			// nolint:nilerr
 			return resp2, nil
 		}
+		defer grpcConn.Close()
 		masterResp, err := masterClient.GetMasterCfg(ctx, &pb.GetMasterCfgRequest{})
 		if err != nil {
 			resp2.Msg = err.Error()

--- a/dm/master/workerrpc/rawgrpc.go
+++ b/dm/master/workerrpc/rawgrpc.go
@@ -96,6 +96,11 @@ func (c *GRPCClient) Close() error {
 	return nil
 }
 
+// Close returns whether this grpc conn is closed. only used for test now
+func (c *GRPCClient) Closed() bool {
+	return c.closed.Load()
+}
+
 func callRPC(ctx context.Context, client pb.WorkerClient, req *Request) (*Response, error) {
 	resp := &Response{}
 	resp.Type = req.Type

--- a/dm/master/workerrpc/rawgrpc.go
+++ b/dm/master/workerrpc/rawgrpc.go
@@ -96,7 +96,7 @@ func (c *GRPCClient) Close() error {
 	return nil
 }
 
-// Close returns whether this grpc conn is closed. only used for test now
+// Closed returns whether this grpc conn is closed. only used for test now
 func (c *GRPCClient) Closed() bool {
 	return c.closed.Load()
 }


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
part 2 of https://github.com/pingcap/dm/issues/1636
dm-master didn't close grpc connections before it close scheduler.

### What is changed and how it works?
Close `scheduler.workers` grpc connections when scheduler fails to start or trying to Close.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
