### PR TITLE
test: fix unstable wait rpc alive

### DIFF
--- a/tests/_utils/check_rpc_alive
+++ b/tests/_utils/check_rpc_alive
@@ -16,7 +16,7 @@ if [ $# == 5 ]; then
 fi
 
 i=0
-while [ $i -lt 10 ]; do
+while [ $i -lt 20 ]; do
 	bash -c "$check_tool $addr $ssl_ca $ssl_cert $ssl_key"
 	ret=$?
 	if [ "$ret" == 0 ]; then
@@ -28,7 +28,7 @@ while [ $i -lt 10 ]; do
 	sleep 1
 done
 
-if [ $i -ge 10 ]; then
+if [ $i -ge 20 ]; then
 	echo "rpc addr $addr check alive timeout"
 	exit 1
 fi


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
part of https://github.com/pingcap/dm/issues/2073

https://ci.pingcap.net/blue/organizations/jenkins/dm_ghpr_new_test/detail/dm_ghpr_new_test/2218/pipeline/ :
- waiting MySQL2 starting cost 32 * 2s
- some DM-master printed `init now`and `dm-master startup ...` to stdout
- some DM-master printed `init now` to stdout

and https://ci.pingcap.net/blue/organizations/jenkins/dm_ghpr_new_test/detail/dm_ghpr_new_test/2143/pipeline/ :
- DM-master print nothing

### What is changed and how it works?

increase retry from 10 times to 20 times 😂 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code


Related changes

 - Need to cherry-pick to the release branch
