### PR TITLE
support json type for mysql downstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/docker/go-units v0.4.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/go-mysql-org/go-mysql v1.1.3-0.20210705101833-83965e516929
+	github.com/go-mysql-org/go-mysql v1.4.1-0.20211222092441-0bb0b8d64e34
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gogo/gateway v1.1.0
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
-github.com/go-mysql-org/go-mysql v1.1.3-0.20210705101833-83965e516929 h1:cjv3hcFlmma66+fYTvhHt/sbwZWWJs09iv2ipVRIr0I=
-github.com/go-mysql-org/go-mysql v1.1.3-0.20210705101833-83965e516929/go.mod h1:3lFZKf7l95Qo70+3XB2WpiSf9wu2s3na3geLMaIIrqQ=
+github.com/go-mysql-org/go-mysql v1.4.1-0.20211222092441-0bb0b8d64e34 h1:WDFsPtJAVyEZAbyqe2pWQCgah8QKzIwfL7YYQlACAmU=
+github.com/go-mysql-org/go-mysql v1.4.1-0.20211222092441-0bb0b8d64e34/go.mod h1:3lFZKf7l95Qo70+3XB2WpiSf9wu2s3na3geLMaIIrqQ=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -820,8 +820,8 @@ func (s *testSyncerSuite) TestGeneratedColumn(c *C) {
 				"UPDATE `gctest_1`.`t_3` SET `id` = ?, `cfg` = ? WHERE `gen_id` = ? LIMIT 1",
 			},
 			[][]interface{}{
-				{int32(1), int32(21), "{\"a\": 12}", int32(1), int32(18), "{}", []uint8("{}")},
-				{int32(2), int32(19), "{}", int32(2), int32(19), "{\"key\": \"value\"}", []uint8("{\"key\":\"value\"}")},
+				{int32(1), int32(21), "{\"a\": 12}", int32(1), int32(18), "{}", "{}"},
+				{int32(2), int32(19), "{}", int32(2), int32(19), "{\"key\": \"value\"}", "{\"key\":\"value\"}"},
 				{int32(3), int32(20), nil, int32(3), int32(17), nil, nil},
 				{int32(1), int32(21), "{\"a\": 12}", int32(1)},
 				{int32(2), int32(19), "{}", int32(2)},
@@ -852,8 +852,8 @@ func (s *testSyncerSuite) TestGeneratedColumn(c *C) {
 				"DELETE FROM `gctest_1`.`t_3` WHERE `gen_id` = ? LIMIT 1",
 			},
 			[][]interface{}{
-				{int32(1), int32(21), "{\"a\": 12}", []uint8("{\"a\":12}")},
-				{int32(2), int32(19), "{}", []uint8("{}")},
+				{int32(1), int32(21), "{\"a\": 12}", "{\"a\":12}"},
+				{int32(2), int32(19), "{}", "{}"},
 				{int32(3), int32(20), nil, nil},
 				{int32(1)},
 				{int32(2)},


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
as title

### What is changed and how it works?
[change go-mysql to store json as string](https://github.com/go-mysql-org/go-mysql/pull/658) and update dependency version

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `dm/dm-ansible`
 - Need to be included in the release note
