### PR TITLE
test: fix integration test which may cause case fail sometimes

### DIFF
--- a/tests/_utils/test_prepare
+++ b/tests/_utils/test_prepare
@@ -32,7 +32,7 @@ function wait_pattern_exit() {
     pattern=$1
     while true
     do
-        if [ "pgrep -f $pattern" != "0" ]; then
+        if ! pgrep -f $pattern >/dev/null 2>&1; then
             echo "pattern $pattern already exit"
             return 0
         fi

--- a/tests/all_mode/run.sh
+++ b/tests/all_mode/run.sh
@@ -400,6 +400,7 @@ function run() {
 		"resume-relay -s mysql-replica-01" \
 		"\"result\": true" 2
 
+	sleep 2
 	# relay should continue pulling from syncer's checkpoint, so only pull the latest binlog
 	server_uuid=$(tail -n 1 $WORK_DIR/worker1/relay_log/server-uuid.index)
 	echo "relay logs $(ls $WORK_DIR/worker1/relay_log/$server_uuid)"


### PR DESCRIPTION
integration test: fix invalid pgrep expression which may cause case fail sometime; add sleep to all_mode test(may fail sometimes)

<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
some integration test case(all_mode) may fail sometimes(when process doesn't exit fast enough or delayed)

### What is changed and how it works?
- fix `pgrep` expression in `wait_pattern_exit`
- add `sleep 2` to integration test case `all_mode`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - No code

