### PR TITLE
dmctl: add config err log

### DIFF
--- a/dm/ctl/common/config.go
+++ b/dm/ctl/common/config.go
@@ -152,7 +152,7 @@ func (c *Config) Adjust() error {
 	if c.ConfigFile != "" {
 		err = c.configFromFile(c.ConfigFile)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Annotatef(err, "the current command parameter: --config is invalid or used incorrectly")
 		}
 	}
 

--- a/dm/ctl/ctl.go
+++ b/dm/ctl/ctl.go
@@ -215,7 +215,7 @@ func MainStart(args []string) {
 		cfg := common.NewConfig(cmd.Flags())
 		err := cfg.Adjust()
 		if err != nil {
-			return err
+			return errors.Annotatef(err, "the current command parameter: --config is invalid or used incorrectly")
 		}
 
 		err = cfg.Validate()

--- a/dm/ctl/ctl.go
+++ b/dm/ctl/ctl.go
@@ -215,7 +215,7 @@ func MainStart(args []string) {
 		cfg := common.NewConfig(cmd.Flags())
 		err := cfg.Adjust()
 		if err != nil {
-			return errors.Annotatef(err, "the current command parameter: --config is invalid or used incorrectly")
+			return err
 		}
 
 		err = cfg.Validate()


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #1988 

### What is changed and how it works?
dmctl will always try to parse --config(even it will not be used) and treat it as the dmctl config, that's the reason of err in this case, and if the --config is actually needed and can't be parsed correctly, it will cause the same err, add log to make it more readable

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - No code

Code changes

Side effects

Related changes
