### PR TITLE
dep: update go-mysql to introduce DECIMAL optimization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/docker/go-units v0.4.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/go-mysql-org/go-mysql v1.1.3-0.20210622052648-13d123b7f2d9
+	github.com/go-mysql-org/go-mysql v1.1.3-0.20210705101833-83965e516929
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gogo/gateway v1.1.0
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,8 @@ github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
-github.com/go-mysql-org/go-mysql v1.1.3-0.20210622052648-13d123b7f2d9 h1:zg57efrJFicmZ0YEMzkonHdveWrnMOlsrIzRJzaZZjI=
-github.com/go-mysql-org/go-mysql v1.1.3-0.20210622052648-13d123b7f2d9/go.mod h1:3lFZKf7l95Qo70+3XB2WpiSf9wu2s3na3geLMaIIrqQ=
+github.com/go-mysql-org/go-mysql v1.1.3-0.20210705101833-83965e516929 h1:cjv3hcFlmma66+fYTvhHt/sbwZWWJs09iv2ipVRIr0I=
+github.com/go-mysql-org/go-mysql v1.1.3-0.20210705101833-83965e516929/go.mod h1:3lFZKf7l95Qo70+3XB2WpiSf9wu2s3na3geLMaIIrqQ=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=

--- a/pkg/streamer/reader.go
+++ b/pkg/streamer/reader.go
@@ -82,8 +82,8 @@ func NewBinlogReader(logger log.Logger, cfg *BinlogReaderConfig) *BinlogReader {
 	ctx, cancel := context.WithCancel(context.Background()) // only can be canceled in `Close`
 	parser := replication.NewBinlogParser()
 	parser.SetVerifyChecksum(true)
-	// useDecimal must set true.  ref: https://github.com/pingcap/tidb-enterprise-tools/pull/272
-	parser.SetUseDecimal(true)
+	// use string representation of decimal, to replicate the exact value
+	parser.SetUseDecimal(false)
 	if cfg.Timezone != nil {
 		parser.SetTimestampStringLocation(cfg.Timezone)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/dm/issues/1826

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - benchmark 1
   using sysbench, but change the `k` column to decimal (40, 16). start a v5.0.1 TiDB in same host with DM (in short of VM 😢)
   without this PR: dm-worker CPU ~250%, TiDB CPS 18.0k
   with this PR: dm-worker CPU ~250%, TiDB CPS 19.5k
- benchmark 2
   using sysbench like above, start a v4.0.13 TiDB in another host. task concurrency is 96.
   without this PR: dm-worker CPU mean 148%, 147%, TiDB CPS 10.0k
   with this PR: dm-worker CPU mean 143%, 146%, TiDB CPS 10.0k
   the decodeDecimal only occupied 3.5% CPU, so the optimization takes a little effects.

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
