### PR TITLE
syncer, loader: make warn log message more accurate

### DIFF
--- a/loader/db.go
+++ b/loader/db.go
@@ -15,6 +15,7 @@ package loader
 
 import (
 	"database/sql"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -87,9 +88,11 @@ func (conn *DBConn) querySQL(ctx *tcontext.Context, query string, args ...interf
 					return ret, ret.Err()
 				}
 				cost := time.Since(startTime)
-				queryHistogram.WithLabelValues(conn.cfg.Name, conn.cfg.SourceID).Observe(cost.Seconds())
-				if cost.Seconds() > 1 {
-					ctx.L().Warn("query statement",
+				// duration seconds
+				ds := cost.Seconds()
+				queryHistogram.WithLabelValues(conn.cfg.Name, conn.cfg.SourceID).Observe(ds)
+				if ds > 1 {
+					ctx.L().Warn(fmt.Sprintf("query statement too slow for %vs", ds),
 						zap.String("query", utils.TruncateString(query, -1)),
 						zap.String("argument", utils.TruncateInterface(args, -1)),
 						zap.Duration("cost time", cost))
@@ -163,9 +166,11 @@ func (conn *DBConn) executeSQL(ctx *tcontext.Context, queries []string, args ...
 			})
 			if err == nil {
 				cost := time.Since(startTime)
-				txnHistogram.WithLabelValues(conn.cfg.Name, conn.cfg.SourceID).Observe(cost.Seconds())
-				if cost.Seconds() > 1 {
-					ctx.L().Warn("execute transaction",
+				// duration seconds
+				ds := cost.Seconds()
+				txnHistogram.WithLabelValues(conn.cfg.Name, conn.cfg.SourceID).Observe(ds)
+				if ds > 1 {
+					ctx.L().Warn(fmt.Sprintf("execute transaction too slow for %vs", ds),
 						zap.String("query", utils.TruncateInterface(queries, -1)),
 						zap.String("argument", utils.TruncateInterface(args, -1)),
 						zap.Duration("cost time", cost))

--- a/loader/db.go
+++ b/loader/db.go
@@ -15,7 +15,6 @@ package loader
 
 import (
 	"database/sql"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -92,10 +91,10 @@ func (conn *DBConn) querySQL(ctx *tcontext.Context, query string, args ...interf
 				ds := cost.Seconds()
 				queryHistogram.WithLabelValues(conn.cfg.Name, conn.cfg.SourceID).Observe(ds)
 				if ds > 1 {
-					ctx.L().Warn(fmt.Sprintf("query statement too slow for %vs", ds),
+					ctx.L().Warn("query statement too slow",
+						zap.Duration("cost time", cost),
 						zap.String("query", utils.TruncateString(query, -1)),
-						zap.String("argument", utils.TruncateInterface(args, -1)),
-						zap.Duration("cost time", cost))
+						zap.String("argument", utils.TruncateInterface(args, -1)))
 				}
 			}
 			return ret, err
@@ -170,10 +169,10 @@ func (conn *DBConn) executeSQL(ctx *tcontext.Context, queries []string, args ...
 				ds := cost.Seconds()
 				txnHistogram.WithLabelValues(conn.cfg.Name, conn.cfg.SourceID).Observe(ds)
 				if ds > 1 {
-					ctx.L().Warn(fmt.Sprintf("execute transaction too slow for %vs", ds),
+					ctx.L().Warn("execute transaction too slow",
+						zap.Duration("cost time", cost),
 						zap.String("query", utils.TruncateInterface(queries, -1)),
-						zap.String("argument", utils.TruncateInterface(args, -1)),
-						zap.Duration("cost time", cost))
+						zap.String("argument", utils.TruncateInterface(args, -1)))
 				}
 			}
 			return nil, err

--- a/syncer/dbconn/db.go
+++ b/syncer/dbconn/db.go
@@ -2,7 +2,6 @@ package dbconn
 
 import (
 	"database/sql"
-	"fmt"
 	"strings"
 	"time"
 
@@ -111,10 +110,10 @@ func (conn *DBConn) QuerySQL(tctx *tcontext.Context, query string, args ...inter
 				ds := cost.Seconds()
 				metrics.QueryHistogram.WithLabelValues(conn.Cfg.Name).Observe(ds)
 				if ds > 1 {
-					ctx.L().Warn(fmt.Sprintf("query statement too slow for %vs", ds),
+					ctx.L().Warn("query statement too slow",
+						zap.Duration("cost time", cost),
 						zap.String("query", utils.TruncateString(query, -1)),
-						zap.String("argument", utils.TruncateInterface(args, -1)),
-						zap.Duration("cost time", cost))
+						zap.String("argument", utils.TruncateInterface(args, -1)))
 				}
 			}
 			return ret, err
@@ -194,10 +193,10 @@ func (conn *DBConn) ExecuteSQLWithIgnore(tctx *tcontext.Context, ignoreError fun
 				ds := cost.Seconds()
 				metrics.TxnHistogram.WithLabelValues(conn.Cfg.Name).Observe(ds)
 				if ds > 1 {
-					ctx.L().Warn(fmt.Sprintf("execute transaction too slow for %vs", ds),
+					ctx.L().Warn("execute transaction too slow",
+						zap.Duration("cost time", cost),
 						zap.String("query", utils.TruncateInterface(queries, -1)),
-						zap.String("argument", utils.TruncateInterface(args, -1)),
-						zap.Duration("cost time", cost))
+						zap.String("argument", utils.TruncateInterface(args, -1)))
 				}
 			}
 			return ret, err

--- a/syncer/dbconn/db.go
+++ b/syncer/dbconn/db.go
@@ -2,6 +2,7 @@ package dbconn
 
 import (
 	"database/sql"
+	"fmt"
 	"strings"
 	"time"
 
@@ -106,9 +107,11 @@ func (conn *DBConn) QuerySQL(tctx *tcontext.Context, query string, args ...inter
 					return err, ret.Err()
 				}
 				cost := time.Since(startTime)
-				metrics.QueryHistogram.WithLabelValues(conn.Cfg.Name).Observe(cost.Seconds())
-				if cost.Seconds() > 1 {
-					ctx.L().Warn("query statement",
+				// duration seconds
+				ds := cost.Seconds()
+				metrics.QueryHistogram.WithLabelValues(conn.Cfg.Name).Observe(ds)
+				if ds > 1 {
+					ctx.L().Warn(fmt.Sprintf("query statement too slow for %vs", ds),
 						zap.String("query", utils.TruncateString(query, -1)),
 						zap.String("argument", utils.TruncateInterface(args, -1)),
 						zap.Duration("cost time", cost))
@@ -187,9 +190,11 @@ func (conn *DBConn) ExecuteSQLWithIgnore(tctx *tcontext.Context, ignoreError fun
 			ret, err := conn.BaseConn.ExecuteSQLWithIgnoreError(ctx, metrics.StmtHistogram, conn.Cfg.Name, ignoreError, queries, args...)
 			if err == nil {
 				cost := time.Since(startTime)
-				metrics.TxnHistogram.WithLabelValues(conn.Cfg.Name).Observe(cost.Seconds())
-				if cost.Seconds() > 1 {
-					ctx.L().Warn("execute transaction",
+				// duration seconds
+				ds := cost.Seconds()
+				metrics.TxnHistogram.WithLabelValues(conn.Cfg.Name).Observe(ds)
+				if ds > 1 {
+					ctx.L().Warn(fmt.Sprintf("execute transaction too slow for %vs", ds),
 						zap.String("query", utils.TruncateInterface(queries, -1)),
 						zap.String("argument", utils.TruncateInterface(args, -1)),
 						zap.Duration("cost time", cost))


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add more accurate log messages to slow SQL.

### What is changed and how it works?
When the SQL execution time exceeds 1 second, an accurate slow SQL warning will be prompted.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
