### PR TITLE
syncer: save empty SQL when online DDL is filtered

### DIFF
--- a/_utils/terror_gen/errors_release.txt
+++ b/_utils/terror_gen/errors_release.txt
@@ -301,7 +301,7 @@ ErrSyncerUnitPTApplyEmptyTable,[code=36047:class=sync-unit:scope=internal:level=
 ErrSyncerUnitPTRenameTableNotValid,[code=36048:class=sync-unit:scope=internal:level=high], "Message: tables should contain old and new table name"
 ErrSyncerUnitPTRenameToPTTable,[code=36049:class=sync-unit:scope=internal:level=high], "Message: rename table to pt temporary table %s not supported"
 ErrSyncerUnitPTRenamePTTblToOther,[code=36050:class=sync-unit:scope=internal:level=high], "Message: rename pt temporary table to other temporary table %s not supported"
-ErrSyncerUnitPTOnlineDDLOnPTTbl,[code=36051:class=sync-unit:scope=internal:level=high], "Message: online ddl metadata for pt temporary table `%s`.`%s` not found"
+ErrSyncerUnitPTOnlineDDLOnPTTbl,[code=36051:class=sync-unit:scope=internal:level=high], "Message: online ddl metadata for pt temporary table `%s`.`%s` not found, Workaround: This error may caused when the online DDL is filtered by binlog event filter, if so, please use `handle-error skip` sometimes to skip related DDLs."
 ErrSyncerUnitRemoteSteamerWithGTID,[code=36052:class=sync-unit:scope=internal:level=high], "Message: open remote streamer with GTID mode not supported"
 ErrSyncerUnitRemoteSteamerStartSync,[code=36053:class=sync-unit:scope=internal:level=high], "Message: start syncing binlog from remote streamer"
 ErrSyncerUnitGetTableFromDB,[code=36054:class=sync-unit:scope=internal:level=high], "Message: invalid table `%s`.`%s`"

--- a/dm/master/server.go
+++ b/dm/master/server.go
@@ -711,7 +711,7 @@ func (s *Server) QueryStatus(ctx context.Context, req *pb.QueryStatusListRequest
 }
 
 // adjust unsynced field in sync status by looking at DDL locks.
-// because if a DM-worker doesn't receive any shard DDL, it doesn't even know it's unsynced for itself
+// because if a DM-worker doesn't receive any shard DDL, it doesn't even know it's unsynced for itself.
 func (s *Server) fillUnsyncedStatus(resps []*pb.QueryStatusResponse) {
 	for _, resp := range resps {
 		for _, subtaskStatus := range resp.SubTaskStatus {

--- a/dm/worker/worker.go
+++ b/dm/worker/worker.go
@@ -545,12 +545,12 @@ func (w *Worker) postProcessStatus(
 				syncStatus.Synced = true
 			}
 		} else {
-			syncPos, err := binlog.PositionFromStr(syncStatus.SyncerBinlog)
+			syncPos, err := binlog.PositionFromPosStr(syncStatus.SyncerBinlog)
 			if err != nil {
 				w.l.Debug("fail to parse mysql position", zap.String("position", syncStatus.SyncerBinlog), log.ShortError(err))
 				continue
 			}
-			masterPos, err := binlog.PositionFromStr(masterBinlogPos)
+			masterPos, err := binlog.PositionFromPosStr(masterBinlogPos)
 			if err != nil {
 				w.l.Debug("fail to parse mysql position", zap.String("position", syncStatus.SyncerBinlog), log.ShortError(err))
 				continue

--- a/errors.toml
+++ b/errors.toml
@@ -1819,7 +1819,7 @@ tags = ["internal", "high"]
 [error.DM-sync-unit-36051]
 message = "online ddl metadata for pt temporary table `%s`.`%s` not found"
 description = ""
-workaround = ""
+workaround = "This error may caused when the online DDL is filtered by binlog event filter, if so, please use `handle-error skip` sometimes to skip related DDLs."
 tags = ["internal", "high"]
 
 [error.DM-sync-unit-36052]

--- a/pkg/terror/error_list.go
+++ b/pkg/terror/error_list.go
@@ -987,7 +987,7 @@ var (
 	ErrSyncerUnitPTRenameTableNotValid      = New(codeSyncerUnitPTRenameTableNotValid, ClassSyncUnit, ScopeInternal, LevelHigh, "tables should contain old and new table name", "")
 	ErrSyncerUnitPTRenameToPTTable          = New(codeSyncerUnitPTRenameToPTTable, ClassSyncUnit, ScopeInternal, LevelHigh, "rename table to pt temporary table %s not supported", "")
 	ErrSyncerUnitPTRenamePTTblToOther       = New(codeSyncerUnitPTRenamePTTblToOther, ClassSyncUnit, ScopeInternal, LevelHigh, "rename pt temporary table to other temporary table %s not supported", "")
-	ErrSyncerUnitPTOnlineDDLOnPTTbl         = New(codeSyncerUnitPTOnlineDDLOnPTTbl, ClassSyncUnit, ScopeInternal, LevelHigh, "online ddl metadata for pt temporary table `%s`.`%s` not found", "")
+	ErrSyncerUnitPTOnlineDDLOnPTTbl         = New(codeSyncerUnitPTOnlineDDLOnPTTbl, ClassSyncUnit, ScopeInternal, LevelHigh, "online ddl metadata for pt temporary table `%s`.`%s` not found", "This error may caused when the online DDL is filtered by binlog event filter, if so, please use `handle-error skip` sometimes to skip related DDLs.")
 	ErrSyncerUnitRemoteSteamerWithGTID      = New(codeSyncerUnitRemoteSteamerWithGTID, ClassSyncUnit, ScopeInternal, LevelHigh, "open remote streamer with GTID mode not supported", "")
 	ErrSyncerUnitRemoteSteamerStartSync     = New(codeSyncerUnitRemoteSteamerStartSync, ClassSyncUnit, ScopeInternal, LevelHigh, "start syncing binlog from remote streamer", "")
 	ErrSyncerUnitGetTableFromDB             = New(codeSyncerUnitGetTableFromDB, ClassSyncUnit, ScopeInternal, LevelHigh, "invalid table `%s`.`%s`", "")

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -36,6 +36,7 @@ import (
 var upgrades = []func(cli *clientv3.Client, uctx Context) error{
 	upgradeToVer1,
 	upgradeToVer2,
+	upgradeToVer4,
 }
 
 // upgradesBeforeScheduler records all upgrade functions before scheduler start. e.g. etcd key changed.
@@ -266,4 +267,10 @@ func upgradeToVer3(ctx context.Context, cli *clientv3.Client) error {
 	}
 	_, _, err := etcdutil.DoOpsInOneTxnWithRetry(cli, ops...)
 	return err
+}
+
+// upgradeToVer4 does nothing, version 4 is just to make sure cluster from version 3 could re-run bootstrap, because
+// version 3 (v2.0.2) has some bugs and user may downgrade.
+func upgradeToVer4(cli *clientv3.Client, uctx Context) error {
+	return nil
 }

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -73,7 +73,7 @@ func (t *testForEtcd) TestTryUpgrade(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(rev2, Greater, rev1)
 	c.Assert(ver, DeepEquals, CurrentVersion)
-	c.Assert(mockVerNo, Equals, uint64(4))
+	c.Assert(mockVerNo, Equals, uint64(5))
 
 	// try to upgrade again, do nothing because the version is the same.
 	mockVerNo = 0

--- a/pkg/upgrade/version.go
+++ b/pkg/upgrade/version.go
@@ -28,7 +28,7 @@ const (
 	// The current internal version number of the DM cluster used when upgrading from an older version.
 	// NOTE: +1 when a new incompatible version is introduced, so it's different from the release version.
 	// NOTE: it's the version of the cluster (= the version of DM-master leader now), other component versions are not recorded yet.
-	currentInternalNo uint64 = 3
+	currentInternalNo uint64 = 4
 	// The minimum internal version number of the DM cluster used when importing from v1.0.x.
 	minInternalNo uint64 = 0
 )

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -183,7 +183,7 @@ func ExtractTaskFromLockID(lockID string) string {
 	return strs[1]
 }
 
-// ExtractDBAndTableFromLockID extract schema and table from lockID
+// ExtractDBAndTableFromLockID extract schema and table from lockID.
 func ExtractDBAndTableFromLockID(lockID string) (string, string) {
 	strs := lockIDPattern.FindStringSubmatch(lockID)
 	// strs should be [full-lock-ID, task, db, table] if successful matched

--- a/syncer/ddl.go
+++ b/syncer/ddl.go
@@ -204,6 +204,16 @@ func (s *Syncer) handleOnlineDDL(tctx *tcontext.Context, p *parser.Parser, schem
 		return sqls, nil, nil
 	}
 
+	// remove empty sqls which inserted because online DDL is filtered
+	end := 0
+	for _, sql2 := range sqls {
+		if sql2 != "" {
+			sqls[end] = sql2
+			end++
+		}
+	}
+	sqls = sqls[:end]
+
 	// replace ghost table name by real table name
 	targetTables := []*filter.Table{
 		{Schema: realSchema, Name: realTable},

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
-	parserpkg "github.com/pingcap/dm/pkg/parser"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser"
@@ -55,6 +54,7 @@ import (
 	fr "github.com/pingcap/dm/pkg/func-rollback"
 	"github.com/pingcap/dm/pkg/gtid"
 	"github.com/pingcap/dm/pkg/log"
+	parserpkg "github.com/pingcap/dm/pkg/parser"
 	"github.com/pingcap/dm/pkg/schema"
 	"github.com/pingcap/dm/pkg/shardddl/pessimism"
 	"github.com/pingcap/dm/pkg/streamer"

--- a/tests/dmctl_basic/run.sh
+++ b/tests/dmctl_basic/run.sh
@@ -206,7 +206,8 @@ function run() {
         "\"result\": true" 3 \
         "\"source\": \"$SOURCE_ID1\"" 1 \
         "\"source\": \"$SOURCE_ID2\"" 1 \
-        "\"stage\": \"Running\"" 4
+        "\"stage\": \"Running\"" 4 \
+        "\"synced\": true" 2
     # update_task_not_paused $TASK_CONF
 
     # stop relay because get_config_to_file will stop source

--- a/tests/online_ddl/conf/dm-task.yaml
+++ b/tests/online_ddl/conf/dm-task.yaml
@@ -75,7 +75,7 @@ filters:
     schema-pattern: "*"
     table-pattern: "*"
     events: ["create index","drop index"]
-    sql-pattern: ["ALTER\\s.*TABLE[\\s\\S]*ADD\\s+KEY", "ALTER\\s.*TABLE[\\s\\S]*DROP\\s+KEY"]
+    sql-pattern: ["ALTER\\s.*TABLE[\\s\\S]*ADD\\s+KEY\\s+NAME", "ALTER\\s.*TABLE[\\s\\S]*DROP\\s+KEY"]
     action: Ignore
 
 mydumpers:

--- a/tests/online_ddl/conf/dm-task.yaml
+++ b/tests/online_ddl/conf/dm-task.yaml
@@ -21,6 +21,7 @@ mysql-instances:
     mydumper-config-name: "global"
     loader-config-name: "global"
     syncer-config-name: "global"
+    filter-rules: ["filter-rule-index"]
 
   - source-id: "mysql-replica-02"
     meta:
@@ -32,6 +33,7 @@ mysql-instances:
     mydumper-config-name: "global"
     loader-config-name: "global"
     syncer-config-name: "global"
+    filter-rules: ["filter-rule-index"]
 
 block-allow-list:
   instance:
@@ -67,6 +69,14 @@ column-mappings:
     source-column: "id"
     target-column: "id"
     arguments: ["2", "", "t"]
+
+filters:
+  filter-rule-index:
+    schema-pattern: "*"
+    table-pattern: "*"
+    events: ["create index","drop index"]
+    sql-pattern: ["ALTER\\s.*TABLE[\\s\\S]*ADD\\s+KEY", "ALTER\\s.*TABLE[\\s\\S]*DROP\\s+KEY"]
+    action: Ignore
 
 mydumpers:
   global:

--- a/tests/online_ddl/data/db1.increment2.sql
+++ b/tests/online_ddl/data/db1.increment2.sql
@@ -3,6 +3,8 @@ insert into t1 (uid, name, info) values (10006, 'name of 10006', '{"age": 10006}
 insert into t2 (uid, name, info) values (20008, 'name of 20008', '{"age": 20008}');
 alter table t1 add column address varchar(255);
 alter table t2 add column address varchar(255);
+alter table t1 add key address (address);
+alter table t2 add key address (address);
 insert into t2 (uid, name, info, address) values (20009, 'name of 20009', '{"age": 20009}', 'address of 20009');
 insert into t1 (uid, name, info, address) values (10007, 'name of 10007', '{"age": 10007}', 'address of 10007');
 alter table t2 drop column age;

--- a/tests/online_ddl/data/db2.increment2.sql
+++ b/tests/online_ddl/data/db2.increment2.sql
@@ -3,6 +3,8 @@ insert into t3 (uid, name, info) values (30004, 'name of 30004', '{"age": 30004}
 insert into t2 (uid, name, info) values (50002, 'name of 50002', '{"age": 50002}');
 alter table t3 add column address varchar(255);
 alter table t2 add column address varchar(255);
+alter table t2 add key address (address);
+alter table t3 add key address (address);
 insert into t2 (uid, name, info, address) values (50003, 'name of 50003', '{"age": 50003}', 'address of 50003');
 insert into t3 (uid, name, info, address) values (30005, 'name of 30005', '{"age": 30005}', 'address of 30005');
 alter table t2 drop column age;

--- a/tests/online_ddl/run.sh
+++ b/tests/online_ddl/run.sh
@@ -45,6 +45,11 @@ function real_run() {
     run_sql_file_online_ddl $cur/data/db1.increment.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1 online_ddl $online_ddl_scheme
     run_sql_file_online_ddl $cur/data/db2.increment.sql $MYSQL_HOST2 $MYSQL_PORT2 $MYSQL_PASSWORD2 online_ddl $online_ddl_scheme
 
+    # manually create index to pass check_sync_diff
+    run_sql_tidb "show create table online_ddl.t_target"
+    check_not_contains "KEY \`name\`"
+    run_sql_tidb "alter table online_ddl.t_target add key name (name)"
+
     echo "use sync_diff_inspector to check increment data"
     check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
 

--- a/tests/sequence_sharding_removemeta/run.sh
+++ b/tests/sequence_sharding_removemeta/run.sh
@@ -44,6 +44,7 @@ function run() {
         "show-ddl-locks" \
         "\"ID\": \"$lock_id\"" 1 \
         "$ddl" 1
+    # check after we changed the behaviour that DM-worker queries master status only once, masterBinlog is not empty
     run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
         "query-status $TEST_NAME" \
         "this DM-worker doesn't receive any shard DDL of this group" 0 \


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/dm/issues/1656

### What is changed and how it works?
- save an empty SQL when online DDL is filtered, and remove it when read it from online DDL component
- use `?` not fmt.Sprintf to build a query

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has persistent data change (not likely, because if there's quote in source-id, an error already occurred)

Side effects

 - Possible performance regression
 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
