### PR TITLE
grafana: fix grafana dashboard

### DIFF
--- a/dm/dm-ansible/scripts/DM-Monitor-Professional.json
+++ b/dm/dm-ansible/scripts/DM-Monitor-Professional.json
@@ -57,7 +57,7 @@
   "panels": [
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${DS_TEST-CLUSTER}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -215,7 +215,7 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "${DS_TEST-CLUSTER}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -230,7 +230,7 @@
           "cacheTimeout": null,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "decimals": 1,
           "description": "The data import process percentage of Dumpling. The value is an estimated value and may exceed less than 100%.",
           "fieldConfig": {
@@ -334,7 +334,7 @@
           "cacheTimeout": null,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The data import process percentage of Loader. The value range is 0% ~ 100%",
           "fieldConfig": {
             "defaults": {},
@@ -1377,7 +1377,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "${DS_TEST-CLUSTER}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1504,7 +1504,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${DS_TEST-CLUSTER}",
       "decimals": 1,
       "description": "The predicted remaining time it takes Syncer to be completely synchronized with the master (in seconds)",
       "fieldConfig": {
@@ -4316,7 +4316,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "${DS_TEST-CLUSTER}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -5589,7 +5589,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "${DS_TEST-CLUSTER}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -6187,7 +6187,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "${DS_TEST-CLUSTER}",
       "gridPos": {
         "h": 1,
         "w": 24,

--- a/dm/dm-ansible/scripts/DM-Monitor-Standard.json
+++ b/dm/dm-ansible/scripts/DM-Monitor-Standard.json
@@ -63,7 +63,7 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "${DS_TEST-CLUSTER}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -77,7 +77,7 @@
       "type": "row"
     },
     {
-      "datasource": null,
+      "datasource": "${DS_TEST-CLUSTER}",
       "description": "The current state of subtasks in instances.\n\n0: Invalid\n\n1: New\n\n2: Running\n\n3: Paused\n\n4: Stopped\n\n5: Finished",
       "fieldConfig": {
         "defaults": {
@@ -138,7 +138,7 @@
       "type": "stat"
     },
     {
-      "datasource": null,
+      "datasource": "${DS_TEST-CLUSTER}",
       "description": "The current state of subtasks in instances.\n\n0: Invalid\n\n1: New\n\n2: Running\n\n3: Paused\n\n4: Stopped\n\n5: Finished",
       "fieldConfig": {
         "defaults": {
@@ -294,7 +294,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${DS_TEST-CLUSTER}",
       "decimals": 1,
       "description": "The predicted remaining time it takes Syncer to be completely synchronized with the master\n\nThis indicator is rough and crude and may vary greatly due to environmental factors",
       "fieldConfig": {
@@ -887,7 +887,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "${DS_TEST-CLUSTER}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -906,7 +906,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${DS_TEST-CLUSTER}",
       "decimals": 1,
       "description": "The data import process percentage of Dumpling. The value is an estimated value and may exceed less than 100%.",
       "fieldConfig": {
@@ -1010,7 +1010,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${DS_TEST-CLUSTER}",
       "description": "The data import process percentage of Loader. The value range is 0% ~ 100%",
       "fieldConfig": {
         "defaults": {},


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #2107 

### What is changed and how it works?

in #1778  we add some new dashboard but forgot to add grafana datasource variable `${DS_TEST-CLUSTER}` in dashboard json, so grafana will choose to use default datasource(grafana random walk)

related to  https://github.com/nginxinc/nginx-prometheus-exporter/pull/71

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   test fixed dashboard with my local mac

pro:
<img width="1189" alt="截屏2021-09-09 下午3 32 50" src="https://user-images.githubusercontent.com/24697284/132642580-19690e4a-4c4a-48a5-a090-99ed3e96d134.png">

standard:
<img width="1193" alt="截屏2021-09-09 下午3 33 23" src="https://user-images.githubusercontent.com/24697284/132642663-33201515-c09c-41bd-8baa-235edd431295.png">



 - No code

Code changes


Side effects



Related changes

 - Need to cherry-pick to the release branch

