### PR TITLE
election: always try to clean last election key

### DIFF
--- a/pkg/election/election.go
+++ b/pkg/election/election.go
@@ -81,7 +81,6 @@ type Election struct {
 	// so do not close it in the methods of Election.
 	cli        *clientv3.Client
 	sessionTTL int
-	session    *concurrency.Session
 	key        string
 
 	info    *CampaignerInfo

--- a/pkg/election/election.go
+++ b/pkg/election/election.go
@@ -81,6 +81,7 @@ type Election struct {
 	// so do not close it in the methods of Election.
 	cli        *clientv3.Client
 	sessionTTL int
+	session    *concurrency.Session
 	key        string
 
 	info    *CampaignerInfo
@@ -267,18 +268,14 @@ func (e *Election) campaignLoop(ctx context.Context, session *concurrency.Sessio
 
 			err2 := elec.Campaign(ctx2, e.infoStr)
 			if err2 != nil {
-				// sometimes we noticed auto Resign does not work, so we try to manually Resign.
-				e.l.Debug("before manually resign",
-					zap.String("current election key", elec.Key()),
-					zap.Any("current election header", elec.Header()))
-				resignCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-				defer cancel()
-				if err3 := elec.Resign(resignCtx); err3 != nil {
-					e.l.Warn("failed to manually resign", zap.Error(err3))
+				// because inner commit may return undetermined error, we try to delete the election key manually
+				deleted, err3 := e.ClearSessionIfNeeded(ctx, e.ID())
+				if err3 != nil {
+					e.l.Warn("failed to clean election key", zap.Error(err3))
+				} else if deleted {
+					e.l.Info("successful manually clean election key",
+						zap.String("campaign error", err2.Error()))
 				}
-				e.l.Debug("after manually resign",
-					zap.String("current election key", elec.Key()),
-					zap.Any("current election header", elec.Header()))
 
 				// err may be ctx.Err(), but this can be handled in `case <-ctx.Done()`
 				e.l.Info("fail to campaign", zap.Stringer("current member", e.info), zap.Error(err2))

--- a/tests/ha_master/run.sh
+++ b/tests/ha_master/run.sh
@@ -64,7 +64,6 @@ function test_evict_leader() {
 			echo "leader evict failed"
 			exit 1
 		fi
-		echo "new leader is $NEW_LEADER_NAME"
 	done
 
 	echo "cancel evict leader on master1, and master1 will be the leader"

--- a/tests/ha_master/run.sh
+++ b/tests/ha_master/run.sh
@@ -59,7 +59,7 @@ function test_evict_leader() {
 			continue
 		fi
 		NEW_LEADER_NAME=$(get_leader $WORK_DIR 127.0.0.1:${MASTER_PORT1})
-    echo "new leader is $NEW_LEADER_NAME"
+		echo "new leader is $NEW_LEADER_NAME"
 		if [ "$NEW_LEADER_NAME" = "$LEADER_NAME" ]; then
 			echo "leader evict failed"
 			exit 1

--- a/tests/ha_master/run.sh
+++ b/tests/ha_master/run.sh
@@ -58,12 +58,19 @@ function test_evict_leader() {
 		if [ $i = 4 ]; then
 			continue
 		fi
-		NEW_LEADER_NAME=$(get_leader $WORK_DIR 127.0.0.1:${MASTER_PORT1})
-		echo "new leader is $NEW_LEADER_NAME"
+		# Leader evict is not effective immediately, we need to wait for a proper period of time.
+		for _ in {0..30}; do
+			NEW_LEADER_NAME=$(get_leader "$WORK_DIR" 127.0.0.1:${MASTER_PORT1})
+			if [ "$NEW_LEADER_NAME" != "$LEADER_NAME" ]; then
+				break
+			fi
+			sleep 1
+		done
 		if [ "$NEW_LEADER_NAME" = "$LEADER_NAME" ]; then
 			echo "leader evict failed"
 			exit 1
 		fi
+		echo "new leader is $NEW_LEADER_NAME"
 	done
 
 	echo "cancel evict leader on master1, and master1 will be the leader"

--- a/tests/ha_master/run.sh
+++ b/tests/ha_master/run.sh
@@ -58,14 +58,8 @@ function test_evict_leader() {
 		if [ $i = 4 ]; then
 			continue
 		fi
-		# Leader evict is not effective immediately, we need to wait for a proper period of time.
-		for _ in {0..30}; do
-			NEW_LEADER_NAME=$(get_leader "$WORK_DIR" 127.0.0.1:${MASTER_PORT1})
-			if [ "$NEW_LEADER_NAME" != "$LEADER_NAME" ]; then
-				break
-			fi
-			sleep 1
-		done
+		NEW_LEADER_NAME=$(get_leader $WORK_DIR 127.0.0.1:${MASTER_PORT1})
+    echo "new leader is $NEW_LEADER_NAME"
 		if [ "$NEW_LEADER_NAME" = "$LEADER_NAME" ]; then
 			echo "leader evict failed"
 			exit 1


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/dm/issues/1983

### What is changed and how it works?
when `Campaign` returned an error, always try to clean last election key

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - hard to test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
