### PR TITLE
syncer, binlog: set all UseDecimal to false

### DIFF
--- a/pkg/binlog/common/replication.go
+++ b/pkg/binlog/common/replication.go
@@ -31,7 +31,9 @@ var (
 // SetDefaultReplicationCfg sets some default value for BinlogSyncerConfig
 // Note: retryCount should be greater than 0, set retryCount = 1 if you want to disable retry sync.
 func SetDefaultReplicationCfg(cfg *replication.BinlogSyncerConfig, retryCount int) {
-	cfg.UseDecimal = true // must set true. ref: https://github.com/pingcap/tidb-enterprise-tools/pull/272
+	// after https://github.com/go-mysql-org/go-mysql/pull/598 we could use `false` to improve performance without
+	// losing precision.
+	cfg.UseDecimal = false
 	cfg.VerifyChecksum = true
 	cfg.MaxReconnectAttempts = retryCount
 	if retryCount == 1 {

--- a/pkg/binlog/reader/file.go
+++ b/pkg/binlog/reader/file.go
@@ -82,7 +82,7 @@ func (s *FileReaderStatus) String() string {
 func NewFileReader(cfg *FileReaderConfig) Reader {
 	parser := replication.NewBinlogParser()
 	parser.SetVerifyChecksum(true)
-	parser.SetUseDecimal(true)
+	parser.SetUseDecimal(false)
 	parser.SetRawMode(cfg.EnableRawMode)
 	if cfg.Timezone != nil {
 		parser.SetTimestampStringLocation(cfg.Timezone)

--- a/pkg/binlog/reader/tcp_test.go
+++ b/pkg/binlog/reader/tcp_test.go
@@ -129,7 +129,7 @@ func (t *testTCPReaderSuite) TestSyncPos(c *C) {
 			Port:           uint16(t.port),
 			User:           t.user,
 			Password:       t.password,
-			UseDecimal:     true,
+			UseDecimal:     false,
 			VerifyChecksum: true,
 		}
 		pos gmysql.Position // empty position
@@ -217,7 +217,7 @@ func (t *testTCPReaderSuite) TestSyncGTID(c *C) {
 			Port:           uint16(t.port),
 			User:           t.user,
 			Password:       t.password,
-			UseDecimal:     true,
+			UseDecimal:     false,
 			VerifyChecksum: true,
 		}
 		gSet gtid.Set // nil GTID set

--- a/pkg/binlog/reader/util_test.go
+++ b/pkg/binlog/reader/util_test.go
@@ -33,7 +33,7 @@ func (t *testTCPReaderSuite) TestGetGTIDsForPos(c *C) {
 			Port:           uint16(t.port),
 			User:           t.user,
 			Password:       t.password,
-			UseDecimal:     true,
+			UseDecimal:     false,
 			VerifyChecksum: true,
 		}
 		ctx, cancel = context.WithTimeout(context.Background(), utils.DefaultDBTimeout)
@@ -73,7 +73,7 @@ func (t *testTCPReaderSuite) TestGetPreviousGTIDFromGTIDSet(c *C) {
 			Port:           uint16(t.port),
 			User:           t.user,
 			Password:       t.password,
-			UseDecimal:     true,
+			UseDecimal:     false,
 			VerifyChecksum: true,
 		}
 		ctx, cancel = context.WithTimeout(context.Background(), utils.DefaultDBTimeout)

--- a/pkg/v1dbschema/schema.go
+++ b/pkg/v1dbschema/schema.go
@@ -62,7 +62,7 @@ func UpdateSchema(tctx *tcontext.Context, db *conn.BaseDB, cfg *config.SubTaskCo
 		Port:           uint16(cfg.From.Port),
 		User:           cfg.From.User,
 		Password:       cfg.From.Password, // plaintext.
-		UseDecimal:     true,
+		UseDecimal:     false,
 		VerifyChecksum: true,
 	}
 	tcpReader := reader.NewTCPReader(syncCfg)

--- a/syncer/db_test.go
+++ b/syncer/db_test.go
@@ -79,7 +79,7 @@ func (s *testDBSuite) resetBinlogSyncer(c *C) {
 		Port:           uint16(s.cfg.From.Port),
 		User:           s.cfg.From.User,
 		Password:       s.cfg.From.Password,
-		UseDecimal:     true,
+		UseDecimal:     false,
 		VerifyChecksum: true,
 	}
 	cfg.TimestampStringLocation = time.UTC

--- a/syncer/filter_test.go
+++ b/syncer/filter_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/parser"
 	bf "github.com/pingcap/tidb-tools/pkg/binlog-filter"
 	"github.com/pingcap/tidb-tools/pkg/filter"
-	"github.com/shopspring/decimal"
 
 	"github.com/pingcap/dm/dm/config"
 	"github.com/pingcap/dm/pkg/conn"
@@ -318,12 +317,6 @@ create table t (
 }
 
 func (s *testFilterSuite) TestAllBinaryProtocolTypes(c *C) {
-	skippedDec, err := decimal.NewFromString("10.10")
-	c.Assert(err, IsNil)
-	passedDec, err := decimal.NewFromString("10.11")
-
-	// https://github.com/go-mysql-org/go-mysql/blob/a18ba90219c438df600fd3e4a64edb7e344c75aa/replication/row_event.go#L994
-	c.Assert(err, IsNil)
 	cases := []struct {
 		exprStr    string
 		tableStr   string
@@ -391,15 +384,14 @@ create table t (
 			[]interface{}{int64(200000000)},
 		},
 		// MYSQL_TYPE_NEWDECIMAL
-		// DM always set UseDecimal to true
 		{
 			"c = 10.1",
 			`
 create table t (
 	c decimal(5,2)
 );`,
-			[]interface{}{skippedDec},
-			[]interface{}{passedDec},
+			[]interface{}{"10.10"},
+			[]interface{}{"10.11"},
 		},
 		// MYSQL_TYPE_FLOAT
 		{


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
in https://github.com/pingcap/dm/pull/1837 I forget to set all `UseDecimal` and `SetUseDecimal` to `false` 😂 

### What is changed and how it works?
as title

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - pass original test


Related changes

 - Need to cherry-pick to the release branch
