### PR TITLE
scheduler: try bind free worker to source in start scheduler

### DIFF
--- a/dm/master/scheduler/scheduler.go
+++ b/dm/master/scheduler/scheduler.go
@@ -215,6 +215,19 @@ func (s *Scheduler) Start(pCtx context.Context, etcdCli *clientv3.Client) (err e
 		return err
 	}
 
+	// check if we can bound free source and workers
+	for _, w := range s.workers {
+		if w.stage == WorkerFree {
+			bound, err := s.tryBoundForWorker(w)
+			if err != nil {
+				return err
+			}
+			if !bound {
+				break
+			}
+		}
+	}
+
 	ctx, cancel := context.WithCancel(pCtx)
 
 	s.wg.Add(1)


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #2002

### What is changed and how it works?
If some worker are offline during master leader transfer, the offline event will be missing. So scheduler should try to bind free source and worker if any after initilized.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 
Code changes


Side effects


Related changes

