### PR TITLE
syncer: fix replication lag when hanle-error

### DIFF
--- a/syncer/err-operator/operator.go
+++ b/syncer/err-operator/operator.go
@@ -126,7 +126,7 @@ func (h *Holder) GetEvent(startLocation binlog.Location) (*replication.BinlogEve
 }
 
 // MatchAndApply tries to match operation for event by location and apply it on replace events.
-func (h *Holder) MatchAndApply(startLocation, endLocation binlog.Location) (bool, pb.ErrorOp) {
+func (h *Holder) MatchAndApply(startLocation, endLocation binlog.Location, realEventHeaderTS uint32) (bool, pb.ErrorOp) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -145,6 +145,7 @@ func (h *Holder) MatchAndApply(startLocation, endLocation binlog.Location) (bool
 		// set LogPos as start position
 		for _, ev := range operator.events {
 			ev.Header.LogPos = startLocation.Position.Pos
+			ev.Header.Timestamp = realEventHeaderTS
 			if e, ok := ev.Event.(*replication.QueryEvent); ok {
 				if startLocation.GetGTID() != nil {
 					e.GSet = startLocation.GetGTID().Origin()

--- a/syncer/err-operator/operator_test.go
+++ b/syncer/err-operator/operator_test.go
@@ -61,6 +61,7 @@ func (o *testOperatorSuite) TestOperator(c *C) {
 	event1 := &replication.BinlogEvent{
 		Header: &replication.EventHeader{
 			EventType: replication.QUERY_EVENT,
+			Timestamp: uint32(1623313992),
 		},
 		Event: &replication.QueryEvent{
 			Schema: []byte("db"),
@@ -71,6 +72,7 @@ func (o *testOperatorSuite) TestOperator(c *C) {
 	event2 := &replication.BinlogEvent{
 		Header: &replication.EventHeader{
 			EventType: replication.QUERY_EVENT,
+			Timestamp: uint32(1623313993),
 		},
 		Event: &replication.QueryEvent{
 			Schema: []byte("db"),
@@ -85,14 +87,14 @@ func (o *testOperatorSuite) TestOperator(c *C) {
 	// skip event
 	err = h.Set(startLocation.Position.String(), pb.ErrorOp_Skip, nil)
 	c.Assert(err, IsNil)
-	apply, op := h.MatchAndApply(startLocation, endLocation)
+	apply, op := h.MatchAndApply(startLocation, endLocation, event1.Header.Timestamp)
 	c.Assert(apply, IsTrue)
 	c.Assert(op, Equals, pb.ErrorOp_Skip)
 
 	// overwrite operator
 	err = h.Set(startLocation.Position.String(), pb.ErrorOp_Replace, []*replication.BinlogEvent{event1, event2})
 	c.Assert(err, IsNil)
-	apply, op = h.MatchAndApply(startLocation, endLocation)
+	apply, op = h.MatchAndApply(startLocation, endLocation, event2.Header.Timestamp)
 	c.Assert(apply, IsTrue)
 	c.Assert(op, Equals, pb.ErrorOp_Replace)
 
@@ -105,6 +107,7 @@ func (o *testOperatorSuite) TestOperator(c *C) {
 	e, err = h.GetEvent(startLocation)
 	c.Assert(err, IsNil)
 	c.Assert(e.Header.LogPos, Equals, startLocation.Position.Pos)
+	c.Assert(e.Header.Timestamp, Equals, event1.Header.Timestamp)
 	c.Assert(e.Header.EventSize, Equals, uint32(0))
 	c.Assert(e.Event, Equals, event1.Event)
 	// get second event
@@ -112,6 +115,7 @@ func (o *testOperatorSuite) TestOperator(c *C) {
 	e, err = h.GetEvent(startLocation)
 	c.Assert(err, IsNil)
 	c.Assert(e.Header.LogPos, Equals, endLocation.Position.Pos)
+	c.Assert(e.Header.Timestamp, Equals, event2.Header.Timestamp)
 	c.Assert(e.Header.EventSize, Equals, endLocation.Position.Pos-startLocation.Position.Pos)
 	c.Assert(e.Event, Equals, event2.Event)
 	// get third event, out of index
@@ -123,7 +127,7 @@ func (o *testOperatorSuite) TestOperator(c *C) {
 	// revert exist operator
 	err = h.Set(startLocation.Position.String(), pb.ErrorOp_Revert, nil)
 	c.Assert(err, IsNil)
-	apply, op = h.MatchAndApply(startLocation, endLocation)
+	apply, op = h.MatchAndApply(startLocation, endLocation, event1.Header.Timestamp)
 	c.Assert(apply, IsFalse)
 	c.Assert(op, Equals, pb.ErrorOp_InvalidErrorOp)
 
@@ -136,17 +140,17 @@ func (o *testOperatorSuite) TestOperator(c *C) {
 	// test removeOutdated
 	flushLocation := startLocation
 	c.Assert(h.RemoveOutdated(flushLocation), IsNil)
-	apply, op = h.MatchAndApply(startLocation, endLocation)
+	apply, op = h.MatchAndApply(startLocation, endLocation, event1.Header.Timestamp)
 	c.Assert(apply, IsTrue)
 	c.Assert(op, Equals, pb.ErrorOp_Replace)
 
 	flushLocation = endLocation
 	c.Assert(h.RemoveOutdated(flushLocation), IsNil)
-	apply, op = h.MatchAndApply(startLocation, endLocation)
+	apply, op = h.MatchAndApply(startLocation, endLocation, event1.Header.Timestamp)
 	c.Assert(apply, IsFalse)
 	c.Assert(op, Equals, pb.ErrorOp_InvalidErrorOp)
 
-	apply, op = h.MatchAndApply(endLocation, nextLocation)
+	apply, op = h.MatchAndApply(endLocation, nextLocation, event1.Header.Timestamp)
 	c.Assert(apply, IsTrue)
 	c.Assert(op, Equals, pb.ErrorOp_Replace)
 }

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -1534,7 +1534,7 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 			}
 
 			if !s.isReplacingErr {
-				apply, op := s.errOperatorHolder.MatchAndApply(startLocation, currentLocation)
+				apply, op := s.errOperatorHolder.MatchAndApply(startLocation, currentLocation, e.Header.Timestamp)
 				if apply {
 					if op == pb.ErrorOp_Replace {
 						s.isReplacingErr = true


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #1763 

### What is changed and how it works?

Replaces the timestamp of the real event header with the event generated by the dm.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - None

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
