### PR TITLE
test: fix can't drop column with index problem

### DIFF
--- a/syncer/error.go
+++ b/syncer/error.go
@@ -62,7 +62,8 @@ func isDropColumnWithIndexError(err error) bool {
 	// different version of TiDB has different error message, try to cover most versions
 	return (mysqlErr.Number == errno.ErrUnsupportedDDLOperation || mysqlErr.Number == tmysql.ErrUnknown) &&
 		strings.Contains(mysqlErr.Message, "drop column") &&
-		strings.Contains(mysqlErr.Message, "with index")
+		(strings.Contains(mysqlErr.Message, "with index") ||
+			strings.Contains(mysqlErr.Message, "with composite index"))
 }
 
 // handleSpecialDDLError handles special errors for DDL execution.


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In https://github.com/pingcap/tidb/pull/18852, TiDB has changed error message from `with index` to `with composite index`. In https://github.com/pingcap/tidb/pull/27500, TiDB is constrained more strictly on drop columns with indices. So the test with TiDB nightly failed.

### What is changed and how it works?
Add check for new format message too.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch

