### PR TITLE
*: manual pause a task which has been pause by error

### DIFF
--- a/dm/worker/subtask.go
+++ b/dm/worker/subtask.go
@@ -473,7 +473,7 @@ func (st *SubTask) Close() {
 	updateTaskState(st.cfg.Name, st.cfg.SourceID, pb.Stage_Stopped)
 }
 
-// Pause pauses the running sub task.
+// Pause pauses a running sub task or a sub task paused by error.
 func (st *SubTask) Pause() error {
 	if st.markResultCanceled() {
 		return nil

--- a/dm/worker/subtask.go
+++ b/dm/worker/subtask.go
@@ -435,6 +435,14 @@ func (st *SubTask) setResult(result *pb.ProcessResult) {
 	st.result = result
 }
 
+func (st *SubTask) markResultCanceled() {
+	st.Lock()
+	defer st.Unlock()
+	if st.result != nil {
+		st.result.IsCanceled = true
+	}
+}
+
 // Result returns the result of the sub task.
 func (st *SubTask) Result() *pb.ProcessResult {
 	st.RLock()
@@ -459,6 +467,15 @@ func (st *SubTask) Close() {
 
 // Pause pauses the running sub task.
 func (st *SubTask) Pause() error {
+	if st.Stage() == pb.Stage_Paused {
+		result := st.Result()
+		if result != nil && !result.IsCanceled {
+			st.l.Info("manually pause task which has been paused by errors")
+			st.markResultCanceled()
+			return nil
+		}
+	}
+
 	if !st.stageCAS(pb.Stage_Running, pb.Stage_Pausing) {
 		return terror.ErrWorkerNotRunningStage.Generate(st.Stage().String())
 	}

--- a/dm/worker/subtask_test.go
+++ b/dm/worker/subtask_test.go
@@ -363,11 +363,12 @@ func (t *testSubTask) TestPauseAndResumeSubtask(c *C) {
 	c.Assert(st.Stage(), Equals, pb.Stage_Paused)
 
 	// pause
-	c.Assert(st.Pause(), NotNil)
+	c.Assert(st.Pause(), IsNil)
 	c.Assert(st.Stage(), Equals, pb.Stage_Paused)
 	c.Assert(st.CurrUnit(), Equals, mockDumper)
 	c.Assert(st.Result(), NotNil)
 	c.Assert(st.Result().Errors, HasLen, 1)
+	c.Assert(st.Result().IsCanceled, IsTrue)
 	c.Assert(strings.Contains(st.Result().Errors[0].Message, "dumper process error"), IsTrue)
 
 	// resume twice

--- a/syncer/streamer_controller.go
+++ b/syncer/streamer_controller.go
@@ -222,10 +222,7 @@ func (c *StreamerController) RedirectStreamer(tctx *tcontext.Context, location b
 	return c.resetReplicationSyncer(tctx, location)
 }
 
-var (
-	mockRestarted   = false
-	mockGetEventErr = false
-)
+var mockRestarted = false
 
 // GetEvent returns binlog event, should only have one thread call this function.
 func (c *StreamerController) GetEvent(tctx *tcontext.Context) (event *replication.BinlogEvent, err error) {
@@ -255,12 +252,6 @@ func (c *StreamerController) GetEvent(tctx *tcontext.Context) (event *replicatio
 	cancel()
 	failpoint.Inject("GetEventError", func() {
 		err = errors.New("go-mysql returned an error")
-	})
-	failpoint.Inject("GetEventErrorOnce", func() {
-		if !mockGetEventErr {
-			mockGetEventErr = true
-			err = errors.New("get event returned an error")
-		}
 	})
 	if err != nil {
 		if err != context.Canceled && err != context.DeadlineExceeded {

--- a/tests/drop_column_with_index/run.sh
+++ b/tests/drop_column_with_index/run.sh
@@ -10,7 +10,7 @@ function run() {
 	run_sql_file $cur/data/db1.prepare.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
 	inject_points=(
 		"github.com/pingcap/dm/syncer/SyncerGetEventError=return"
-		"github.com/pingcap/dm/syncer/GetEventErrorOnce=return"
+		"github.com/pingcap/dm/syncer/GetEventError=1*return"
 	)
 	export GO_FAILPOINTS="$(join_string \; ${inject_points[@]})"
 
@@ -40,16 +40,16 @@ function run() {
 
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"query-status test" \
-		"get event returned an error" 1 \
+		"go-mysql returned an error" 1 \
 		"\"stage\": \"Paused\"" 1 \
 		"\"isCanceled\": false" 1
 	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"pause-task test" \
 		"\"result\": true" 1 \
-		"get event returned an error" 1
+		"go-mysql returned an error" 1
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"query-status test" \
-		"get event returned an error" 1 \
+		"go-mysql returned an error" 1 \
 		"\"stage\": \"Paused\"" 1 \
 		"\"isCanceled\": true" 1
 


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #1729 

### What is changed and how it works?
TaskChecker will not resume a task that is manually paused(isCancel: true)
When users manual pauses a task which has been pause by error(task stage is paused while isCancel is false), mark the isCancel to true.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `dm/dm-ansible`
 - Need to be included in the release note
