### PR TITLE
test: increase unit test timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ define run_unit_test
 	mkdir -p $(TEST_DIR)
 	$(FAILPOINT_ENABLE)
 	@export log_level=error; \
-	$(GOTEST)  -timeout 2m -covermode=atomic -coverprofile="$(TEST_DIR)/cov.$(2).out" $(TEST_RACE_FLAG) $(1) \
+	$(GOTEST)  -timeout 5m -covermode=atomic -coverprofile="$(TEST_DIR)/cov.$(2).out" $(TEST_RACE_FLAG) $(1) \
 	|| { $(FAILPOINT_DISABLE); exit 1; }
 	$(FAILPOINT_DISABLE)
 endef


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
part of #1997 , some unit tests will timeout

### What is changed and how it works?

in #1709 we add a 2m timeout, that's tight now. For a success CI, we can see some slow unit test

```
[2021-08-24T08:56:29.459Z] ok  	github.com/pingcap/dm/dm/master	87.674s	coverage: 62.3% of statements
[2021-08-24T08:56:31.994Z] ok  	github.com/pingcap/dm/dm/master/shardddl	100.157s	coverage: 77.0% of statements
[2021-08-24T08:57:04.080Z] ok  	github.com/pingcap/dm/dm/worker	101.352s	coverage: 71.7% of statements
[2021-08-24T08:57:04.081Z] ok  	github.com/pingcap/dm/pkg/streamer	70.131s	coverage: 89.7% of statements
```

so when CI node is slow, there's chance that unit test will timeout

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Related changes

 - Need to cherry-pick to the release branch
