### PR TITLE
syncer: fix safemode exit too early

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -1343,6 +1343,12 @@ func (s *Syncer) syncDML(
 		// resets the time interval for each loop to prevent a certain amount of time being spent on the previous ticker
 		// execution to `executeSQLs` resulting in the next tikcer not waiting for the full waitTime.
 		ticker.Reset(tickerInterval)
+		failpoint.Inject("noJobInQueueLog", func() {
+			tctx.L().Debug("ticker Reset",
+				zap.String("workerLagKey", workerLagKey),
+				zap.Duration("tickerInterval", tickerInterval),
+				zap.Int64("current ts", time.Now().Unix()))
+		})
 		select {
 		case sqlJob, ok := <-jobChan:
 			metrics.QueueSizeGauge.WithLabelValues(s.cfg.Name, queueBucket, s.cfg.SourceID).Set(float64(len(jobChan)))

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -1353,7 +1353,7 @@ func (s *Syncer) syncDML(
 				affect, err = executeSQLs()
 
 				failpoint.Inject("SafeModeExit", func(val failpoint.Value) {
-					if intVal, ok := val.(int); ok && intVal == 4 {
+					if intVal, ok := val.(int); ok && intVal == 4 && len(jobs) > 0 {
 						s.tctx.L().Warn("fail to exec DML", zap.String("failpoint", "SafeModeExit"))
 						affect, err = 0, terror.ErrDBExecuteFailed.Delegate(errors.New("SafeModeExit"), "mock")
 					}
@@ -1373,7 +1373,7 @@ func (s *Syncer) syncDML(
 				affect, err = executeSQLs()
 
 				failpoint.Inject("SafeModeExit", func(val failpoint.Value) {
-					if intVal, ok := val.(int); ok && intVal == 4 {
+					if intVal, ok := val.(int); ok && intVal == 4 && len(jobs) > 0 {
 						s.tctx.L().Warn("fail to exec DML", zap.String("failpoint", "SafeModeExit"))
 						affect, err = 0, terror.ErrDBExecuteFailed.Delegate(errors.New("SafeModeExit"), "mock")
 					}

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -1572,7 +1572,6 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 			err2            error
 			exitSafeModeLoc binlog.Location
 		)
-		// TODO: why use a sharding-resync variable savedGlobalLastLocation?
 		if binlog.CompareLocation(currentLocation, savedGlobalLastLocation, s.cfg.EnableGTID) > 0 {
 			exitSafeModeLoc = currentLocation.Clone()
 		} else {
@@ -1584,7 +1583,7 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 		} else {
 			err2 = s.flushCheckPoints()
 		}
-		if err != nil {
+		if err2 != nil {
 			tctx.L().Warn("failed to flush checkpoints when exit task", zap.Error(err2))
 		} else {
 			tctx.L().Info("flush checkpoints when exit task")

--- a/tests/all_mode/data/db2.increment3.sql
+++ b/tests/all_mode/data/db2.increment3.sql
@@ -1,3 +1,6 @@
 use all_mode;
-insert into t2 (id, name) values (10, '10'), (20, '20');
+begin;
+insert into t2 (id, name) values (10, '10');
+insert into t2 (id, name) values (20, '20');
+commit;
 insert into t2 (id, name) values (30, '30');

--- a/tests/all_mode/run.sh
+++ b/tests/all_mode/run.sh
@@ -192,7 +192,7 @@ function test_fail_job_between_event() {
 	sed -i "s/enable-gtid: true/enable-gtid: false/g" $WORK_DIR/source1.yaml
 	sed -i "/relay-binlog-name/i\relay-dir: $WORK_DIR/worker2/relay_log" $WORK_DIR/source2.yaml
 
-  # worker1 will be bound to source1 and fail when see the second row change in an event
+	# worker1 will be bound to source1 and fail when see the second row change in an event
 	inject_points=(
 		"github.com/pingcap/dm/dm/worker/TaskCheckInterval=return(\"500ms\")"
 		"github.com/pingcap/dm/syncer/countJobFromOneEvent=return()"
@@ -204,8 +204,8 @@ function test_fail_job_between_event() {
 	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
 	dmctl_operate_source create $WORK_DIR/source1.yaml $SOURCE_ID1
 
-  # worker2 will be bound to source2 and fail when see the second event in a GTID
-  inject_points=(
+	# worker2 will be bound to source2 and fail when see the second event in a GTID
+	inject_points=(
 		"github.com/pingcap/dm/dm/worker/TaskCheckInterval=return(\"500ms\")"
 		"github.com/pingcap/dm/syncer/countJobFromOneGTID=return()"
 		"github.com/pingcap/dm/syncer/flushFirstJob=return()"

--- a/tests/all_mode/run.sh
+++ b/tests/all_mode/run.sh
@@ -186,33 +186,42 @@ function test_fail_job_between_event() {
 	check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT
 	check_metric $MASTER_PORT 'start_leader_counter' 3 0 2
 
-	inject_points=(
-		"github.com/pingcap/dm/dm/worker/TaskCheckInterval=return(\"500ms\")"
-		"github.com/pingcap/dm/syncer/countJobFromOneEvent=return()"
-		"github.com/pingcap/dm/syncer/flushFirstJobOfEvent=return()"
-		"github.com/pingcap/dm/syncer/failSecondJobOfEvent=return()"
-	)
-	export GO_FAILPOINTS="$(join_string \; ${inject_points[@]})"
-	run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
-	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
-	run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
-	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
-
-	# operate mysql config to worker
 	cp $cur/conf/source1.yaml $WORK_DIR/source1.yaml
 	cp $cur/conf/source2.yaml $WORK_DIR/source2.yaml
 	sed -i "/relay-binlog-name/i\relay-dir: $WORK_DIR/worker1/relay_log" $WORK_DIR/source1.yaml
 	sed -i "s/enable-gtid: true/enable-gtid: false/g" $WORK_DIR/source1.yaml
 	sed -i "/relay-binlog-name/i\relay-dir: $WORK_DIR/worker2/relay_log" $WORK_DIR/source2.yaml
+
+  # worker1 will be bound to source1 and fail when see the second row change in an event
+	inject_points=(
+		"github.com/pingcap/dm/dm/worker/TaskCheckInterval=return(\"500ms\")"
+		"github.com/pingcap/dm/syncer/countJobFromOneEvent=return()"
+		"github.com/pingcap/dm/syncer/flushFirstJob=return()"
+		"github.com/pingcap/dm/syncer/failSecondJob=return()"
+	)
+	export GO_FAILPOINTS="$(join_string \; ${inject_points[@]})"
+	run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
+	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
 	dmctl_operate_source create $WORK_DIR/source1.yaml $SOURCE_ID1
+
+  # worker2 will be bound to source2 and fail when see the second event in a GTID
+  inject_points=(
+		"github.com/pingcap/dm/dm/worker/TaskCheckInterval=return(\"500ms\")"
+		"github.com/pingcap/dm/syncer/countJobFromOneGTID=return()"
+		"github.com/pingcap/dm/syncer/flushFirstJob=return()"
+		"github.com/pingcap/dm/syncer/failSecondJob=return()"
+	)
+	export GO_FAILPOINTS="$(join_string \; ${inject_points[@]})"
+	run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
+	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
 	dmctl_operate_source create $WORK_DIR/source2.yaml $SOURCE_ID2
 
 	dmctl_start_task "$cur/conf/dm-task.yaml" "--remove-meta"
 
 	run_sql_file $cur/data/db1.increment3.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
 	run_sql_file $cur/data/db2.increment3.sql $MYSQL_HOST2 $MYSQL_PORT2 $MYSQL_PASSWORD2
-	check_log_contain_with_retry "failSecondJobOfEvent" $WORK_DIR/worker1/log/dm-worker.log
-	check_log_contain_with_retry "failSecondJobOfEvent" $WORK_DIR/worker2/log/dm-worker.log
+	check_log_contain_with_retry "failSecondJob" $WORK_DIR/worker1/log/dm-worker.log
+	check_log_contain_with_retry "failSecondJob" $WORK_DIR/worker2/log/dm-worker.log
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"query-status test" \
 		"\"result\": true" 3

--- a/tests/case_sensitive/run.sh
+++ b/tests/case_sensitive/run.sh
@@ -64,8 +64,6 @@ function run() {
 	wait_pattern_exit dm-worker2.toml
 	run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
 	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
-	check_metric $WORKER1_PORT "dm_worker_task_state{source_id=\"mysql-replica-01\",task=\"test\"}" 3 1 3
-	check_metric $WORKER2_PORT "dm_worker_task_state{source_id=\"mysql-replica-02\",task=\"test\"}" 3 1 3
 
 	sleep 10
 	echo "after restart dm-worker, task should resume automatically"
@@ -73,6 +71,8 @@ function run() {
 	# wait for task running
 	check_http_alive 127.0.0.1:$MASTER_PORT/apis/${API_VERSION}/status/test '"stage": "Running"' 10
 	sleep 2 # still wait for subtask running on other dm-workers
+	check_metric $WORKER1_PORT "dm_worker_task_state{source_id=\"mysql-replica-01\",task=\"test\"}" 3 1 3
+	check_metric $WORKER2_PORT "dm_worker_task_state{source_id=\"mysql-replica-02\",task=\"test\"}" 3 1 3
 
 	run_sql_file $cur/data/db1.increment.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
 	run_sql_file $cur/data/db2.increment.sql $MYSQL_HOST2 $MYSQL_PORT2 $MYSQL_PASSWORD2

--- a/tests/ha/run.sh
+++ b/tests/ha/run.sh
@@ -181,7 +181,8 @@ function run() {
 	sleep 2
 
 	# leader needs some time to rebuild info
-	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT5" \
+	# start-task is not retryable
+	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT5" \
 		"start-task $cur/conf/dm-task.yaml" \
 		"\"result\": true" 3 \
 		"\"source\": \"$SOURCE_ID1\"" 1 \

--- a/tests/metrics/run.sh
+++ b/tests/metrics/run.sh
@@ -93,7 +93,7 @@ function run() {
 	echo "check zero job done!"
 
 	kill_dm_worker
-	export GO_FAILPOINTS="github.com/pingcap/dm/syncer/changeTickerInterval=return(5);github.com/pingcap/dm/syncer/noJobInQueueLog=return(true)"
+	export GO_FAILPOINTS="github.com/pingcap/dm/syncer/changeTickerInterval=return(5);github.com/pingcap/dm/syncer/noJobInQueueLog=return(true);github.com/pingcap/dm/syncer/WaitUserCancel=return(1)"
 	# First set the ticker interval to 5s -> expect the execSQL interval to be greater than 5s
 	# At 5s, the first no job log will appear in the log
 	# At 6s, the ticker has already waited 1s and the ticker goes to 1/5th of the way

--- a/tests/metrics/run.sh
+++ b/tests/metrics/run.sh
@@ -45,6 +45,9 @@ function run() {
 	# start DM task
 	cp $cur/conf/dm-task.yaml $WORK_DIR/dm-task.yaml
 	dmctl_start_task "$WORK_DIR/dm-task.yaml" "--remove-meta"
+	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
+		"query-status test" \
+		"\"result\": true" 3
 
 	# check ddl job lag
 	run_sql_source1 "alter table metrics.t1 add column new_col1 int;"
@@ -112,8 +115,6 @@ function run() {
 	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"stop-task test" \
 		"\"result\": true" 3
-	cleanup_data metrics
-	cleanup_process $*
 	export GO_FAILPOINTS=''
 }
 

--- a/tests/metrics/run.sh
+++ b/tests/metrics/run.sh
@@ -105,6 +105,7 @@ function run() {
 	sleep 6
 	echo "make a dml job"
 	run_sql_source1 "use metrics;insert into t1 (id, name, ts) values (1004, 'zmj4', '2022-05-11 12:01:05')"
+	check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
 	echo "sleep 6s"
 	sleep 6
 	$cur/../_utils/check_ticker_interval.py $WORK_DIR/worker1/log/dm-worker.log 5


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
as title, since many events share a same GTID, the checking of exitSafeMode should not use `equal` otherwise some partitially replicated GTID will cause duplicate entry error.

### What is changed and how it works?

we now make sure the replication progress is later (not equal) than exitSafeModePoint when exit safe-mode

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test


Related changes

 - Need to cherry-pick to the release branch
